### PR TITLE
feat(vsa): path-based layer detection + interactive detail panel

### DIFF
--- a/crates/aps-cli/src/main.rs
+++ b/crates/aps-cli/src/main.rs
@@ -3139,9 +3139,16 @@ fn topology_viz(path: &str, viz_type: &str, output: Option<&str>, verbose: bool)
                             if !vsa_cfg.is_context_allowed(&context) {
                                 return None;
                             }
-                            // Re-serialize with the correct slice name
+                            // Re-serialize with the correct slice and layer names
                             let mut val = serde_json::to_value(m).ok()?;
                             val["slice"] = serde_json::Value::String(context);
+                            // Override layer from directory structure instead of keyword matching
+                            if let Some(layer) = vsa_cfg
+                                .extract_layer(path)
+                                .or_else(|| vsa_cfg.extract_layer(id))
+                            {
+                                val["layer"] = serde_json::Value::String(layer);
+                            }
                             Some(val)
                         })
                         .collect();

--- a/crates/aps-cli/src/vsa_config.rs
+++ b/crates/aps-cli/src/vsa_config.rs
@@ -250,6 +250,57 @@ impl VsaConfig {
         None
     }
 
+    /// Extract the architectural layer from a module path/ID.
+    ///
+    /// Returns the path component TWO positions after the root match
+    /// (root → context → **layer**).
+    ///
+    /// For the `domain` layer, drills one level deeper to distinguish
+    /// commands, events, queries, read_models, aggregates, and services.
+    /// Aggregate directories (`aggregate_*`) are normalized to `aggregates`.
+    ///
+    /// Examples (root = "packages/syn-domain/src/syn_domain/contexts"):
+    /// - `...orchestration.slices.execute_workflow.Handler` → "slices"
+    /// - `...orchestration.domain.commands.CreateWorkspace` → "commands"
+    /// - `...orchestration.domain.aggregate_execution.Agg` → "aggregates"
+    pub fn extract_layer(&self, module_path: &str) -> Option<String> {
+        let root_parts = self.root_components();
+        if root_parts.is_empty() {
+            return None;
+        }
+        let path_parts = Self::normalize_to_components(module_path);
+        let root_len = root_parts.len();
+
+        if path_parts.len() < root_len {
+            return None;
+        }
+
+        for start in 0..=path_parts.len() - root_len {
+            if path_parts[start..start + root_len] == root_parts[..] {
+                let layer_index = start + root_len + 1;
+                if let Some(&layer) = path_parts.get(layer_index) {
+                    if layer.is_empty() {
+                        return None;
+                    }
+                    // For "domain", drill one level deeper to get the sublayer
+                    if layer == "domain" {
+                        if let Some(&sublayer) = path_parts.get(layer_index + 1) {
+                            if sublayer.starts_with("aggregate_") {
+                                return Some("aggregates".to_string());
+                            }
+                            if !sublayer.is_empty() {
+                                return Some(sublayer.to_string());
+                            }
+                        }
+                    }
+                    return Some(layer.to_string());
+                }
+                return None;
+            }
+        }
+        None
+    }
+
     /// Check if a context name is allowed by this config.
     /// If contexts map is defined (v1), only listed contexts are allowed.
     /// If no contexts map (v2), all contexts under root are allowed.
@@ -440,6 +491,70 @@ root: src/syn_domain/contexts
         let config =
             VsaConfig::parse_str("root: ./src\ncontexts:\n  foo:\n    description: bar\n").unwrap();
         assert_eq!(config.version, 1);
+    }
+
+    #[test]
+    fn extract_layer_works() {
+        let config = VsaConfig::parse_str(
+            "version: 1\nroot: ./packages/syn-domain/src/syn_domain/contexts\ncontexts:\n  orchestration:\n    description: test\n  artifacts:\n    description: test\n",
+        )
+        .unwrap();
+
+        // Domain sublayers — drills into domain/ to get the specific sublayer
+        assert_eq!(
+            config.extract_layer("packages.syn-domain.src.syn_domain.contexts.orchestration.domain.commands.CreateWorkspaceCommand"),
+            Some("commands".to_string())
+        );
+        assert_eq!(
+            config.extract_layer("packages.syn-domain.src.syn_domain.contexts.orchestration.domain.events.WorkspaceCreatedEvent"),
+            Some("events".to_string())
+        );
+        assert_eq!(
+            config.extract_layer("packages.syn-domain.src.syn_domain.contexts.orchestration.domain.read_models.workflow_detail"),
+            Some("read_models".to_string())
+        );
+        assert_eq!(
+            config.extract_layer("packages.syn-domain.src.syn_domain.contexts.orchestration.domain.queries.GetWorkflowQuery"),
+            Some("queries".to_string())
+        );
+        // aggregate_* directories normalize to "aggregates"
+        assert_eq!(
+            config.extract_layer("packages.syn-domain.src.syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate"),
+            Some("aggregates".to_string())
+        );
+        assert_eq!(
+            config.extract_layer("packages.syn-domain.src.syn_domain.contexts.artifacts.domain.aggregate_artifact.ArtifactAggregate"),
+            Some("aggregates".to_string())
+        );
+        // Non-domain layers returned as-is
+        assert_eq!(
+            config.extract_layer("packages.syn-domain.src.syn_domain.contexts.orchestration.slices.execute_workflow.ExecuteWorkflowHandler"),
+            Some("slices".to_string())
+        );
+        assert_eq!(
+            config.extract_layer("packages.syn-domain.src.syn_domain.contexts.artifacts.ports.ArtifactRepositoryPort"),
+            Some("ports".to_string())
+        );
+        assert_eq!(
+            config.extract_layer("packages.syn-domain.src.syn_domain.contexts.orchestration._shared.value_objects"),
+            Some("_shared".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_layer_too_short() {
+        let config = VsaConfig::parse_str(
+            "version: 1\nroot: ./packages/syn-domain/src/syn_domain/contexts\ncontexts:\n  orchestration:\n    description: test\n",
+        )
+        .unwrap();
+
+        // Only context, no layer component
+        assert_eq!(
+            config.extract_layer("packages.syn-domain.src.syn_domain.contexts.orchestration"),
+            None
+        );
+        // Shorter than root
+        assert_eq!(config.extract_layer("packages.syn-domain"), None);
     }
 
     #[test]

--- a/standards-experimental/v1/EXP-V1-0001-code-topology/substandards/VIZ01-dashboard/src/vsa.rs
+++ b/standards-experimental/v1/EXP-V1-0001-code-topology/substandards/VIZ01-dashboard/src/vsa.rs
@@ -70,7 +70,7 @@ pub fn generate(modules_json: &str) -> String {
 
     <script>
         const MODULES = {modules_json};
-        const LAYERS = ['handlers', 'services', 'models', 'data', 'adapters', 'utils', 'core', 'examples', 'tests', 'other'];
+        const LAYERS = [...new Set(MODULES.map(m => m.layer))].sort();
 
         // Build slice × layer matrix
         const matrix = {{}};

--- a/standards/v1/APS-V1-0001-code-topology/substandards/VIZ01-dashboard/src/vsa.rs
+++ b/standards/v1/APS-V1-0001-code-topology/substandards/VIZ01-dashboard/src/vsa.rs
@@ -32,29 +32,42 @@ pub fn generate(modules_json: &str) -> String {
         .subtitle {{ color: #666; margin-bottom: 30px; }}
         .matrix-container {{ overflow-x: auto; }}
         table {{ border-collapse: collapse; min-width: 100%; }}
-        th, td {{ padding: 12px 16px; text-align: center; border: 1px solid #222; min-width: 100px; }}
+        th, td {{ padding: 12px 16px; text-align: center; border: 1px solid #222; min-width: 140px; }}
         th {{ background: #1a1a20; color: #888; font-weight: 500; position: sticky; top: 0; }}
         th.layer-header {{ writing-mode: horizontal-tb; background: #15151a; }}
         .layer-label {{ background: #15151a; font-weight: 500; text-align: left; color: #888; }}
-        .cell {{ position: relative; cursor: pointer; transition: transform 0.2s; }}
-        .cell:hover {{ transform: scale(1.05); z-index: 10; }}
+        .cell {{ position: relative; cursor: pointer; transition: transform 0.2s; vertical-align: top; }}
+        .cell:hover {{ transform: scale(1.02); z-index: 10; }}
         .cell-inner {{ border-radius: 6px; padding: 8px; min-height: 50px; display: flex; flex-direction: column; justify-content: center; align-items: center; }}
+        .cell-inner.has-features {{ align-items: flex-start; gap: 6px; }}
+        .cell-header {{ display: flex; justify-content: space-between; width: 100%; align-items: baseline; }}
         .cell-count {{ font-size: 20px; font-weight: 600; }}
         .cell-label {{ font-size: 10px; color: rgba(255,255,255,0.6); margin-top: 4px; }}
+        .feature-tags {{ display: flex; flex-wrap: wrap; gap: 3px; width: 100%; }}
+        .feature-tag {{ font-size: 9px; padding: 2px 6px; border-radius: 3px; background: rgba(255,255,255,0.08); color: rgba(255,255,255,0.7); white-space: nowrap; }}
         .empty {{ background: #0f0f12; color: #333; }}
         .legend {{ margin-top: 30px; display: flex; gap: 20px; flex-wrap: wrap; }}
         .legend-item {{ display: flex; align-items: center; gap: 8px; font-size: 12px; color: #888; }}
         .legend-color {{ width: 20px; height: 20px; border-radius: 4px; }}
-        #tooltip {{ position: fixed; display: none; background: rgba(0,0,0,0.95); padding: 15px; border-radius: 8px; border: 1px solid #444; font-size: 12px; pointer-events: none; z-index: 200; max-width: 300px; }}
-        #tooltip h3 {{ color: #00ff88; margin-bottom: 8px; }}
-        #tooltip .module-list {{ max-height: 200px; overflow-y: auto; }}
-        #tooltip .module-item {{ padding: 4px 0; border-bottom: 1px solid #222; }}
+        #detail-panel {{ position: fixed; top: 20px; right: 20px; width: 340px; max-height: calc(100vh - 40px); background: #12121a; border: 1px solid #333; border-radius: 10px; padding: 16px; font-size: 12px; z-index: 200; overflow-y: auto; display: none; }}
+        #detail-panel.visible {{ display: block; }}
+        #detail-panel h3 {{ color: #00ff88; margin-bottom: 10px; font-size: 14px; }}
+        #detail-panel .close-btn {{ position: absolute; top: 10px; right: 14px; color: #666; cursor: pointer; font-size: 18px; line-height: 1; }}
+        #detail-panel .close-btn:hover {{ color: #fff; }}
+        #detail-panel .module-list {{ }}
+        #detail-panel .module-item {{ padding: 3px 0; border-bottom: 1px solid #1a1a22; color: #ccc; }}
+        #detail-panel .module-item .mod-name {{ color: #fff; }}
+        #detail-panel .feature-group {{ margin-top: 8px; }}
+        #detail-panel .feature-group-header {{ color: #00bbff; font-weight: 500; margin-bottom: 3px; font-size: 13px; }}
+        #detail-panel .summary {{ color: #888; margin-bottom: 12px; font-size: 11px; }}
+        .cell.selected .cell-inner {{ outline: 2px solid #00ff88; outline-offset: -2px; }}
+        body.has-panel .matrix-container {{ margin-right: 360px; }}
     </style>
 </head>
 <body>
     <h1>🍰 Vertical Slice Architecture</h1>
-    <p class="subtitle">Columns = feature slices, Rows = architectural layers, Cells = module count</p>
-    
+    <p class="subtitle">Columns = bounded contexts, Rows = architectural layers — click a cell to inspect</p>
+
     <div class="matrix-container">
         <table id="matrix"></table>
     </div>
@@ -66,11 +79,49 @@ pub fn generate(modules_json: &str) -> String {
         <div class="legend-item"><div class="legend-color" style="background:#0f0f12;border:1px solid #333"></div>Empty (no modules)</div>
     </div>
 
-    <div id="tooltip"></div>
+    <div id="detail-panel"><span class="close-btn">&times;</span><div id="detail-content"></div></div>
 
     <script>
         const MODULES = {modules_json};
-        const LAYERS = ['handlers', 'services', 'models', 'data', 'adapters', 'utils', 'core', 'examples', 'tests', 'other'];
+        // Architectural priority: slices and aggregates first (core VSA),
+        // then domain subdivisions, then infrastructure, then misc at bottom.
+        const LAYER_ORDER = [
+            'slices', 'aggregates',
+            'commands', 'queries', 'events', 'read_models', 'services',
+            'ports', '_shared',
+        ];
+        const allLayers = [...new Set(MODULES.map(m => m.layer))];
+        const LAYERS = [
+            ...LAYER_ORDER.filter(l => allLayers.includes(l)),
+            ...allLayers.filter(l => !LAYER_ORDER.includes(l)).sort(),
+        ];
+
+        // Extract a short readable name from a full module ID.
+        // Strips the common prefix up to and including the layer segment.
+        // "pkg.dom.src.ctx.orchestration.slices.execute_workflow.Handler" → "execute_workflow.Handler"
+        function shortName(m) {{
+            const parts = m.id ? m.id.split('.') : m.name.split('.');
+            const sliceIdx = parts.indexOf(m.slice);
+            const layerIdx = parts.indexOf(m.layer);
+            if (layerIdx >= 0 && layerIdx < parts.length - 1) {{
+                return parts.slice(layerIdx + 1).join('.');
+            }}
+            if (sliceIdx >= 0 && sliceIdx < parts.length - 1) {{
+                return parts.slice(sliceIdx + 1).join('.');
+            }}
+            // Fallback: last 2 segments
+            return parts.slice(-2).join('.');
+        }}
+
+        // For slices layer, extract the feature name (first segment after "slices.")
+        function featureName(m) {{
+            const parts = m.id ? m.id.split('.') : m.name.split('.');
+            const layerIdx = parts.indexOf(m.layer);
+            if (layerIdx >= 0 && layerIdx + 1 < parts.length) {{
+                return parts[layerIdx + 1];
+            }}
+            return shortName(m);
+        }}
 
         // Build slice × layer matrix
         const matrix = {{}};
@@ -97,11 +148,22 @@ pub fn generate(modules_json: &str) -> String {
             return '#ff3333';
         }}
 
+        // Group modules by feature within a cell
+        function groupByFeature(modules) {{
+            const groups = {{}};
+            modules.forEach(m => {{
+                const feat = featureName(m);
+                if (!groups[feat]) groups[feat] = [];
+                groups[feat].push(m);
+            }});
+            return groups;
+        }}
+
         // Render table
         const table = document.getElementById('matrix');
-        
+
         // Header row
-        let headerRow = '<tr><th class="layer-header">Layer \\ Slice</th>';
+        let headerRow = '<tr><th class="layer-header">Layer \\ Context</th>';
         sliceList.forEach(slice => {{
             const label = slice.split('.').pop() || slice;
             headerRow += `<th>${{label}}</th>`;
@@ -115,18 +177,41 @@ pub fn generate(modules_json: &str) -> String {
             sliceList.forEach(slice => {{
                 const key = `${{slice}}|${{layer}}`;
                 const cell = matrix[key];
-                
+
                 if (cell && cell.modules.length > 0) {{
                     const avgHealth = cell.totalHealth / cell.modules.length;
                     const color = healthToColor(avgHealth);
-                    row += `
-                        <td class="cell" data-slice="${{slice}}" data-layer="${{layer}}">
+                    const features = groupByFeature(cell.modules);
+                    const featureNames = Object.keys(features).sort();
+                    const showTags = featureNames.length <= 12;
+
+                    let cellContent;
+                    if (showTags && featureNames.length > 1) {{
+                        // Show feature tags inline
+                        const tags = featureNames.map(f => {{
+                            const cnt = features[f].length;
+                            const label = cnt > 1 ? `${{f}} (${{cnt}})` : f;
+                            return `<span class="feature-tag">${{label}}</span>`;
+                        }}).join('');
+                        cellContent = `
+                            <div class="cell-inner has-features" style="background:${{color}}20;border:1px solid ${{color}}">
+                                <div class="cell-header">
+                                    <span class="cell-count" style="color:${{color}}">${{cell.modules.length}}</span>
+                                    <span class="cell-label">${{(avgHealth * 100).toFixed(0)}}%</span>
+                                </div>
+                                <div class="feature-tags">${{tags}}</div>
+                            </div>
+                        `;
+                    }} else {{
+                        cellContent = `
                             <div class="cell-inner" style="background:${{color}}20;border:1px solid ${{color}}">
                                 <span class="cell-count" style="color:${{color}}">${{cell.modules.length}}</span>
                                 <span class="cell-label">${{(avgHealth * 100).toFixed(0)}}%</span>
                             </div>
-                        </td>
-                    `;
+                        `;
+                    }}
+
+                    row += `<td class="cell" data-slice="${{slice}}" data-layer="${{layer}}">${{cellContent}}</td>`;
                 }} else {{
                     row += '<td class="cell empty"><div class="cell-inner">-</div></td>';
                 }}
@@ -135,38 +220,62 @@ pub fn generate(modules_json: &str) -> String {
             table.innerHTML += row;
         }});
 
-        // Tooltips
-        const tooltip = document.getElementById('tooltip');
+        // Detail panel (click to inspect)
+        const panel = document.getElementById('detail-panel');
+        const panelContent = document.getElementById('detail-content');
+        let selectedCell = null;
+
+        function closePanel() {{
+            panel.classList.remove('visible');
+            document.body.classList.remove('has-panel');
+            if (selectedCell) {{ selectedCell.classList.remove('selected'); selectedCell = null; }}
+        }}
+
+        panel.querySelector('.close-btn').addEventListener('click', closePanel);
+        document.addEventListener('keydown', e => {{ if (e.key === 'Escape') closePanel(); }});
+
         document.querySelectorAll('.cell[data-slice]').forEach(cell => {{
-            cell.addEventListener('mouseenter', e => {{
+            cell.addEventListener('click', () => {{
                 const slice = cell.dataset.slice;
                 const layer = cell.dataset.layer;
                 const key = `${{slice}}|${{layer}}`;
                 const data = matrix[key];
-                
-                if (data) {{
-                    tooltip.style.display = 'block';
-                    tooltip.innerHTML = `
-                        <h3>${{slice}} / ${{layer}}</h3>
-                        <div class="module-list">
-                            ${{data.modules.map(m => `
-                                <div class="module-item">
-                                    <span style="color:${{m.color}}">●</span> ${{m.name}}
-                                    <span style="color:#666;font-size:10px">(${{(m.health * 100).toFixed(0)}}%)</span>
-                                </div>
-                            `).join('')}}
-                        </div>
-                    `;
-                }}
-            }});
-            
-            cell.addEventListener('mousemove', e => {{
-                tooltip.style.left = (e.clientX + 15) + 'px';
-                tooltip.style.top = (e.clientY + 15) + 'px';
-            }});
-            
-            cell.addEventListener('mouseleave', () => {{
-                tooltip.style.display = 'none';
+                if (!data) return;
+
+                // Toggle selection
+                if (selectedCell) selectedCell.classList.remove('selected');
+                if (selectedCell === cell) {{ closePanel(); return; }}
+                selectedCell = cell;
+                cell.classList.add('selected');
+
+                const features = groupByFeature(data.modules);
+                const featureNames = Object.keys(features).sort();
+                const avgHealth = data.totalHealth / data.modules.length;
+
+                let body = `<div class="summary">${{data.modules.length}} modules · ${{featureNames.length}} features · ${{(avgHealth * 100).toFixed(0)}}% avg health</div>`;
+
+                featureNames.forEach(feat => {{
+                    const mods = features[feat];
+                    const avgH = mods.reduce((s, m) => s + m.health, 0) / mods.length;
+                    const hColor = healthToColor(avgH);
+                    body += `<div class="feature-group">
+                        <div class="feature-group-header"><span style="color:${{hColor}}">●</span> ${{feat}} <span style="color:#666;font-weight:400">(${{mods.length}})</span></div>`;
+                    mods.forEach(m => {{
+                        const sn = shortName(m);
+                        if (sn !== feat) {{
+                            body += `<div class="module-item">
+                                <span style="color:${{m.color}}">●</span>
+                                <span class="mod-name">${{sn}}</span>
+                                <span style="color:#555;font-size:10px">${{(m.health * 100).toFixed(0)}}%</span>
+                            </div>`;
+                        }}
+                    }});
+                    body += '</div>';
+                }});
+
+                panelContent.innerHTML = `<h3>${{slice}} / ${{layer}}</h3>${{body}}`;
+                panel.classList.add('visible');
+                document.body.classList.add('has-panel');
             }});
         }});
     </script>


### PR DESCRIPTION
## Summary

- **Path-based layers**: `extract_layer()` derives architectural layers from directory structure via `vsa.yaml` instead of keyword substring matching. The `domain/` layer is expanded into its sublayers: `aggregates`, `commands`, `events`, `queries`, `read_models`, `services`
- **Interactive detail panel**: Click-to-inspect replaces hover tooltip — scrolling no longer blocked
- **Feature tags**: Inline feature name tags in cells when ≤12 features
- **Short names**: Tooltip/panel shows `ExecuteWorkflowHandler` instead of `packages.syn-domain.src.syn_domain.contexts.orchestration.slices.execute_workflow.ExecuteWorkflowHandler`
- **Ordered rows**: Slices and aggregates first (core VSA), then domain subdivisions, then infrastructure/misc

## Before

All 215 modules classified as layer "handlers" — one giant row, unreadable tooltips with full dot-paths that block scrolling.

## After

12 distinct architectural layers (slices, aggregates, commands, queries, events, read_models, services, ports, _shared, cleanup, domain, seed_workflow) with click-to-inspect detail panel and inline feature tags.

## Test plan

- [x] 16 unit tests pass (`extract_layer` + existing)
- [x] `cargo clippy` clean
- [x] `aps run topology viz --type all` generates all 5 viz types without panics
- [x] VSA viz shows correct layers derived from directory structure
- [x] Detail panel opens on click, closes on click/Escape/×
- [x] Scrolling works freely (no tooltip blocking)

Closes #22 (partially — layers now driven by vsa.yaml structure)