### PR TITLE
docs: correct 'apss add' to 'apss init --standard' (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ APSS uses crates.io as its distribution transport (see [ADR-0002](standards/v1/A
 cargo install apss
 
 # In your repo
-apss init        # generates APSS.yaml, the user-owned project manifest
-apss add code-topology   # add a standard to APSS.yaml
+apss init --standard code-topology   # generates APSS.yaml declaring the standard
+                                     # (replace the scaffolded id placeholder with APS-V1-0001)
 apss install     # resolves standards from crates.io, writes apss.lock, builds the composed binary, installs git hooks
 apss validate    # validate the project (also runs from the pre-commit hook)
 apss status      # show project configuration and status

--- a/crates/apss-bootstrap/README.md
+++ b/crates/apss-bootstrap/README.md
@@ -16,8 +16,7 @@ cargo install apss
 ## Usage
 
 ```bash
-apss init        # generate APSS.yaml, the user-owned project manifest
-apss add <standard>   # add a standard to APSS.yaml
+apss init --standard <slug>   # generate APSS.yaml declaring the standard
 apss install     # resolve standards from crates.io, write apss.lock, install git hooks
 apss validate    # validate the project (also runs from the pre-commit hook)
 apss status      # show project configuration and status

--- a/docs/runbooks/visualize-your-codebase.runbook.md
+++ b/docs/runbooks/visualize-your-codebase.runbook.md
@@ -26,13 +26,30 @@ Expected: `apss 1.0.0` (or newer) on PATH.
 From the target repository root:
 
 ```bash
-apss init
-apss add code-topology
+apss init --standard code-topology
 ```
 
 Expected:
 
 - `APSS.yaml` created (user-owned, edit freely) with a `code-topology` standard entry.
+
+The generated entry scaffolds the id as a placeholder:
+
+```yaml
+standards:
+  code-topology:
+    id: APS-V1-XXXX  # FIXME: replace with the real ID
+    version: ">=0.1.0"
+```
+
+Replace the placeholder id with the Code Topology standard's real ID, `APS-V1-0001`:
+
+```yaml
+standards:
+  code-topology:
+    id: APS-V1-0001
+    version: ">=0.1.0"
+```
 
 ## 3. Install the Standard
 
@@ -152,7 +169,7 @@ Expected: `Created APSS bundle: /tmp/apss-bundles/APS-V1-0001-code-topology-<ver
 
 ### A.2 Install From the Bundle
 
-From the target repository root, after `apss init` and `apss add code-topology` (step 2), install with `--bundle-dir` instead of the plain `apss install`:
+From the target repository root, after `apss init --standard code-topology` (step 2), install with `--bundle-dir` instead of the plain `apss install`:
 
 ```bash
 apss install --bundle-dir /tmp/apss-bundles/APS-V1-0001-code-topology-<version>.apss

--- a/standards/v1/APS-V1-0001-code-topology/README.md
+++ b/standards/v1/APS-V1-0001-code-topology/README.md
@@ -23,7 +23,7 @@ binary that contains only the standards your project declares.
 
 ```bash
 cargo install apss              # install the bootstrap CLI
-apss add code-topology          # declare the standard in APSS.yaml
+apss init --standard code-topology   # declare the standard in APSS.yaml (set id to APS-V1-0001)
 apss install                    # resolve, pin, and build the composed binary
 apss run code-topology analyze .            # analyze the codebase into .topology/
 apss run code-topology viz .topology --type all   # render the visualizations


### PR DESCRIPTION
The published CLI has no `apss add` subcommand; declaring a standard is `apss init --standard <slug>`. This was a wrong instruction shipped in the runbook and READMEs (found during the Phase D friend simulation).

Fixes the runbook, root README, bootstrap crate README, and the code-topology README, and documents replacing the scaffolded `APS-V1-XXXX` placeholder id with `APS-V1-0001`.

The deeper functional gaps (add an actual `apss add` command; a slug-to-id catalog so `init --standard` does not scaffold a FIXME) remain tracked in #76. This PR is the docs-accuracy stopgap so nobody follows a broken instruction.