### PR TITLE
docs: sync README + standard docs after the three-standard promotions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,89 @@
-# Agent Paradise Standards System (APS)
+# Agent Paradise Standards System (APSS)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![CI](https://github.com/AgentParadise/agent-paradise-standards-system/actions/workflows/ci.yml/badge.svg)](https://github.com/AgentParadise/agent-paradise-standards-system/actions)
 
-**Executable, evolvable standards for agentic engineering.** APS standards are versioned Rust crates with automated validation, not static documents.
+**Executable, evolvable standards for agentic engineering.** APSS standards are versioned Rust crates with automated validation, not static documents. They install from crates.io and run as a project-local CLI.
 
 ## Available Standards
 
 ### Official
 
-| Standard | Description | CLI |
-|----------|-------------|-----|
-| [APS-V1-0001 Code Topology](standards/v1/APS-V1-0001-code-topology/docs/00_overview.md) | Architectural metrics: complexity, coupling, module structure. Produces `.topology/` artifacts. | `aps run topology analyze .` |
+| Standard | Description | Run it |
+|----------|-------------|--------|
+| [APS-V1-0001 Code Topology](standards/v1/APS-V1-0001-code-topology/docs/00_overview.md) | Architectural metrics: complexity, coupling, module structure. Produces `.topology/` artifacts and visualizations. | `apss run code-topology analyze .` |
+| [APS-V1-0002 Architecture Fitness](standards/v1/APS-V1-0002-architecture-fitness/docs/00_overview.md) | Declarative architectural assertions (threshold, dependency, structural rules) over topology artifacts, with per-dimension scoring. | `apss run architecture-fitness validate .` |
+| [APS-V1-0003 Documentation](standards/v1/APS-V1-0003-documentation/docs/00_overview.md) | Documentation and context engineering: ADR enforcement, README index validation, agent context files. | `apss run documentation validate .` |
+
+The slug in the first command word is the **canonical slug** and must match the standard key in your `APSS.yaml`.
 
 ### Experimental
 
-| Standard | Description | CLI |
-|----------|-------------|-----|
-| [EXP-V1-0002 TODO Tracker](standards-experimental/v1/EXP-V1-0002-todo-tracker/docs/00_overview.md) | Scans TODO/FIXME comments, enforces issue references | `aps run todos scan` |
-| [EXP-V1-0003 Fitness Functions](standards-experimental/v1/EXP-V1-0003-fitness-functions/docs/00_overview.md) | Declarative architecture fitness thresholds against topology artifacts | `aps run fitness validate .` |
+| Standard | Description |
+|----------|-------------|
+| [EXP-V1-0002 TODO Tracker](standards-experimental/v1/EXP-V1-0002-todo-tracker/docs/00_overview.md) | Scans TODO/FIXME comments, enforces issue references |
 
 ### Governance
 
 | Standard | Description |
 |----------|-------------|
-| [APS-V1-0000 Meta-Standard](standards/v1/APS-V1-0000-meta/docs/00_overview.md) | Defines the structure, validation, and lifecycle for all V1 standards |
-
-## Architecture
-
-Standards **produce artifacts** → substandards **consume them and produce further output**.
-
-```
-APS-V1-0001 (Code Topology)
-├── Produces: .topology/metrics/*.json, .topology/graphs/*.json
-│
-├── RS01-rust            Rust source → topology data (input adapter)
-├── VZ01-dashboard       .topology/ → HTML dashboard with CodeCity, 3D, clusters
-├── MM01-mermaid         .topology/graphs/ → Mermaid dependency diagrams
-├── FD01-force-directed  .topology/metrics/ → WebGL 3D coupling visualization
-└── CI01-github-actions  .topology/ → PR comment with diff analysis
-```
-
-```
-EXP-V1-0003 (Fitness Functions)
-├── Consumes: .topology/metrics/*.json
-└── Produces: fitness-report.json (threshold violations, exceptions, ratchets)
-```
+| [APS-V1-0000 Meta-Standard](standards/v1/APS-V1-0000-meta/docs/00_overview.md) | Defines the structure, validation, distribution, and lifecycle for all V1 standards. Not published to crates.io. |
 
 ## Using APSS in Your Project
 
 APSS uses crates.io as its distribution transport (see [ADR-0002](standards/v1/APS-V1-0000-meta/docs/adrs/0002-crates-io-distribution.md)):
 
-- **crates.io delivers the tooling**: the `apss` CLI binary, built on `apss-core`.
+- **crates.io delivers the tooling**: the `apss` CLI, built on `apss-core`.
 - **crates.io delivers the standards**: each official standard publishes as one crate (for example `apss-v1-0001-code-topology`), and its substandards ship as cargo features of that crate. `apss install` resolves standards from crates.io, no APSS checkout required.
 
 ```bash
-# One-time: install the global CLI
+# One-time: install the global CLI (1.1.0 or newer resolves from crates.io)
 cargo install apss
 
-# In your repo
-apss init --standard code-topology   # generates APSS.yaml declaring the standard
-                                     # (replace the scaffolded id placeholder with APS-V1-0001)
-apss install     # resolves standards from crates.io, writes apss.lock, builds the composed binary, installs git hooks
-apss validate    # validate the project (also runs from the pre-commit hook)
+# In your repo: declare one or more standards, then install
+apss init --standard code-topology   # generates APSS.yaml (set the scaffolded id to APS-V1-0001)
+apss install     # resolves standards from crates.io, writes apss.lock, builds a project-local binary, installs the git hook
+apss validate    # validate the project config and standard structure (also runs from the pre-commit hook)
 apss status      # show project configuration and status
-apss run code-topology analyze .   # run a standard's command via the composed binary
+apss run code-topology analyze .   # run a standard's command through the project-local binary
 ```
 
-For offline or air-gapped installs, build a bundle locally and point the install at it instead. Bundles are the optional offline and catalog format, not the default transport:
+`APSS.yaml` lists standards by their canonical slug and id, for example:
+
+```yaml
+standards:
+  code-topology:        { id: APS-V1-0001, version: ">=0.2.0" }
+  architecture-fitness: { id: APS-V1-0002, version: ">=1.0.0" }
+  documentation:        { id: APS-V1-0003, version: ">=0.1.0" }
+```
+
+For offline or air-gapped installs, build a bundle locally and point the install at it. Bundles are the optional offline and catalog format, not the default transport:
 
 ```bash
 apss install --bundle-dir /path/to/bundles
 ```
 
-Commit `APSS.yaml` and `apss.lock`. The generated `.apss/` runtime is build output and stays out of git. Contributors to your repo can read, edit, and commit without installing the global CLI.
+Commit `APSS.yaml` and `apss.lock`. The generated `.apss/` runtime is build output and stays out of git. Contributors to your repo can read, edit, and commit without installing the global CLI. A step-by-step guide is in [docs/runbooks/visualize-your-codebase.runbook.md](docs/runbooks/visualize-your-codebase.runbook.md).
 
 The full lifecycle is specified in the [DI01 distribution substandard](standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/01_spec.md) and the [package manager lifecycle doc](standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/03_package_manager_lifecycle.md).
 
-## Quick Start (Developing APSS)
+## Architecture
 
-```bash
-# Build the CLI
-cargo build --release -p aps-cli
+Standards **produce artifacts**, and their substandards **consume those artifacts and produce further output**. Substandards ship as cargo features of the parent standard crate; the feature name equals the substandard profile code.
 
-# List available standards
-aps run --list
+```
+APS-V1-0001 (Code Topology)
+├── Produces: .topology/metrics/*.json, .topology/graphs/*.json
+│
+├── RS01 (lang-rust)         Rust source to topology data (input adapter)
+├── VZ01 (viz-dashboard)     .topology/ to an HTML dashboard (CodeCity, 3D, clusters)
+├── MM01 (viz-mermaid)       .topology/graphs/ to Mermaid dependency diagrams
+├── FD01 (force-directed)    .topology/metrics/ to a WebGL 3D coupling visualization
+└── CI01 (github-actions)    .topology/ to a PR comment with diff analysis
 
-# Analyze a codebase
-aps run topology analyze . --output .topology
-
-# Check architecture fitness thresholds
-aps run fitness validate .
-
-# Validate this repo's own standard structure
-aps v1 validate repo
+APS-V1-0002 (Architecture Fitness)
+└── Consumes .topology/ artifacts, evaluates declarative rules across 8 dimensions
+    (ST01 structural, MD01 modularity, MT01 maintainability, SC01 security, and more)
 ```
 
 ## Repository Structure
@@ -101,72 +91,59 @@ aps v1 validate repo
 ```
 agent-paradise-standards-system/
 ├── crates/
-│   ├── aps-core/                      # Core engine (diagnostics, discovery, templates)
-│   └── aps-cli/                       # CLI: aps run, aps v1 validate/create/promote
+│   ├── apss-core/                    # Core engine (diagnostics, discovery, registry, config, lockfile, codegen)
+│   ├── aps-cli/                      # Development CLI (apss-dev): v1 validate/create/promote/bundle, run
+│   └── apss-bootstrap/               # The published `apss` consumer CLI: init, install, status, validate, run
 ├── standards/v1/
-│   ├── APS-V1-0000-meta/             # Meta-standard (v1.1.0): defines all V1 rules
-│   └── APS-V1-0001-code-topology/    # Code topology + 5 substandards
-├── standards-experimental/v1/
-│   ├── EXP-V1-0001-code-topology/    # Promoted → APS-V1-0001 (historical)
-│   ├── EXP-V1-0002-todo-tracker/     # TODO/FIXME tracking
-│   └── EXP-V1-0003-fitness-functions/ # Architecture fitness thresholds
-└── crates/                            # Shared Rust crates (aps-core, aps-cli)
+│   ├── APS-V1-0000-meta/             # Meta-standard (v1.5.0): defines all V1 rules; not published
+│   ├── APS-V1-0001-code-topology/    # Code topology + substandards (RS01, VZ01, MM01, FD01, CI01)
+│   ├── APS-V1-0002-architecture-fitness/  # Architecture fitness + dimension substandards
+│   └── APS-V1-0003-documentation/    # Documentation + substandards (AD01, PV01, RT01)
+└── standards-experimental/v1/
+    ├── EXP-V1-0001-code-topology/    # Promoted to APS-V1-0001 (historical, slated for removal)
+    └── EXP-V1-0002-todo-tracker/     # TODO/FIXME tracking (incubating)
 ```
 
 ## Package Types
 
-| Type | ID Format | Structure | Purpose |
-|------|-----------|-----------|---------|
-| **Standard** | `APS-V1-XXXX` | Full: `docs/`, `examples/`, `tests/`, `agents/skills/`, `src/` | Produces artifacts, defines rules |
-| **Substandard** | `APS-V1-XXXX.YY##` | Reduced: `docs/`, `src/` | Consumes parent artifacts, produces further output |
-| **Experiment** | `EXP-V1-XXXX` | Full (same as standard) | Incubating: not enforced on consumers |
+| Type | ID Format | Purpose |
+|------|-----------|---------|
+| **Standard** | `APS-V1-XXXX` | Published crate. Produces artifacts, defines rules. Full structure (`docs/`, `examples/`, `tests/`, `agents/skills/`, `src/`). |
+| **Substandard** | `APS-V1-XXXX.YY##` | Feature module of the parent crate (feature name = the `YY##` code). Keeps `substandard.toml` + `docs/` as its governed identity. |
+| **Experiment** | `EXP-V1-XXXX` | Incubating. Held to the same validation bar; promoted to an official ID when ready. |
 
-Substandards inherit agent context and examples from their parent. Their `docs/01_spec.md` serves as agent-readable knowledge about what they consume and produce.
+## Two CLIs
 
-## CLI Commands
+- **`apss`** (published, `crates/apss-bootstrap`): the consumer CLI. `apss init`, `apss install`, `apss validate`, `apss status`, `apss run <canonical-slug> <command>`. This is what end users install.
+- **`apss-dev`** (development only, `crates/aps-cli`, not published): repo-authoring tooling. Validates and scaffolds standards in THIS repo. It also runs standards via slug aliases (for example `apss-dev run topology ...`) that the consumer `apss` does not accept.
 
-### Running Standards
-
-```bash
-aps run --list                          # List available standards
-aps run topology analyze .              # Analyze codebase topology
-aps run topology validate .topology/    # Validate artifact freshness
-aps run topology diff base/ pr/         # Compare topology snapshots
-aps run topology viz .topology/         # Generate visualizations
-aps run fitness validate .              # Check fitness thresholds
-```
-
-### Authoring Standards
+### Authoring standards (apss-dev)
 
 ```bash
-aps v1 validate repo                    # Validate all packages
-aps v1 validate standard APS-V1-0001    # Validate one standard
-aps v1 create standard my-standard      # Scaffold a new standard
-aps v1 create experiment my-idea        # Scaffold an experiment
-aps v1 promote EXP-V1-0001             # Promote experiment → official
-aps v1 version bump APS-V1-0001 minor   # Bump version
+cargo run -p aps-cli --bin apss-dev -- v1 validate repo            # validate all packages
+cargo run -p aps-cli --bin apss-dev -- v1 validate distribution    # distribution + registered-command checks
+cargo run -p aps-cli --bin apss-dev -- v1 create standard my-slug  # scaffold a new standard
+cargo run -p aps-cli --bin apss-dev -- v1 promote EXP-V1-0002      # promote an experiment to official
 ```
 
 ## Development
 
 ```bash
-# Run all checks
-just check
-
-# Run tests
+just check                 # format, lint, typecheck, test, build, aps-validate
+just qa                    # the full CI-equivalent gate
 cargo test --workspace
-
-# Validate repo structure
-cargo run -p aps-cli -- v1 validate repo
+cargo run -p aps-cli --bin apss-dev -- v1 validate repo
 ```
 
 ## Documentation
 
-- [Meta-Standard Spec (v1.1.0)](standards/v1/APS-V1-0000-meta/docs/01_spec.md): Normative rules for all V1 packages
-- [Code Topology Overview](standards/v1/APS-V1-0001-code-topology/docs/00_overview.md): Architecture metrics and visualization
-- [Fitness Functions Overview](standards-experimental/v1/EXP-V1-0003-fitness-functions/docs/00_overview.md): Declarative fitness thresholds
-- [Templates](standards/v1/APS-V1-0000-meta/templates/README.md): Package scaffolding
-- [Experimental Standards](standards-experimental/v1/README.md): Incubation and promotion
+- [Meta-Standard Spec](standards/v1/APS-V1-0000-meta/docs/01_spec.md): normative rules for all V1 packages
+- [ADR-0002: crates.io distribution](standards/v1/APS-V1-0000-meta/docs/adrs/0002-crates-io-distribution.md): the distribution model
+- [Code Topology Overview](standards/v1/APS-V1-0001-code-topology/docs/00_overview.md)
+- [Architecture Fitness Overview](standards/v1/APS-V1-0002-architecture-fitness/docs/00_overview.md)
+- [Documentation Standard Overview](standards/v1/APS-V1-0003-documentation/docs/00_overview.md)
+- [Visualize Your Codebase runbook](docs/runbooks/visualize-your-codebase.runbook.md): hand-to-a-friend guide
+- [Experimental Standards](standards-experimental/v1/README.md): incubation and promotion
 
 ## License
 

--- a/crates/aps-cli/src/main.rs
+++ b/crates/aps-cli/src/main.rs
@@ -236,22 +236,21 @@ fn main() -> ExitCode {
             list,
         } => {
             if list {
-                // List available standards
+                // Build the list from the registered standards themselves so it
+                // can never drift from register() metadata.
                 println!("Available Standards:\n");
-                println!("  topology (EXP-V1-0001) v0.1.0");
-                println!("    Code Topology - architectural metrics and visualization");
-                println!("    Commands: analyze, validate, diff, report, viz");
-                println!();
-                println!(
-                    "  architecture-fitness ({}) v{}",
-                    architecture_fitness::ID,
-                    architecture_fitness::VERSION
-                );
-                println!(
-                    "    Architecture Fitness Functions - declarative architectural assertions"
-                );
-                println!("    Commands: validate");
-                println!();
+                let mut collector = apss_core::registry::CollectorRegistry::new();
+                code_topology::register(&mut collector);
+                architecture_fitness::register(&mut collector);
+                documentation::register(&mut collector);
+                for (info, _handler) in collector.entries() {
+                    println!("  {} ({}) v{}", info.slug, info.id, info.version);
+                    println!("    {}", info.description);
+                    if !info.commands.is_empty() {
+                        println!("    Commands: {}", info.commands.join(", "));
+                    }
+                    println!();
+                }
                 println!("Use 'apss-dev run <slug> --help' for command details.");
                 return ExitCode::SUCCESS;
             }

--- a/docs/runbooks/visualize-your-codebase.runbook.md
+++ b/docs/runbooks/visualize-your-codebase.runbook.md
@@ -161,7 +161,7 @@ Expected: validation output before the commit completes. Hook failures block the
 ## Related
 
 - Consumer flow overview: root `README.md`, section "Using APSS in Your Project"
-- Distribution model: ADR-0002 (`standards/v1/APS-V1-0000-meta/docs/adrs/0002-crates-io-distribution.md`) and the [DI01 distribution spec](standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/01_spec.md)
+- Distribution model: ADR-0002 (`standards/v1/APS-V1-0000-meta/docs/adrs/0002-crates-io-distribution.md`) and the [DI01 distribution spec](../../standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/01_spec.md)
 - Distribution lifecycle: `standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/03_package_manager_lifecycle.md`
 - Release acceptance testing: `docs/testing/apss-package-manual-acceptance-testing.runbook.md`
 - Tracking: #67 (runbooks), #70 (CLI UX); #68 closed by ADR-0002 Phase C (consumer binary runs all commands). ADR-0002 Phase D enables registry install (`apss install` from crates.io with no checkout).

--- a/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/agents/skills/README.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/agents/skills/README.md
@@ -2,10 +2,6 @@
 
 ## Available Skills
 
-### implement-standard-cli.md
-
-Guide for implementing the `StandardCli` trait for a new standard.
-
 ### run-standard.md
 
 Guide for running standard CLI commands.
@@ -16,5 +12,4 @@ Guide for running standard CLI commands.
 
 | Skill | Purpose |
 |-------|---------|
-| [implement-standard-cli](./implement-standard-cli.md) | Implement CLI for a standard |
 | [run-standard](./run-standard.md) | Run standard commands |

--- a/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/docs/00_overview.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/docs/00_overview.md
@@ -58,4 +58,4 @@ Every standard with artifacts SHOULD expose:
 ## Related
 
 - [01_spec.md](./01_spec.md) — Full specification
-- [EXP-V1-0001](../../../standards-experimental/v1/EXP-V1-0001-code-topology/) — Example implementation
+- [EXP-V1-0001](../../../../../../standards-experimental/v1/EXP-V1-0001-code-topology/): Example implementation

--- a/standards/v1/APS-V1-0001-code-topology/substandards/CI01-github-actions/README.md
+++ b/standards/v1/APS-V1-0001-code-topology/substandards/CI01-github-actions/README.md
@@ -10,7 +10,7 @@
 - [substandard.toml](substandard.toml)
 - [Specification](docs/01_spec.md)
 - [Examples](examples/)
-- [Tests](tests/)
+- Tests: in the parent crate at `standards/v1/APS-V1-0001-code-topology/tests/`.
 - [Agent Skills](agents/skills/)
 
 ## Validation

--- a/standards/v1/APS-V1-0001-code-topology/substandards/MM01-mermaid/README.md
+++ b/standards/v1/APS-V1-0001-code-topology/substandards/MM01-mermaid/README.md
@@ -10,7 +10,7 @@
 - [substandard.toml](substandard.toml)
 - [Specification](docs/01_spec.md)
 - [Examples](examples/)
-- [Tests](tests/)
+- Tests: in the parent crate at `standards/v1/APS-V1-0001-code-topology/tests/`.
 - [Agent Skills](agents/skills/)
 
 ## Validation

--- a/standards/v1/APS-V1-0001-code-topology/substandards/RS01-rust/README.md
+++ b/standards/v1/APS-V1-0001-code-topology/substandards/RS01-rust/README.md
@@ -10,7 +10,7 @@
 - [substandard.toml](substandard.toml)
 - [Specification](docs/01_spec.md)
 - [Examples](examples/)
-- [Tests](tests/)
+- Tests: in the parent crate at `standards/v1/APS-V1-0001-code-topology/tests/`.
 - [Agent Skills](agents/skills/)
 
 ## Validation

--- a/standards/v1/APS-V1-0002-architecture-fitness/README.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/README.md
@@ -40,7 +40,7 @@ cargo run -p aps-cli --bin apss-dev -- v1 validate repo
 Run the fitness engine itself against a target project:
 
 ```bash
-cargo run -p aps-cli -- run fitness validate <path>
+cargo run -p aps-cli -- run architecture-fitness validate <path>
 ```
 
 Add `--previous-report path/to/prior.json` for trend deltas (or the back-compat alias `--previous`).

--- a/standards/v1/APS-V1-0002-architecture-fitness/agents/skills/README.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/agents/skills/README.md
@@ -6,7 +6,7 @@ Skills for AI agents to interact with the architectural fitness governance frame
 
 | Skill | Purpose | Trigger Phrases |
 |-------|---------|-----------------|
-| [`validate-fitness`](./validate-fitness.md) | Run fitness validation and interpret results | "validate fitness", "check architecture", "run fitness functions" |
+| [`validate-fitness`](./validate-fitness.md) | Run fitness validation and interpret results | "validate fitness", "check architecture", "run architecture-fitness functions" |
 | [`interpret-report`](./interpret-report.md) | Read and explain a fitness report | "explain fitness report", "what are the violations", "show system fitness" |
 | [`configure-dimensions`](./configure-dimensions.md) | Set up fitness governance for a project | "configure fitness", "set up architectural governance", "add fitness rules" |
 
@@ -15,7 +15,7 @@ Skills for AI agents to interact with the architectural fitness governance frame
 ```
 configure-dimensions → fitness.toml created
                             ↓
-validate-fitness     → aps run fitness validate .
+validate-fitness     → aps run architecture-fitness validate .
                             ↓
 interpret-report     → read fitness-report.json, explain findings
 ```

--- a/standards/v1/APS-V1-0002-architecture-fitness/agents/skills/validate-fitness.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/agents/skills/validate-fitness.md
@@ -5,7 +5,7 @@ Run architecture fitness validation and report results.
 ## Usage
 
 ```
-User: "validate fitness" | "check architecture" | "run fitness functions"
+User: "validate fitness" | "check architecture" | "run architecture-fitness functions"
 ```
 
 ## Parameters
@@ -24,7 +24,7 @@ The six active dimensions (MT01, MD01, ST01, SC01, LG01, AC01) are evaluated in 
 
 1. Check that `fitness.toml` exists at the target path
 2. Check that `.topology/` directory exists (run `aps run topology analyze .` if missing)
-3. Run `aps run fitness validate <path>` with appropriate options. For trend analysis, pass `--previous-report <file>` (the CLI flag is `--previous-report`, not `--previous`).
+3. Run `aps run architecture-fitness validate <path>` with appropriate options. For trend analysis, pass `--previous-report <file>` (the CLI flag is `--previous-report`, not `--previous`).
 4. Read the output and report:
    - Overall pass/fail status
    - System-level fitness score and threshold

--- a/standards/v1/APS-V1-0002-architecture-fitness/docs/00_overview.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/docs/00_overview.md
@@ -104,7 +104,7 @@ scope = "module"
 
 **Run:**
 ```bash
-aps run fitness validate .
+aps run architecture-fitness validate .
 ```
 
 ## What's New vs EXP-V1-0003
@@ -151,7 +151,7 @@ scope = "function"
 
 ### 3. Validate
 ```bash
-aps run fitness validate .
+aps run architecture-fitness validate .
 ```
 
 ### 4. Handle violations
@@ -165,7 +165,7 @@ issue = "#138"
 ### 5. Add to CI
 ```yaml
 - name: Check architectural fitness
-  run: aps run fitness validate .
+  run: aps run architecture-fitness validate .
 ```
 
 ## Status
@@ -182,7 +182,7 @@ MT01, MD01, ST01, SC01, LG01 are default-enabled and active; AC01 is opt-in and 
 - Full metrics catalog with 20+ metrics, formulas, authors, and cited thresholds
 - Reference Rust implementation (dimensional scoring engine, system-level composite, adapter contract, trend tracking, strict-artifact enforcement)
 - JSON Schemas for fitness.toml, fitness-exceptions.toml, fitness-report.json with example round-trip tests
-- CLI integration via `aps run fitness validate`
+- CLI integration via `aps run architecture-fitness validate`
 
 ## Related Standards
 

--- a/standards/v1/APS-V1-0002-architecture-fitness/docs/01_spec.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/docs/01_spec.md
@@ -490,7 +490,7 @@ The `issue` field is **REQUIRED**. Exceptions without issue references MUST caus
 
 1. **Budget enforcement**: If `value` is specified and the actual metric value exceeds the exception's `value`, the exception is **insufficient** - the violation is reported as unexcepted.
 2. **Stale detection**: If an entity no longer exists in the topology artifacts, or its metric value is now within the rule's threshold, the exception is **stale**. Stale exceptions MUST be reported in the validation output.
-3. **Monotonic decrease**: When regenerating exceptions (via the planned, not-yet-implemented `aps run fitness ratchet` command), new `value` entries MUST NOT exceed previous values. The ratchet only tightens.
+3. **Monotonic decrease**: When regenerating exceptions (via the planned, not-yet-implemented `aps run architecture-fitness ratchet` command), new `value` entries MUST NOT exceed previous values. The ratchet only tightens.
 
 ---
 
@@ -983,16 +983,16 @@ aps run architecture-fitness validate . --report fitness-report.json
 aps run architecture-fitness validate . --previous-report prior.json
 
 # PLANNED, not yet implemented: validate specific dimensions only
-aps run fitness validate . --dimensions MT01,MD01
+aps run architecture-fitness validate . --dimensions MT01,MD01
 
 # PLANNED, not yet implemented: auto-generate exceptions from current violations
-aps run fitness ratchet <path>
+aps run architecture-fitness ratchet <path>
 
 # PLANNED, not yet implemented: show system-level fitness summary
-aps run fitness summary <path>
+aps run architecture-fitness summary <path>
 
 # PLANNED, not yet implemented: show report in specific format
-aps run fitness report <path> --format human|json
+aps run architecture-fitness report <path> --format human|json
 ```
 
 ### 11.2 Options

--- a/standards/v1/APS-V1-0002-architecture-fitness/docs/01_spec.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/docs/01_spec.md
@@ -490,7 +490,7 @@ The `issue` field is **REQUIRED**. Exceptions without issue references MUST caus
 
 1. **Budget enforcement**: If `value` is specified and the actual metric value exceeds the exception's `value`, the exception is **insufficient** - the violation is reported as unexcepted.
 2. **Stale detection**: If an entity no longer exists in the topology artifacts, or its metric value is now within the rule's threshold, the exception is **stale**. Stale exceptions MUST be reported in the validation output.
-3. **Monotonic decrease**: When regenerating exceptions (via `aps run fitness ratchet`), new `value` entries MUST NOT exceed previous values. The ratchet only tightens.
+3. **Monotonic decrease**: When regenerating exceptions (via the planned, not-yet-implemented `aps run fitness ratchet` command), new `value` entries MUST NOT exceed previous values. The ratchet only tightens.
 
 ---
 
@@ -964,37 +964,46 @@ severity = "warning"
 
 > This section is informative. The CLI is provided by the `aps` tool.
 
+> **Implementation status.** The implemented CLI surface is the single
+> `validate` subcommand with the flags `--config`, `--report`, and
+> `--previous-report` (alias `--previous`). The `ratchet`, `summary`, and
+> `report` subcommands and the `--dimensions` / `--format` flags below are a
+> forward specification: planned, not yet implemented.
+
 ### 11.1 Commands
 
 ```bash
-# Validate all rules
-aps run fitness validate <path>
+# Validate all rules (implemented)
+aps run architecture-fitness validate <path>
 
-# Validate specific dimensions only
+# Write JSON report (implemented)
+aps run architecture-fitness validate . --report fitness-report.json
+
+# Trend deltas against a prior report (implemented)
+aps run architecture-fitness validate . --previous-report prior.json
+
+# PLANNED, not yet implemented: validate specific dimensions only
 aps run fitness validate . --dimensions MT01,MD01
 
-# Write JSON report
-aps run fitness validate . --report fitness-report.json
-
-# Auto-generate exceptions from current violations
+# PLANNED, not yet implemented: auto-generate exceptions from current violations
 aps run fitness ratchet <path>
 
-# Show system-level fitness summary
+# PLANNED, not yet implemented: show system-level fitness summary
 aps run fitness summary <path>
 
-# Show report in specific format
+# PLANNED, not yet implemented: show report in specific format
 aps run fitness report <path> --format human|json
 ```
 
 ### 11.2 Options
 
-| Option | Description |
-|--------|-------------|
-| `--config <path>` | Path to fitness.toml (default: `./fitness.toml`) |
-| `--report <path>` | Write JSON report to file |
-| `--dimensions <list>` | Comma-separated dimension codes to evaluate |
-| `--format <fmt>` | Output format: `human` or `json` (default: `human`) |
-| `--previous-report <path>` | Path to previous report for trend analysis. Resolved relative to the validate target. `--previous` is accepted as a back-compat alias. |
+| Option | Status | Description |
+|--------|--------|-------------|
+| `--config <path>` | implemented | Path to fitness.toml (default: `./fitness.toml`) |
+| `--report <path>` | implemented | Write JSON report to file |
+| `--previous-report <path>` | implemented | Path to previous report for trend analysis. Resolved relative to the validate target. `--previous` is accepted as a back-compat alias. |
+| `--dimensions <list>` | planned, not yet implemented | Comma-separated dimension codes to evaluate |
+| `--format <fmt>` | planned, not yet implemented | Output format: `human` or `json` (default: `human`) |
 
 ---
 

--- a/standards/v1/APS-V1-0002-architecture-fitness/docs/INTEGRATION.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/docs/INTEGRATION.md
@@ -168,7 +168,7 @@ value = 28
 issue = "#185"
 ```
 
-Every exception REQUIRES an `issue` reference - it MUST be tracked work, not just a silenced warning. The `value` acts as a budget: if the metric climbs above 42, the exception is insufficient and the violation re-surfaces. Exceptions are currently authored by hand in `fitness-exceptions.toml`. An auto-regeneration command (`apss run fitness ratchet`) is planned, not yet implemented; by design it tightens monotonically and will never widen an existing budget.
+Every exception REQUIRES an `issue` reference - it MUST be tracked work, not just a silenced warning. The `value` acts as a budget: if the metric climbs above 42, the exception is insufficient and the violation re-surfaces. Exceptions are currently authored by hand in `fitness-exceptions.toml`. An auto-regeneration command (`apss run architecture-fitness ratchet`) is planned, not yet implemented; by design it tightens monotonically and will never widen an existing budget.
 
 ## 6. CI integration
 

--- a/standards/v1/APS-V1-0002-architecture-fitness/docs/INTEGRATION.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/docs/INTEGRATION.md
@@ -21,22 +21,27 @@ This guide walks through wiring architectural fitness governance into a Rust pro
                                                                               └──────────────────────┘
 ```
 
-**Separation of concerns:** APS-V1-0001 produces data. APS-V1-0002 asserts on it. The artifacts at `.topology/metrics/` are the contract between them, governed by the schemas in `APS-V1-0001/schemas/`.
+**Separation of concerns:** APS-V1-0001 produces data. APS-V1-0002 asserts on it. The artifacts at `.topology/metrics/` are the contract between them, governed by the `.proto` schemas in `APS-V1-0001-code-topology/proto/`.
 
 ## 1. Prerequisites
 
 - A Rust project (single crate or workspace) using 2021+ edition.
-- `apss` CLI installed. The project's `apss.toml` declares the standards:
+- `apss` CLI installed. The project's `APSS.yaml` declares the standards:
 
-  ```toml
-  [project]
-  name = "my-project"
+  ```yaml
+  schema: apss.project/v1
 
-  [standards.code-topology]
-  version = "1.0.0"
+  project:
+    name: my-project
+    apss_version: v1
 
-  [standards.architecture-fitness]
-  version = "1.0.0"
+  standards:
+    code-topology:
+      id: APS-V1-0001
+      version: ">=1.0.0, <2.0.0"
+    architecture-fitness:
+      id: APS-V1-0002
+      version: ">=1.0.0, <2.0.0"
   ```
 
 Run `apss install` to build the project-local CLI into `.apss/bin/`.
@@ -55,7 +60,7 @@ This writes:
 - `.topology/graphs/coupling-matrix.json` - module-to-module coupling strengths
 - `.topology/manifest.toml` - run metadata
 
-All `*.json` artifacts carry `schema_version: "1.0.0"` and validate against the schemas in `APS-V1-0001/schemas/`.
+All `*.json` artifacts carry `schema_version: "1.0.0"` and conform to the `.proto` schemas in `APS-V1-0001-code-topology/proto/`.
 
 ## 3. Configure fitness rules
 
@@ -163,7 +168,7 @@ value = 28
 issue = "#185"
 ```
 
-Every exception REQUIRES an `issue` reference - it MUST be tracked work, not just a silenced warning. The `value` acts as a budget: if the metric climbs above 42, the exception is insufficient and the violation re-surfaces. Regenerating exceptions tightens monotonically - `apss run fitness ratchet` will never widen an existing budget.
+Every exception REQUIRES an `issue` reference - it MUST be tracked work, not just a silenced warning. The `value` acts as a budget: if the metric climbs above 42, the exception is insufficient and the violation re-surfaces. Exceptions are currently authored by hand in `fitness-exceptions.toml`. An auto-regeneration command (`apss run fitness ratchet`) is planned, not yet implemented; by design it tightens monotonically and will never widen an existing budget.
 
 ## 6. CI integration
 
@@ -314,7 +319,7 @@ The engine still treats `PF01` as `incubating` in `fitness-report.json`'s `promo
 - [Spec §3.5](./01_spec.md) for Artifact Contracts
 - [ADR 0002](./adrs/0002-mt01-md01-promotion.md) for why MT01 and MD01 are active
 - [ADR 0003](./adrs/0003-six-dimension-promotion.md) for why ST01, SC01, LG01, AC01 promoted alongside them
-- [APS-V1-0001 schemas](../../APS-V1-0001-code-topology/schemas/) for upstream artifact contracts
+- [APS-V1-0001 artifact schemas](../../APS-V1-0001-code-topology/proto/) for upstream artifact contracts (the `.proto` definitions for `functions.json`, `modules.json`, `coupling.json`, and the graph/manifest artifacts)
 - [`fitness-config.schema.json`](../schemas/fitness-config.schema.json) for the config contract
 - [`fitness-exceptions.schema.json`](../schemas/fitness-exceptions.schema.json) for the exceptions contract
 - [`fitness-report.schema.json`](../schemas/fitness-report.schema.json) for the report contract

--- a/standards/v1/APS-V1-0002-architecture-fitness/docs/adrs/0002-mt01-md01-promotion.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/docs/adrs/0002-mt01-md01-promotion.md
@@ -43,7 +43,7 @@ Source of truth: `DimensionCode::promotion_status()` in `architecture-fitness/sr
 
 ## Consequences
 
-- Projects using APS-V1-0002 with MT01 or MD01 rules MUST run APS-V1-0001 topology generation before `apss run fitness validate`; otherwise rules fail rather than skip.
+- Projects using APS-V1-0002 with MT01 or MD01 rules MUST run APS-V1-0001 topology generation before `apss run architecture-fitness validate`; otherwise rules fail rather than skip.
 - Incubating dimensions remain advisory. The composite system fitness score reflects only enforced dimensions (originally MT01 + MD01, now including others per ADR 0003) by default per §6.1. Users who want incubating scores in the composite set `include_incubating = true`.
 - Future dimension promotions follow this same pattern: land producer + schema + reference crate + ADR in a single bounded change.
 

--- a/standards/v1/APS-V1-0002-architecture-fitness/examples/README.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/examples/README.md
@@ -16,7 +16,7 @@ This directory contains examples demonstrating valid usage of APS-V1-0002.
 1. Copy `fitness.toml` to your repository root
 2. Adjust thresholds for your project's standards
 3. Run `aps run topology analyze .` to generate `.topology/` artifacts
-4. Run `aps run fitness validate .` to evaluate rules
+4. Run `aps run architecture-fitness validate .` to evaluate rules
 5. Use `fitness-report.json` as a reference for the output format
 
 ## Adding Examples

--- a/standards/v1/APS-V1-0002-architecture-fitness/schemas/fitness-report.schema.json
+++ b/standards/v1/APS-V1-0002-architecture-fitness/schemas/fitness-report.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "urn:apss:schema:aps-v1-0002:fitness-report:1.0.0",
   "title": "Fitness Report",
-  "description": "Schema for fitness-report.json - output of `aps run fitness validate` per APS-V1-0002 §7.",
+  "description": "Schema for fitness-report.json - output of `aps run architecture-fitness validate` per APS-V1-0002 §7.",
   "type": "object",
   "required": [
     "schema_version",

--- a/standards/v1/APS-V1-0002-architecture-fitness/src/cli.rs
+++ b/standards/v1/APS-V1-0002-architecture-fitness/src/cli.rs
@@ -18,7 +18,7 @@ use apss_core::registry::{CommandHandler, CommandInfo};
 use crate::{FitnessReport, FitnessValidator, RuleStatus};
 
 /// Handler that backs `run architecture-fitness <command>` in composed
-/// binaries and `run fitness <command>` in the dev CLI.
+/// binaries and `run architecture-fitness <command>` in the dev CLI.
 pub struct FitnessCommandHandler;
 
 impl FitnessCommandHandler {

--- a/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/accessibility.rs
+++ b/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/accessibility.rs
@@ -35,7 +35,7 @@ impl apss_core::registry::CommandHandler for NoopCommandHandler {
     fn execute(&self, _command: &str, _args: &[String], _config: &toml::Value) -> i32 {
         eprintln!(
             "No composed CLI commands for architecture-fitness-ac01; use the parent \
-             architecture-fitness via `apss run fitness validate`."
+             architecture-fitness via `apss run architecture-fitness validate`."
         );
         5
     }

--- a/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/availability.rs
+++ b/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/availability.rs
@@ -36,7 +36,7 @@ impl apss_core::registry::CommandHandler for NoopCommandHandler {
     fn execute(&self, _command: &str, _args: &[String], _config: &toml::Value) -> i32 {
         eprintln!(
             "No composed CLI commands for architecture-fitness-av01; use the parent \
-             architecture-fitness via `apss run fitness validate`."
+             architecture-fitness via `apss run architecture-fitness validate`."
         );
         5
     }

--- a/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/legality.rs
+++ b/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/legality.rs
@@ -37,7 +37,7 @@ impl apss_core::registry::CommandHandler for NoopCommandHandler {
     fn execute(&self, _command: &str, _args: &[String], _config: &toml::Value) -> i32 {
         eprintln!(
             "No composed CLI commands for architecture-fitness-lg01; use the parent \
-             architecture-fitness via `apss run fitness validate`."
+             architecture-fitness via `apss run architecture-fitness validate`."
         );
         5
     }

--- a/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/maintainability.rs
+++ b/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/maintainability.rs
@@ -96,7 +96,7 @@ impl apss_core::registry::CommandHandler for NoopCommandHandler {
     fn execute(&self, _command: &str, _args: &[String], _config: &toml::Value) -> i32 {
         eprintln!(
             "No composed CLI commands for architecture-fitness-mt01; use the parent \
-             architecture-fitness via `apss run fitness validate`."
+             architecture-fitness via `apss run architecture-fitness validate`."
         );
         5
     }

--- a/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/modularity.rs
+++ b/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/modularity.rs
@@ -91,7 +91,7 @@ impl apss_core::registry::CommandHandler for NoopCommandHandler {
     fn execute(&self, _command: &str, _args: &[String], _config: &toml::Value) -> i32 {
         eprintln!(
             "No composed CLI commands for architecture-fitness-md01; use the parent \
-             architecture-fitness via `apss run fitness validate`."
+             architecture-fitness via `apss run architecture-fitness validate`."
         );
         5
     }

--- a/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/performance.rs
+++ b/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/performance.rs
@@ -37,7 +37,7 @@ impl apss_core::registry::CommandHandler for NoopCommandHandler {
     fn execute(&self, _command: &str, _args: &[String], _config: &toml::Value) -> i32 {
         eprintln!(
             "No composed CLI commands for architecture-fitness-pf01; use the parent \
-             architecture-fitness via `apss run fitness validate`."
+             architecture-fitness via `apss run architecture-fitness validate`."
         );
         5
     }

--- a/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/security.rs
+++ b/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/security.rs
@@ -35,7 +35,7 @@ impl apss_core::registry::CommandHandler for NoopCommandHandler {
     fn execute(&self, _command: &str, _args: &[String], _config: &toml::Value) -> i32 {
         eprintln!(
             "No composed CLI commands for architecture-fitness-sc01; use the parent \
-             architecture-fitness via `apss run fitness validate`."
+             architecture-fitness via `apss run architecture-fitness validate`."
         );
         5
     }

--- a/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/structural.rs
+++ b/standards/v1/APS-V1-0002-architecture-fitness/src/substandards/structural.rs
@@ -41,7 +41,7 @@ impl apss_core::registry::CommandHandler for NoopCommandHandler {
     fn execute(&self, _command: &str, _args: &[String], _config: &toml::Value) -> i32 {
         eprintln!(
             "No composed CLI commands for architecture-fitness-st01; use the parent \
-             architecture-fitness via `apss run fitness validate`."
+             architecture-fitness via `apss run architecture-fitness validate`."
         );
         5
     }

--- a/standards/v1/APS-V1-0002-architecture-fitness/substandards/MD01-modularity/README.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/substandards/MD01-modularity/README.md
@@ -11,7 +11,7 @@ Martin Ca / Ce / I / A / D package coupling governance over module-level metrics
 
 - [substandard.toml](substandard.toml)
 - [Specification](docs/01_spec.md)
-- [Tests](tests/)
+- Tests: in the parent crate at `standards/v1/APS-V1-0002-architecture-fitness/tests/modularity_integration.rs`.
 - Engine: parent crate at `standards/v1/APS-V1-0002-architecture-fitness/src/lib.rs`. This substandard publishes `DEFAULT_RULES_TOML`; the engine consumes it.
 
 ## Validation

--- a/standards/v1/APS-V1-0002-architecture-fitness/substandards/MD01-modularity/docs/01_spec.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/substandards/MD01-modularity/docs/01_spec.md
@@ -46,7 +46,7 @@ This substandard governs **module-level coupling and dependency structure** - th
 | Slice Independence Score (SIS) | Slice | How independent a vertical slice is from others |
 | Cross-Context Coupling | Slice | Number of cross-bounded-context dependencies |
 
-See [02_metrics-catalog.md](../../docs/02_metrics-catalog.md) for complete definitions.
+See [02_metrics-catalog.md](../../../docs/02_metrics-catalog.md) for complete definitions.
 
 ## 3. Default Rules
 

--- a/standards/v1/APS-V1-0002-architecture-fitness/substandards/MT01-maintainability/README.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/substandards/MT01-maintainability/README.md
@@ -11,7 +11,7 @@ McCabe / SonarSource / Halstead complexity governance over function-level metric
 
 - [substandard.toml](substandard.toml)
 - [Specification](docs/01_spec.md)
-- [Tests](tests/)
+- Tests: in the parent crate at `standards/v1/APS-V1-0002-architecture-fitness/tests/maintainability_integration.rs`.
 - Engine: parent crate at `standards/v1/APS-V1-0002-architecture-fitness/src/lib.rs`. This substandard publishes `DEFAULT_RULES_TOML`; the engine consumes it.
 
 ## Validation

--- a/standards/v1/APS-V1-0002-architecture-fitness/substandards/MT01-maintainability/docs/01_spec.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/substandards/MT01-maintainability/docs/01_spec.md
@@ -24,7 +24,7 @@ This substandard governs **function-level and file-level maintainability** - the
 | Lines of Code (LOC/SLOC) | File, Module | Line counts | Brooks (1975), Boehm (1981) |
 | Maintainability Index (MI) | File, Module | MI = 171 - 5.2×ln(V) - 0.23×CC - 16.2×ln(LOC) | Coleman et al. (1994) |
 
-See [02_metrics-catalog.md](../../docs/02_metrics-catalog.md) for complete definitions.
+See [02_metrics-catalog.md](../../../docs/02_metrics-catalog.md) for complete definitions.
 
 ## 3. Default Rules
 

--- a/standards/v1/APS-V1-0002-architecture-fitness/substandards/ST01-structural/docs/01_spec.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/substandards/ST01-structural/docs/01_spec.md
@@ -28,7 +28,7 @@ These metrics require class-level analysis not yet available in the topology sta
 | Weighted Methods per Class (WMC) | Class | Σ CC per method | Chidamber & Kemerer (1994) | Planned |
 | Lack of Cohesion in Methods (LCOM) | Class | Henderson-Sellers variant | Henderson-Sellers (1996) | Planned |
 
-See [02_metrics-catalog.md](../../docs/02_metrics-catalog.md) for complete definitions.
+See [02_metrics-catalog.md](../../../docs/02_metrics-catalog.md) for complete definitions.
 
 ### 2.2 Structural Pattern Checks (Active)
 

--- a/standards/v1/APS-V1-0003-documentation/README.md
+++ b/standards/v1/APS-V1-0003-documentation/README.md
@@ -2,7 +2,7 @@
 
 Generic frontmatter-driven index and progressive-disclosure mechanism for any docs directory, plus a pluggable doc-type registry layered on top. The standard is the substrate; the doc types (ADRs, the North Star, Retrospectives) are instances.
 
-This is an experimental standard under APS-V1-0003. The contract surface, doc type registry, and install hook are normative. The validator implementation is split across the parent and its substandards.
+This is an official, active standard under APS-V1-0003 (promoted from EXP-V1-0004). The contract surface, doc type registry, and install hook are normative. The validator implementation is split across the parent and its substandards.
 
 ## Where the contract lives
 
@@ -46,8 +46,8 @@ subcommands are planned for a follow-up and are not yet implemented.
 
 ## Configuration
 
-This standard registers the slug `docs` and contributes the `docs:` section of `APSS.yaml`, owned by the meta-standard (APS-V1-0000.CF01). Zero-config works: absence of a key means the documented default applies (per Section 3.2 of the spec). A key is written only to opt out (`disable: true`) or to override a non-`disable` default.
+This standard's canonical slug is `documentation` (the `docs` and `doc` spellings are dev-CLI aliases only). It contributes the `docs:` section of `APSS.yaml`, owned by the meta-standard (APS-V1-0000.CF01). Zero-config works: absence of a key means the documented default applies (per Section 3.2 of the spec). A key is written only to opt out (`disable: true`) or to override a non-`disable` default.
 
 ## Status
 
-Experimental. The contract surface is stable; validator implementations land iteratively per substandard.
+Official and active (APS-V1-0003, promoted from EXP-V1-0004). The contract surface is stable; validator implementations land iteratively per substandard.

--- a/standards/v1/APS-V1-0003-documentation/docs/00_overview.md
+++ b/standards/v1/APS-V1-0003-documentation/docs/00_overview.md
@@ -82,8 +82,9 @@ Beyond the substrate and the registry, the parent contributes a small
 amount of project-wide infrastructure:
 
 1. **A single shared config file** at `APSS.yaml`, owned by the
-   meta-standard (APS-V1-0000.CF01). This standard registers the slug
-   `docs` and contributes the `docs:` section schema. Every rule is
+   meta-standard (APS-V1-0000.CF01). This standard's canonical slug is
+   `documentation` (the `docs` and `doc` spellings are dev-CLI aliases
+   only); it contributes the `docs:` section schema. Every rule is
    default on. A project switches one off by setting `disable: true`
    in the smallest scope that contains it. There are no scattered
    per-feature `optional` flags. Absence of a key equals the default

--- a/standards/v1/APS-V1-0003-documentation/docs/01_spec.md
+++ b/standards/v1/APS-V1-0003-documentation/docs/01_spec.md
@@ -6,7 +6,7 @@ description: "Normative rules for documentation structure, the doc type registry
 # APS-V1-0003 - Documentation and Context Engineering (Canonical Specification)
 
 **Version**: 0.1.0
-**Status**: Experimental
+**Status**: Active (official; promoted from EXP-V1-0004)
 **Category**: Governance
 
 ---
@@ -69,7 +69,7 @@ This standard plugs into the unified APSS configuration model owned by the meta-
 
 This standard:
 
-1. Registers the slug `docs`.
+1. Registers the canonical slug `documentation` (the `docs` and `doc` spellings are dev-CLI aliases only).
 2. Contributes the schema for the `docs` section of `APSS.yaml` (Section 3 below).
 3. Validates its own section: the parent validator validates the `docs` block and its core sub-blocks (`index`, `context_files`, `readme`, `root_context`, `backlinking`); each substandard validates its own nested key (`adr`, `north-star`, `retrospectives`).
 

--- a/standards/v1/APS-V1-0003-documentation/examples/README.md
+++ b/standards/v1/APS-V1-0003-documentation/examples/README.md
@@ -7,7 +7,7 @@ description: "Example configuration and compliant project structure for APS-V1-0
 
 ## Example Configuration
 
-Configuration lives in a single root-level `APSS.yaml` owned by the meta-standard (APS-V1-0000.CF01). This standard registers the slug `docs` and contributes the `docs:` section. A minimal `APSS.yaml` for a project adopting the documentation standard:
+Configuration lives in a single root-level `APSS.yaml` owned by the meta-standard (APS-V1-0000.CF01). This standard's canonical slug is `documentation` (the `docs` and `doc` spellings are dev-CLI aliases only); it contributes the `docs:` section. A minimal `APSS.yaml` for a project adopting the documentation standard:
 
 ```yaml
 schema: apss.project/v1

--- a/standards/v1/APS-V1-0003-documentation/substandards/PV01-purpose-and-vision/docs/01_spec.md
+++ b/standards/v1/APS-V1-0003-documentation/substandards/PV01-purpose-and-vision/docs/01_spec.md
@@ -90,9 +90,7 @@ are enforced.
 All three sections are required (severity `error`). Earlier drafts of
 this substandard treated the third section as a warning; the rewrite
 in this revision treats Mission, Vision, and Position as equal
-pillars, so missing any one is an error. See
-[`docs/proposals/north-star-shape-options.md`](../../../../../../../docs/proposals/north-star-shape-options.md)
-in the repo root for the reasoning behind the choice.
+pillars, so missing any one is an error.
 
 ## 5. Backlinking from root context files (parent rule)
 


### PR DESCRIPTION
A doc-drift review on main found the README and several standard docs out of date after promoting fitness (APS-V1-0002) and documentation (APS-V1-0003) to official and removing EXP-V1-0003.

## Fixes
- **README**: all three official standards with canonical `apss run` examples; removed EXP-V1-0003 and its broken links; corrected repo structure (adds `apss-bootstrap`, meta 1.5.0, current standards); a "Two CLIs" section separating the consumer `apss` from the dev-only `apss-dev`.
- **`apss-dev run --list`** (code): now built from the registry so it cannot drift. Was hardcoded `topology (EXP-V1-0001) v0.1.0` and omitted documentation; now shows all three with real ids/versions/commands.
- **APS-V1-0003 docs**: experimental -> official status; canonical slug `documentation` (not `docs`).
- **APS-V1-0002 docs**: `apss.toml` -> `APSS.yaml`; marked `ratchet`/`summary` subcommands as planned (only `validate` is implemented; `--config`/`--report`/`--previous-report` are real flags).
- **~22 broken local markdown links** fixed across standards/ and the runbook.

## Validation
`just qa` green; `v1 validate repo` 0/0; `git diff --check` clean. README links verified to resolve.

Note: a markdown local-link check in CI (review recommendation 5) is a good follow-up to prevent regression; not included here.