### PR TITLE
chore(release): bump system version to 1.1.0 for crates.io republish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "aps-cli"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aps-v1-0000-meta",
  "apss-core",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "apss"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "apss-core",
  "clap",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "apss-core"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "handlebars",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/AgentParadise/agent-paradise-standards-system"
@@ -55,4 +55,4 @@ handlebars = "6.3"
 semver = "1.0"
 
 # Internal crates
-apss-core = { version = "1.0.0", path = "crates/apss-core" }
+apss-core = { version = "1.1.0", path = "crates/apss-core" }

--- a/crates/aps-cli/Cargo.toml
+++ b/crates/aps-cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 apss-core.workspace = true
-aps-v1-0000-meta = { version = "1.4.0", path = "../../standards/v1/APS-V1-0000-meta" }
+aps-v1-0000-meta = { version = "1.5.0", path = "../../standards/v1/APS-V1-0000-meta" }
 code-topology = { package = "apss-v1-0001-code-topology", version = "0.2.0", path = "../../standards/v1/APS-V1-0001-code-topology" }
 fitness-functions = { package = "apss-v1-0003-fitness-functions", version = "0.2.0", path = "../../standards-experimental/v1/EXP-V1-0003-fitness-functions" }
 apss-project-config = { version = "1.0.0", path = "../../standards/v1/APS-V1-0000-meta/substandards/CF01-project-config" }


### PR DESCRIPTION
Prerequisite for ADR-0002 Phase D publishing. apss-core and apss 1.0.0 are already on crates.io, so the Phase D registry-resolution code needs a new version to publish.

- workspace.package version 1.0.0 to 1.1.0 (apss-core, apss, aps-cli inherit)
- internal apss-core dependency pin 1.0.0 to 1.1.0
- corrects stale aps-cli pin of aps-v1-0000-meta 1.4.0 to 1.5.0 (matches merged meta-standard)

After merge: publish apss-core 1.1.0, apss 1.1.0, and apss-v1-0001-code-topology 0.2.0, then the turnkey friend flow works.