### PR TITLE
refactor(config): rename project manifest APSS.yaml to lowercase apss.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [APS-V1-0002 Architecture Fitness](standards/v1/APS-V1-0002-architecture-fitness/docs/00_overview.md) | Declarative architectural assertions (threshold, dependency, structural rules) over topology artifacts, with per-dimension scoring. | `apss run architecture-fitness validate .` |
 | [APS-V1-0003 Documentation](standards/v1/APS-V1-0003-documentation/docs/00_overview.md) | Documentation and context engineering: ADR enforcement, README index validation, agent context files. | `apss run documentation validate .` |
 
-The slug in the first command word is the **canonical slug** and must match the standard key in your `APSS.yaml`.
+The slug in the first command word is the **canonical slug** and must match the standard key in your `apss.yaml`.
 
 ### Experimental
 
@@ -41,14 +41,14 @@ APSS uses crates.io as its distribution transport (see [ADR-0002](standards/v1/A
 cargo install apss
 
 # In your repo: declare one or more standards, then install
-apss init --standard code-topology   # generates APSS.yaml (set the scaffolded id to APS-V1-0001)
+apss init --standard code-topology   # generates apss.yaml (set the scaffolded id to APS-V1-0001)
 apss install     # resolves standards from crates.io, writes apss.lock, builds a project-local binary, installs the git hook
 apss validate    # validate the project config and standard structure (also runs from the pre-commit hook)
 apss status      # show project configuration and status
 apss run code-topology analyze .   # run a standard's command through the project-local binary
 ```
 
-`APSS.yaml` lists standards by their canonical slug and id, for example:
+`apss.yaml` lists standards by their canonical slug and id, for example:
 
 ```yaml
 standards:
@@ -63,7 +63,7 @@ For offline or air-gapped installs, build a bundle locally and point the install
 apss install --bundle-dir /path/to/bundles
 ```
 
-Commit `APSS.yaml` and `apss.lock`. The generated `.apss/` runtime is build output and stays out of git. Contributors to your repo can read, edit, and commit without installing the global CLI. A step-by-step guide is in [docs/runbooks/visualize-your-codebase.runbook.md](docs/runbooks/visualize-your-codebase.runbook.md).
+Commit `apss.yaml` and `apss.lock`. The generated `.apss/` runtime is build output and stays out of git. Contributors to your repo can read, edit, and commit without installing the global CLI. A step-by-step guide is in [docs/runbooks/visualize-your-codebase.runbook.md](docs/runbooks/visualize-your-codebase.runbook.md).
 
 The full lifecycle is specified in the [DI01 distribution substandard](standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/01_spec.md) and the [package manager lifecycle doc](standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/03_package_manager_lifecycle.md).
 

--- a/crates/aps-cli/src/main.rs
+++ b/crates/aps-cli/src/main.rs
@@ -184,9 +184,9 @@ enum ValidateTarget {
         /// Experiment ID (e.g., EXP-V1-0001)
         id: String,
     },
-    /// Validate an APSS.yaml project configuration file (CF01)
+    /// Validate an apss.yaml project configuration file (CF01)
     Config {
-        /// Path to APSS.yaml. If omitted, searches upward from the current directory.
+        /// Path to apss.yaml. If omitted, searches upward from the current directory.
         path: Option<PathBuf>,
     },
     /// Validate standard crates for distribution compliance (DI01)
@@ -317,7 +317,7 @@ fn main() -> ExitCode {
                             ) {
                                 Some(path) => path,
                                 None => {
-                                    eprintln!("Error: No APSS.yaml found");
+                                    eprintln!("Error: No apss.yaml found");
                                     return ExitCode::FAILURE;
                                 }
                             },

--- a/crates/apss-bootstrap/README.md
+++ b/crates/apss-bootstrap/README.md
@@ -16,14 +16,14 @@ cargo install apss
 ## Usage
 
 ```bash
-apss init --standard <slug>   # generate APSS.yaml declaring the standard
+apss init --standard <slug>   # generate apss.yaml declaring the standard
 apss install     # resolve standards from crates.io, write apss.lock, install git hooks
 apss validate    # validate the project (also runs from the pre-commit hook)
 apss status      # show project configuration and status
 apss run <standard> <command>   # run a standard's command
 ```
 
-Commit `APSS.yaml` and `apss.lock`. The generated `.apss/` runtime is build output and stays out of git. Contributors to your repo can read, edit, and commit without installing this CLI.
+Commit `apss.yaml` and `apss.lock`. The generated `.apss/` runtime is build output and stays out of git. Contributors to your repo can read, edit, and commit without installing this CLI.
 
 ## Documentation
 

--- a/crates/apss-bootstrap/src/main.rs
+++ b/crates/apss-bootstrap/src/main.rs
@@ -40,7 +40,7 @@ enum Commands {
 
     /// Validate project configuration
     Validate {
-        /// Only validate APSS.yaml structure (skip standard-specific validation)
+        /// Only validate apss.yaml structure (skip standard-specific validation)
         #[arg(long)]
         config_only: bool,
     },
@@ -61,7 +61,7 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum ConfigAction {
-    /// Generate APSS.yaml with all defaults and comments
+    /// Generate apss.yaml with all defaults and comments
     Template,
 }
 
@@ -94,7 +94,7 @@ fn cmd_status() -> i32 {
     let config_path = match find_config() {
         Some(p) => p,
         None => {
-            eprintln!("No APSS.yaml found. Run 'apss init' to create one.");
+            eprintln!("No apss.yaml found. Run 'apss init' to create one.");
             return 1;
         }
     };
@@ -102,7 +102,7 @@ fn cmd_status() -> i32 {
     let config = match apss_core::config::parse_project_config(&config_path) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("Failed to load APSS.yaml: {e}");
+            eprintln!("Failed to load apss.yaml: {e}");
             return 1;
         }
     };
@@ -161,7 +161,7 @@ fn cmd_validate(config_only: bool) -> i32 {
     let config_path = match find_config() {
         Some(p) => p,
         None => {
-            eprintln!("No APSS.yaml found. Run 'apss init' to create one.");
+            eprintln!("No apss.yaml found. Run 'apss init' to create one.");
             return 1;
         }
     };
@@ -184,7 +184,7 @@ fn cmd_run(args: &[String]) -> i32 {
     let config_path = match find_config() {
         Some(p) => p,
         None => {
-            eprintln!("No APSS.yaml found. Run 'apss init' to create one.");
+            eprintln!("No apss.yaml found. Run 'apss init' to create one.");
             return 1;
         }
     };
@@ -192,7 +192,7 @@ fn cmd_run(args: &[String]) -> i32 {
     let config = match apss_core::config::parse_project_config(&config_path) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("Failed to load APSS.yaml: {e}");
+            eprintln!("Failed to load apss.yaml: {e}");
             return 1;
         }
     };
@@ -228,7 +228,7 @@ fn cmd_run(args: &[String]) -> i32 {
 
 fn cmd_config_template() -> i32 {
     println!(
-        r#"# APSS.yaml - APSS Project Configuration
+        r#"# apss.yaml - APSS Project Configuration
 # See: https://github.com/AgentParadise/agent-paradise-standards-system
 
 schema: apss.project/v1

--- a/crates/apss-bootstrap/tests/init_integration.rs
+++ b/crates/apss-bootstrap/tests/init_integration.rs
@@ -19,8 +19,8 @@ fn test_init_creates_expected_layout() {
         .expect("failed to invoke apss init");
     assert!(status.success(), "apss init exited non-zero: {status}");
 
-    // APSS.yaml exists and contains expected fields
-    let apss_yaml = std::fs::read_to_string(temp.path().join("APSS.yaml")).unwrap();
+    // apss.yaml exists and contains expected fields
+    let apss_yaml = std::fs::read_to_string(temp.path().join("apss.yaml")).unwrap();
     assert!(
         apss_yaml.contains("schema: apss.project/v1"),
         "missing schema line:\n{apss_yaml}"
@@ -89,7 +89,7 @@ fn test_init_with_standard_flag() {
         .expect("failed to invoke apss init --standard");
     assert!(status.success(), "apss init exited non-zero: {status}");
 
-    let apss_yaml = std::fs::read_to_string(temp.path().join("APSS.yaml")).unwrap();
+    let apss_yaml = std::fs::read_to_string(temp.path().join("apss.yaml")).unwrap();
     assert!(
         apss_yaml.contains("  code-topology:"),
         "missing standards.code-topology section:\n{apss_yaml}"

--- a/crates/apss-core/src/config.rs
+++ b/crates/apss-core/src/config.rs
@@ -1,9 +1,10 @@
-//! Project configuration parsing for `APSS.yaml`.
+//! Project configuration parsing for `apss.yaml`.
 //!
 //! This module provides types and functions for reading consumer project
-//! configuration files. An `APSS.yaml` at the root of a project declares
+//! configuration files. An `apss.yaml` at the root of a project declares
 //! which APS standards the project implements, their version requirements,
-//! and standard-specific configuration.
+//! and standard-specific configuration. The legacy `APSS.yaml` name is still
+//! accepted on read for backwards compatibility.
 //!
 //! See `APS-V1-0000.CF01` for the normative specification.
 
@@ -15,8 +16,16 @@ use thiserror::Error;
 /// Schema identifier for project configuration files.
 pub const PROJECT_SCHEMA: &str = "apss.project/v1";
 
-/// Default config filename.
-pub const CONFIG_FILENAME: &str = "APSS.yaml";
+/// Canonical config filename. Written by `apss init` and preferred on read.
+pub const CONFIG_FILENAME: &str = "apss.yaml";
+
+/// Legacy config filename, accepted on read for backwards compatibility.
+///
+/// Projects created before the lowercase rename shipped `APSS.yaml`. Discovery
+/// prefers [`CONFIG_FILENAME`] and falls back to this so those repos keep
+/// working on case-sensitive filesystems. New files are always written
+/// lowercase.
+pub const LEGACY_CONFIG_FILENAME: &str = "APSS.yaml";
 
 // ============================================================================
 // Error Types
@@ -40,7 +49,7 @@ pub enum ConfigError {
     },
 
     /// Configuration file not found.
-    #[error("no APSS.yaml found (searched from {start_dir})")]
+    #[error("no apss.yaml found (searched from {start_dir})")]
     NotFound { start_dir: PathBuf },
 
     /// Included config file does not exist.
@@ -59,7 +68,7 @@ pub enum ConfigError {
 // Configuration Types
 // ============================================================================
 
-/// Parsed `APSS.yaml` project configuration.
+/// Parsed `apss.yaml` project configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ProjectConfig {
     /// Schema identifier. MUST be `"apss.project/v1"`.
@@ -125,7 +134,7 @@ pub struct StandardEntry {
 /// Workspace configuration for monorepo support.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WorkspaceConfig {
-    /// Glob patterns for child package directories that may have their own `APSS.yaml`.
+    /// Glob patterns for child package directories that may have their own `apss.yaml`.
     pub members: Vec<String>,
 
     /// Glob patterns to exclude from workspace discovery.
@@ -382,15 +391,30 @@ fn parse_included_config(path: &Path, content: &str) -> Result<toml::Value, Conf
     }
 }
 
-/// Walk up from `start_dir` to find the nearest `APSS.yaml`.
+/// Return the config file in `dir`, preferring the canonical lowercase
+/// [`CONFIG_FILENAME`] and falling back to the legacy
+/// [`LEGACY_CONFIG_FILENAME`] for backwards compatibility.
+fn config_in_dir(dir: &Path) -> Option<PathBuf> {
+    let canonical = dir.join(CONFIG_FILENAME);
+    if canonical.is_file() {
+        return Some(canonical);
+    }
+    let legacy = dir.join(LEGACY_CONFIG_FILENAME);
+    if legacy.is_file() {
+        return Some(legacy);
+    }
+    None
+}
+
+/// Walk up from `start_dir` to find the nearest `apss.yaml`.
 ///
 /// Returns the path to the found config file, or `None` if no config
-/// file is found before reaching the filesystem root.
+/// file is found before reaching the filesystem root. The legacy
+/// `APSS.yaml` name is accepted as a fallback.
 pub fn find_project_config(start_dir: &Path) -> Option<PathBuf> {
     let mut current = start_dir.to_path_buf();
     loop {
-        let candidate = current.join(CONFIG_FILENAME);
-        if candidate.is_file() {
+        if let Some(candidate) = config_in_dir(&current) {
             return Some(candidate);
         }
         if !current.pop() {
@@ -399,17 +423,17 @@ pub fn find_project_config(start_dir: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Walk up from `start_dir` to find the workspace root `APSS.yaml`.
+/// Walk up from `start_dir` to find the workspace root `apss.yaml`.
 ///
-/// The workspace root is the first `APSS.yaml` that contains a `workspace`
-/// section. If no workspace root is found, returns the nearest `APSS.yaml`.
+/// The workspace root is the first `apss.yaml` that contains a `workspace`
+/// section. If no workspace root is found, returns the nearest `apss.yaml`.
+/// The legacy `APSS.yaml` name is accepted as a fallback.
 pub fn find_workspace_root(start_dir: &Path) -> Option<PathBuf> {
     let mut nearest: Option<PathBuf> = None;
     let mut current = start_dir.to_path_buf();
 
     loop {
-        let candidate = current.join(CONFIG_FILENAME);
-        if candidate.is_file() {
+        if let Some(candidate) = config_in_dir(&current) {
             if nearest.is_none() {
                 nearest = Some(candidate.clone());
             }
@@ -431,6 +455,36 @@ pub fn find_workspace_root(start_dir: &Path) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_find_project_config_prefers_canonical_lowercase() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join(CONFIG_FILENAME),
+            "schema: apss.project/v1\n",
+        )
+        .unwrap();
+        let found = find_project_config(temp.path()).unwrap();
+        assert_eq!(found.file_name().unwrap(), CONFIG_FILENAME);
+    }
+
+    #[test]
+    fn test_find_project_config_falls_back_to_legacy_name() {
+        let temp = tempfile::tempdir().unwrap();
+        // Only the legacy capitalized name exists.
+        std::fs::write(
+            temp.path().join(LEGACY_CONFIG_FILENAME),
+            "schema: apss.project/v1\n",
+        )
+        .unwrap();
+        let found =
+            find_project_config(temp.path()).expect("legacy APSS.yaml should still be discovered");
+        // On case-insensitive filesystems the canonical lookup matches the
+        // legacy file; on case-sensitive ones the explicit fallback does. Either
+        // way a config must be found.
+        let name = found.file_name().unwrap().to_string_lossy().to_lowercase();
+        assert_eq!(name, "apss.yaml");
+    }
 
     #[test]
     fn test_parse_minimal_config() {

--- a/crates/apss-core/src/distribution/codegen.rs
+++ b/crates/apss-core/src/distribution/codegen.rs
@@ -135,7 +135,7 @@ fn generate_cargo_toml(
                     standard: standard.id.clone(),
                 })?;
             let ident = standard_crate_ident(&standard.crate_name);
-            // Substandard selection (APSS.yaml `substandards`) maps to cargo
+            // Substandard selection (apss.yaml `substandards`) maps to cargo
             // features of the parent standard crate (ADR-0002 / DI01: substandards
             // ship as feature modules, not separate crates). None means "all
             // substandards", which is cargo's default feature set, so we emit no

--- a/crates/apss-core/src/distribution/mod.rs
+++ b/crates/apss-core/src/distribution/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! ```bash
 //! cargo install apss              # install bootstrap
-//! apss init --standard code-topology   # create APSS.yaml
+//! apss init --standard code-topology   # create apss.yaml
 //! apss install                    # build composed binary
 //! apss run topology analyze .     # use it
 //! ```

--- a/crates/apss-core/src/lib.rs
+++ b/crates/apss-core/src/lib.rs
@@ -11,7 +11,7 @@
 //! - [`promotion`] - Experiment to standard promotion workflow
 //! - [`views`] - Derived views generator (registry.json, INDEX.md)
 //! - [`versioning`] - Version management for packages
-//! - [`config`] - Project configuration parsing (`APSS.yaml`)
+//! - [`config`] - Project configuration parsing (`apss.yaml`)
 //! - [`standard_config`] - Typed configuration contract for standards
 //! - [`resolution`] - Cascading configuration resolution for monorepos
 //! - [`lockfile`] - Lockfile types for reproducible installations

--- a/crates/apss-core/src/project_config_validation.rs
+++ b/crates/apss-core/src/project_config_validation.rs
@@ -1,13 +1,13 @@
 //! Project Configuration (APS-V1-0000.CF01)
 //!
-//! Validates `APSS.yaml` project configuration files and ensures standards
+//! Validates `apss.yaml` project configuration files and ensures standards
 //! define typed configuration surfaces via the `StandardConfig` trait.
 //!
 //! ## Dual Validation Role
 //!
 //! CF01 validates two things:
 //!
-//! 1. **Consumer `APSS.yaml` files**  -  schema, field types, version requirements,
+//! 1. **Consumer `apss.yaml` files**  -  schema, field types, version requirements,
 //!    cascading consistency, and standard-specific config blocks.
 //!
 //! 2. **Standard config compliance**  -  ensures every standard in the APS repo
@@ -19,7 +19,7 @@
 //! use apss_core::project_config_validation::validate_project_config;
 //! use std::path::Path;
 //!
-//! let diags = validate_project_config(Path::new("APSS.yaml"));
+//! let diags = validate_project_config(Path::new("apss.yaml"));
 //! if diags.has_errors() {
 //!     eprintln!("{diags}");
 //!     std::process::exit(1);
@@ -36,7 +36,7 @@ use std::path::Path;
 
 /// Error codes for CF01 validation.
 pub mod error_codes {
-    // --- Consumer APSS.yaml validation ---
+    // --- Consumer apss.yaml validation ---
 
     /// `schema` field missing or not `"apss.project/v1"`.
     pub const CF_MISSING_SCHEMA: &str = "CF_MISSING_SCHEMA";
@@ -65,10 +65,10 @@ pub mod error_codes {
     /// A substandard code doesn't match `[A-Z]{2}\d{2}`.
     pub const CF_INVALID_SUBSTANDARD_CODE: &str = "CF_INVALID_SUBSTANDARD_CODE";
 
-    /// An experimental standard is explicitly declared in `APSS.yaml`.
+    /// An experimental standard is explicitly declared in `apss.yaml`.
     pub const CF_EXPERIMENT_DECLARED: &str = "CF_EXPERIMENT_DECLARED";
 
-    /// A child `APSS.yaml` contains a `[workspace]` section.
+    /// A child `apss.yaml` contains a `[workspace]` section.
     pub const CF_WORKSPACE_IN_CHILD: &str = "CF_WORKSPACE_IN_CHILD";
 
     /// Child and root `apss_version` values differ.
@@ -86,16 +86,16 @@ pub mod error_codes {
     /// `[standards]` section exists but is empty.
     pub const CF_EMPTY_STANDARDS: &str = "CF_EMPTY_STANDARDS";
 
-    /// `APSS.yaml` exists but no `apss.lock` found.
+    /// `apss.yaml` exists but no `apss.lock` found.
     pub const CF_NO_LOCKFILE: &str = "CF_NO_LOCKFILE";
 
-    /// `APSS.yaml` was modified more recently than `apss.lock`.
+    /// `apss.yaml` was modified more recently than `apss.lock`.
     pub const CF_LOCKFILE_STALE: &str = "CF_LOCKFILE_STALE";
 
-    /// Failed to parse the APSS.yaml file.
+    /// Failed to parse the apss.yaml file.
     pub const CF_PARSE_ERROR: &str = "CF_PARSE_ERROR";
 
-    /// The APSS.yaml file was not found.
+    /// The apss.yaml file was not found.
     pub const CF_FILE_NOT_FOUND: &str = "CF_FILE_NOT_FOUND";
 
     /// An included config file (via `config = { include = "..." }`) was not found.
@@ -233,7 +233,7 @@ fn validate_config_fields(path: &Path) -> Diagnostics {
     diags
 }
 
-/// Validate a child `APSS.yaml` in a workspace context.
+/// Validate a child `apss.yaml` in a workspace context.
 pub fn validate_child_config(child_path: &Path, root_config: &ProjectConfig) -> Diagnostics {
     // Use validate_config_fields (not validate_project_config) to skip lockfile
     // checks  -  in a workspace, the lockfile lives at the root, not in each child.
@@ -252,7 +252,7 @@ pub fn validate_child_config(child_path: &Path, root_config: &ProjectConfig) -> 
                 "Child configuration must not contain a [workspace] section",
             )
             .with_path(child_path)
-            .with_hint("Only the root APSS.yaml may define workspace members"),
+            .with_hint("Only the root apss.yaml may define workspace members"),
         );
     }
 
@@ -517,7 +517,7 @@ fn validate_lockfile(config_path: &Path, diags: &mut Diagnostics) {
                 diags.push(
                     Diagnostic::warning(
                         error_codes::CF_LOCKFILE_STALE,
-                        "APSS.yaml is newer than apss.lock. Run 'apss install' to update",
+                        "apss.yaml is newer than apss.lock. Run 'apss install' to update",
                     )
                     .with_path(config_path),
                 );
@@ -836,7 +836,7 @@ project:
 
     #[test]
     fn test_validate_missing_file() {
-        let diags = validate_project_config(Path::new("/nonexistent/APSS.yaml"));
+        let diags = validate_project_config(Path::new("/nonexistent/apss.yaml"));
         assert!(diags.has_errors());
         assert!(
             diags

--- a/crates/apss-core/src/registry.rs
+++ b/crates/apss-core/src/registry.rs
@@ -3,7 +3,7 @@
 //! This module provides the [`StandardRegistry`] trait and [`ProjectRunner`]
 //! for composing multiple standards into a single CLI binary. Standards
 //! register themselves via `register()` functions, and the runner dispatches
-//! commands based on the project's `APSS.yaml` configuration.
+//! commands based on the project's `apss.yaml` configuration.
 //!
 //! See `APS-V1-0000.DI01` for the normative specification.
 
@@ -28,11 +28,11 @@ pub enum RunnerError {
     StandardNotFound { slug: String },
 
     /// Standard not registered (declared in config but not linked).
-    #[error("standard '{slug}' is declared in APSS.yaml but not registered in this binary")]
+    #[error("standard '{slug}' is declared in apss.yaml but not registered in this binary")]
     StandardNotRegistered { slug: String },
 
     /// No configuration file found.
-    #[error("no APSS.yaml found (searched from {start_dir})")]
+    #[error("no apss.yaml found (searched from {start_dir})")]
     NoConfig { start_dir: PathBuf },
 }
 
@@ -113,7 +113,7 @@ struct RegistryEntry {
 /// Config-driven CLI runner for consumer projects.
 ///
 /// This is the main entry point for composed binaries. It:
-/// 1. Loads `APSS.yaml` configuration
+/// 1. Loads `apss.yaml` configuration
 /// 2. Accepts standard registrations via [`StandardRegistry`]
 /// 3. Dispatches CLI commands to the appropriate standard handler
 pub struct ProjectRunner {
@@ -122,7 +122,7 @@ pub struct ProjectRunner {
 }
 
 impl ProjectRunner {
-    /// Create a runner from an `APSS.yaml` file path.
+    /// Create a runner from an `apss.yaml` file path.
     pub fn from_config_file(path: &Path) -> Result<Self, RunnerError> {
         let project_config = config::parse_project_config(path)?;
         let resolved = resolution::resolve_single(project_config, path.to_path_buf());
@@ -192,11 +192,11 @@ impl ProjectRunner {
         let resolved = match self.config.standards.get(slug.as_str()) {
             Some(s) if s.enabled => s,
             Some(_) => {
-                eprintln!("Standard '{slug}' is disabled in APSS.yaml");
+                eprintln!("Standard '{slug}' is disabled in apss.yaml");
                 return 1;
             }
             None => {
-                eprintln!("Standard '{slug}' not found in APSS.yaml");
+                eprintln!("Standard '{slug}' not found in apss.yaml");
                 return 1;
             }
         };
@@ -206,7 +206,7 @@ impl ProjectRunner {
             Some(e) => e,
             None => {
                 eprintln!(
-                    "Standard '{slug}' is declared in APSS.yaml but not registered in this binary"
+                    "Standard '{slug}' is declared in apss.yaml but not registered in this binary"
                 );
                 eprintln!("Run 'apss install' to rebuild with the correct standards.");
                 return 1;

--- a/crates/apss-core/src/resolution.rs
+++ b/crates/apss-core/src/resolution.rs
@@ -1,6 +1,6 @@
 //! Cascading configuration resolution for monorepos.
 //!
-//! When a project uses workspace-style `APSS.yaml` files, child configs
+//! When a project uses workspace-style `apss.yaml` files, child configs
 //! inherit from and override the root config. This module handles the
 //! merge logic and version resolution.
 //!
@@ -56,7 +56,7 @@ pub enum ResolutionError {
 /// A fully resolved project configuration after cascading merge.
 #[derive(Debug, Clone)]
 pub struct ResolvedProjectConfig {
-    /// Project identity (from the nearest `APSS.yaml`).
+    /// Project identity (from the nearest `apss.yaml`).
     pub project: ProjectInfo,
 
     /// Resolved standards with merged config.
@@ -65,7 +65,7 @@ pub struct ResolvedProjectConfig {
     /// Resolved tool configuration.
     pub tool: ToolConfig,
 
-    /// Which `APSS.yaml` files contributed to this resolution.
+    /// Which `apss.yaml` files contributed to this resolution.
     pub source_files: Vec<PathBuf>,
 }
 
@@ -98,7 +98,7 @@ pub struct ResolvedStandard {
 // Resolution Logic
 // ============================================================================
 
-/// Resolve a project configuration from a single `APSS.yaml` (no cascading).
+/// Resolve a project configuration from a single `apss.yaml` (no cascading).
 pub fn resolve_single(config: ProjectConfig, source: PathBuf) -> ResolvedProjectConfig {
     let standards = config
         .standards
@@ -313,7 +313,7 @@ standards:
     #[test]
     fn test_resolve_single() {
         let config = minimal_root();
-        let resolved = resolve_single(config, PathBuf::from("APSS.yaml"));
+        let resolved = resolve_single(config, PathBuf::from("apss.yaml"));
 
         assert_eq!(resolved.project.name, "root");
         assert_eq!(resolved.standards.len(), 1);
@@ -331,9 +331,9 @@ standards:
 
         let resolved = merge_configs(
             &root,
-            Path::new("APSS.yaml"),
+            Path::new("apss.yaml"),
             &child,
-            Path::new("packages/a/APSS.yaml"),
+            Path::new("packages/a/apss.yaml"),
         )
         .unwrap();
 
@@ -382,9 +382,9 @@ project:
 
         let resolved = merge_configs(
             &root,
-            Path::new("APSS.yaml"),
+            Path::new("apss.yaml"),
             &child,
-            Path::new("packages/a/APSS.yaml"),
+            Path::new("packages/a/apss.yaml"),
         )
         .unwrap();
 
@@ -402,9 +402,9 @@ project:
 
         let result = merge_configs(
             &root,
-            Path::new("APSS.yaml"),
+            Path::new("apss.yaml"),
             &child,
-            Path::new("packages/a/APSS.yaml"),
+            Path::new("packages/a/apss.yaml"),
         );
 
         assert!(matches!(
@@ -424,9 +424,9 @@ project:
 
         let result = merge_configs(
             &root,
-            Path::new("APSS.yaml"),
+            Path::new("apss.yaml"),
             &child,
-            Path::new("packages/a/APSS.yaml"),
+            Path::new("packages/a/apss.yaml"),
         );
 
         assert!(matches!(
@@ -513,9 +513,9 @@ tool:
 
         let resolved = merge_configs(
             &root,
-            Path::new("APSS.yaml"),
+            Path::new("apss.yaml"),
             &child,
-            Path::new("packages/a/APSS.yaml"),
+            Path::new("packages/a/apss.yaml"),
         )
         .unwrap();
 
@@ -557,9 +557,9 @@ tool:
 
         let resolved = merge_configs(
             &root,
-            Path::new("APSS.yaml"),
+            Path::new("apss.yaml"),
             &child,
-            Path::new("packages/a/APSS.yaml"),
+            Path::new("packages/a/apss.yaml"),
         )
         .unwrap();
 
@@ -597,9 +597,9 @@ project:
 
         let resolved = merge_configs(
             &root,
-            Path::new("APSS.yaml"),
+            Path::new("apss.yaml"),
             &child,
-            Path::new("packages/a/APSS.yaml"),
+            Path::new("packages/a/apss.yaml"),
         )
         .unwrap();
 
@@ -642,9 +642,9 @@ tool:
 
         let resolved = merge_configs(
             &root,
-            Path::new("APSS.yaml"),
+            Path::new("apss.yaml"),
             &child,
-            Path::new("packages/a/APSS.yaml"),
+            Path::new("packages/a/apss.yaml"),
         )
         .unwrap();
 

--- a/crates/apss-core/src/standard_config.rs
+++ b/crates/apss-core/src/standard_config.rs
@@ -1,7 +1,7 @@
 //! Typed configuration contract for APS standards.
 //!
 //! Standards that accept runtime configuration via `[standards.<slug>.config]`
-//! in `APSS.yaml` MUST implement the [`StandardConfig`] trait. Standards that
+//! in `apss.yaml` MUST implement the [`StandardConfig`] trait. Standards that
 //! accept no configuration MUST use the [`NoConfig`] marker type.
 //!
 //! See meta-standard §8.3 for the normative specification.

--- a/docs/runbooks/adopt-apss-standards.runbook.md
+++ b/docs/runbooks/adopt-apss-standards.runbook.md
@@ -8,13 +8,13 @@ It ends with a section on integrating APSS into the agentic harness template (le
 
 ## The official standards
 
-| Canonical slug (APSS.yaml key) | ID | Crate | What it enforces |
+| Canonical slug (apss.yaml key) | ID | Crate | What it enforces |
 |---|---|---|---|
 | `code-topology` | APS-V1-0001 | `apss-v1-0001-code-topology` | Architectural metrics, coupling, module structure; produces `.topology/` and visualizations |
 | `architecture-fitness` | APS-V1-0002 | `apss-v1-0002-architecture-fitness` | Declarative fitness rules (threshold, dependency, structural) over topology artifacts |
 | `documentation` | APS-V1-0003 | `apss-v1-0003-documentation` | ADR enforcement, README index validation, agent context files |
 
-Use the canonical slug in `APSS.yaml` and in `apss run <slug>`. The composed project binary dispatches by the exact key in `APSS.yaml`, so `code-topology` works but `topology` does not (short aliases like `topology`, `fitness`, `docs` are accepted only by the development CLI `apss-dev`).
+Use the canonical slug in `apss.yaml` and in `apss run <slug>`. The composed project binary dispatches by the exact key in `apss.yaml`, so `code-topology` works but `topology` does not (short aliases like `topology`, `fitness`, `docs` are accepted only by the development CLI `apss-dev`).
 
 ## Prerequisites
 
@@ -31,10 +31,10 @@ apss --version          # expect 1.1.0 or newer; `cargo install apss --force` to
 
 ## 2. Declare the standards
 
-`apss init` creates `APSS.yaml`. You can scaffold one standard with `--standard <slug>` (it leaves the id as a `APS-V1-XXXX` placeholder to fill in), or write `APSS.yaml` directly. To adopt all three:
+`apss init` creates `apss.yaml`. You can scaffold one standard with `--standard <slug>` (it leaves the id as a `APS-V1-XXXX` placeholder to fill in), or write `apss.yaml` directly. To adopt all three:
 
 ```yaml
-# APSS.yaml
+# apss.yaml
 schema: apss.project/v1
 
 project:
@@ -66,7 +66,7 @@ Expected:
 - A project-local composed binary is built at `.apss/bin/apss`.
 - A managed pre-commit hook is installed at `.git/hooks/pre-commit` (see step 6).
 
-Commit `APSS.yaml` and `apss.lock`. Do not commit `.apss/` (generated build output; it is gitignored by the managed install). Contributors who clone the repo do not need to install the global CLI.
+Commit `apss.yaml` and `apss.lock`. Do not commit `.apss/` (generated build output; it is gitignored by the managed install). Contributors who clone the repo do not need to install the global CLI.
 
 ## 4. Run each standard once
 
@@ -93,7 +93,7 @@ There are two distinct checks. Use both.
 
 ### Layer 1: project validation (auto-installed hook)
 
-The managed pre-commit hook from `apss install` runs `apss validate`, which checks the project configuration and standard installation state (is `APSS.yaml` valid, is `apss.lock` consistent, is the composed binary present). It does NOT run the standards' own rules. Control it with `tool.hooks.pre_commit` in `APSS.yaml`.
+The managed pre-commit hook from `apss install` runs `apss validate`, which checks the project configuration and standard installation state (is `apss.yaml` valid, is `apss.lock` consistent, is the composed binary present). It does NOT run the standards' own rules. Control it with `tool.hooks.pre_commit` in `apss.yaml`.
 
 ### Layer 2: the standards' own rules (you wire this)
 
@@ -130,7 +130,10 @@ jobs:
 
 The harness template manages hooks with lefthook and tasks with just. Wire APSS into both, plus CI.
 
-1. **Add `APSS.yaml`** (step 2) at the template root and commit it with `apss.lock` after a one-time `apss install`.
+> [!CAUTION]
+> The harness fitness gate (`harness/sensors/bin/sensors gate`) calls `apss run code-topology analyze` to produce native topology metrics. If APSS is not installed in the harness repo (no `apss.yaml`, no `apss install`, no composed `.apss/bin/apss`), the gate does **not** fail: it silently falls back to an external dependency-cruiser + ts-morph collector. On a ~95-file TypeScript repo that fallback was measured at ~136s (about 75% of a 183s gate run) versus ~0.1s for the native analyzer. Wire APSS correctly (steps below) and verify `.apss/bin/apss` exists in CI, or the gate stays correct but quietly runs orders of magnitude slower.
+
+1. **Add `apss.yaml`** (step 2) at the template root and commit it with `apss.lock` after a one-time `apss install`.
 
 2. **A `just` recipe** as the single task surface (the template prefers `just <recipe>` over direct tool calls):
 
@@ -168,7 +171,7 @@ Contributors to the harness fork get enforcement for free: `apss.lock` pins exac
 
 | Symptom | Cause and fix |
 |---|---|
-| `Standard '<x>' not found in APSS.yaml` | Use the canonical slug as the `APSS.yaml` key and in `apss run` (`code-topology`, `architecture-fitness`, `documentation`). |
+| `Standard '<x>' not found in apss.yaml` | Use the canonical slug as the `apss.yaml` key and in `apss run` (`code-topology`, `architecture-fitness`, `documentation`). |
 | `apss install` cannot reach crates.io | Offline or proxied network. Use `apss install --bundle-dir <path>` with a locally built bundle. |
 | `fitness.toml not found` | architecture-fitness needs a `fitness.toml` at the repo root (step 5). |
 | fitness rules fail with missing artifacts | Run `apss run code-topology analyze .` first; fitness reads `.topology/`. |

--- a/docs/runbooks/visualize-your-codebase.runbook.md
+++ b/docs/runbooks/visualize-your-codebase.runbook.md
@@ -12,8 +12,8 @@ From the root of a repo that contains Rust or Python source:
 
 ```bash
 cargo install apss                                  # one-time, needs apss 1.1.0+
-apss init --standard code-topology                  # creates APSS.yaml
-# edit APSS.yaml: set the code-topology id to APS-V1-0001 (see step 2)
+apss init --standard code-topology                  # creates apss.yaml
+# edit apss.yaml: set the code-topology id to APS-V1-0001 (see step 2)
 apss install                                        # resolves the standard from crates.io
 apss run code-topology analyze .                    # writes .topology/ artifacts
 apss run code-topology viz .topology --type all     # opens the dashboard
@@ -23,7 +23,7 @@ That is the whole flow. The sections below explain each step, the expected outpu
 
 ## Audience and Prerequisites
 
-- A target repository containing Rust (`.rs`) or Python (`.py`/`.pyi`) source files. Other languages are not yet supported by the analyzer.
+- A target repository containing Rust (`.rs`), Python (`.py`/`.pyi`), or TypeScript (`.ts`/`.tsx`) source files. JavaScript (`.js`/`.jsx`) is not yet supported by the analyzer.
 - Rust toolchain and Cargo installed (`cargo --version` succeeds).
 - Network access to crates.io. The standard is resolved and built from crates.io; no APSS repository checkout is required. If you are offline or air-gapped, see the appendix at the end.
 
@@ -46,7 +46,7 @@ apss init --standard code-topology
 
 Expected:
 
-- `APSS.yaml` created (user-owned, edit freely) with a `code-topology` standard entry.
+- `apss.yaml` created (user-owned, edit freely) with a `code-topology` standard entry.
 
 The generated entry scaffolds the id as a placeholder:
 
@@ -80,7 +80,10 @@ Expected:
 - A composed binary compiled to `.apss/bin/apss`.
 - `Installed Git hook: .git/hooks/pre-commit` (see step 7).
 
-Commit `APSS.yaml` and `apss.lock`. Do not commit `.apss/`; it is generated output.
+Commit `apss.yaml` and `apss.lock`. Do not commit `.apss/`; it is generated output.
+
+> [!IMPORTANT]
+> Confirm the composed binary at `.apss/bin/apss` exists before relying on topology anywhere. That binary runs the native tree-sitter analyzer, which is fast (topology is ~0.1s on a small repo). If `apss install` has not run, or the binary is missing (`No apss.yaml found` / `Composed binary not found`), the standalone commands below fail outright, and any harness integration that wraps this standard (the architectural fitness gate) **silently falls back to a much slower external collector** (dependency-cruiser): measured at ~136s versus ~0.1s on the same repository. A misconfigured install does not error in the gate; it just gets quietly slow. See the harness-integration note in [adopt-apss-standards.runbook.md](adopt-apss-standards.runbook.md).
 
 ## 4. Validate the Installation
 
@@ -132,7 +135,7 @@ Visualization types: `3d` (force-directed coupling), `codecity` (buildings = mod
 
 ## 7. Git Pre-Commit Hook (Optional but Recommended)
 
-`apss install` already installed a pre-commit hook that runs `apss validate` on every commit. Control it via `APSS.yaml`:
+`apss install` already installed a pre-commit hook that runs `apss validate` on every commit. Control it via `apss.yaml`:
 
 ```yaml
 tool:
@@ -152,8 +155,8 @@ Expected: validation output before the commit completes. Hook failures block the
 
 | Symptom | Cause and Fix |
 |---|---|
-| `No supported source files found` | Target repo has no `.rs`/`.py` files at or below the analyzed path. Point `analyze` at the source root. |
-| `Standard 'topology' not found in APSS.yaml` | The consumer config uses the slug `code-topology`; `topology` is a dev-CLI alias only (issue #70). |
+| `No supported source files found` | Target repo has no `.rs`/`.py`/`.ts`/`.tsx` files at or below the analyzed path. Point `analyze` at the source root. |
+| `Standard 'topology' not found in apss.yaml` | The consumer config uses the slug `code-topology`; `topology` is a dev-CLI alias only (issue #70). |
 | `No modules.json found at ./metrics/modules.json` | `viz` was given the repo root. Pass the `.topology` directory (issue #70). |
 | `apss install` cannot reach crates.io | You are offline or behind a proxy. Use the offline install in the appendix. |
 | `cargo install apss` fails on publish metadata | Update Rust; the workspace requires Rust 1.85+. |

--- a/docs/testing/apss-package-manual-acceptance-testing.runbook.md
+++ b/docs/testing/apss-package-manual-acceptance-testing.runbook.md
@@ -64,7 +64,7 @@ Expected result:
 
 ## 4. Prepare Example Repo Manifest
 
-In `/Users/neural/Code/AgentParadise/apss-example-repo`, ensure the project manifest is named `APSS.yaml` and contains a Code Topology standard entry:
+In `/Users/neural/Code/AgentParadise/apss-example-repo`, ensure the project manifest is named `apss.yaml` and contains a Code Topology standard entry:
 
 ```yaml
 schema: apss.project/v1
@@ -85,7 +85,7 @@ standards:
     version: "0.1.0"
 ```
 
-If the repo still has an old `apss.toml`, rename it to `APSS.yaml` and convert the content to YAML before continuing.
+If the repo still has an old `apss.toml`, rename it to `apss.yaml` and convert the content to YAML before continuing.
 
 ## 5. Install Into Example Repo (Registry Path, Primary)
 
@@ -168,7 +168,7 @@ Use a temporary copy so the example repo is not changed:
 ```bash
 rm -rf /tmp/apss-example-hooks-off
 cp -a /Users/neural/Code/AgentParadise/apss-example-repo /tmp/apss-example-hooks-off
-perl -0pi -e 's/pre_commit: true/pre_commit: false/' /tmp/apss-example-hooks-off/APSS.yaml
+perl -0pi -e 's/pre_commit: true/pre_commit: false/' /tmp/apss-example-hooks-off/apss.yaml
 cd /tmp/apss-example-hooks-off
 apss install 2>&1 | tee /tmp/apss-hooks-off.log
 rg "Warning: APSS pre-commit hook installation is disabled" /tmp/apss-hooks-off.log
@@ -189,12 +189,12 @@ mkdir /tmp/apss-fresh-init
 cd /tmp/apss-fresh-init
 git init -q
 apss init --standard code-topology@0.1.0
-sed -n '1,160p' APSS.yaml
+sed -n '1,160p' apss.yaml
 ```
 
 Expected result:
 
-- `APSS.yaml` is created.
+- `apss.yaml` is created.
 - The manifest includes `tool.hooks.pre_commit: true`.
 - The generated standard entry includes a placeholder `APS-V1-XXXX` ID and the requested version.
 

--- a/justfile
+++ b/justfile
@@ -252,9 +252,9 @@ aps-validate-distribution:
     cargo run -p aps-cli --bin apss-dev -- v1 validate distribution
     @echo '{{ GREEN }}✓ Distribution validation complete{{ NORMAL }}'
 
-# Validate an APSS.yaml project configuration file (CF01)
+# Validate an apss.yaml project configuration file (CF01)
 [group('aps')]
-aps-validate-config path="APSS.yaml":
+aps-validate-config path="apss.yaml":
     @echo '{{ YELLOW }}Validating project config (CF01): {{ path }}...{{ NORMAL }}'
     cargo run -p aps-cli --bin apss-dev -- v1 validate config {{ path }}
     @echo '{{ GREEN }}✓ Config validation complete{{ NORMAL }}'

--- a/standards/v1/APS-V1-0000-meta/docs/01_spec.md
+++ b/standards/v1/APS-V1-0000-meta/docs/01_spec.md
@@ -54,7 +54,7 @@ An **experimental standard** is an incubating package used for iteration and com
 
 - Are never considered official
 - Are enforced in downstream repositories only when explicitly declared in
-  `APSS.yaml`
+  `apss.yaml`
 - Follow the same structure as official standards
 - Can be promoted to official after peer review and security audit
 
@@ -401,7 +401,7 @@ pub trait StandardConfig: DeserializeOwned + Serialize + Default {
 
 This trait enables:
 
-- **Type-safe config validation**  -  Consumer `APSS.yaml` config blocks are deserialized into the standard's config type, catching type errors at parse time.
+- **Type-safe config validation**  -  Consumer `apss.yaml` config blocks are deserialized into the standard's config type, catching type errors at parse time.
 - **Semantic validation**  -  The `validate()` method checks value ranges, cross-field consistency, and other constraints beyond what the type system expresses.
 - **Schema generation**  -  `json_schema()` produces a JSON Schema for IDE completion and external tooling.
 - **Scaffolding**  -  `toml_template()` generates documented default config snippets for `apss init`.
@@ -422,7 +422,7 @@ Standards that implement `StandardConfig` SHOULD include a generated `config.sch
 
 - MUST be regenerable from the Rust type via `StandardConfig::json_schema()`
 - SHOULD be kept in sync (CI MAY validate staleness)
-- Enables IDE completion and external tooling for `APSS.yaml`
+- Enables IDE completion and external tooling for `apss.yaml`
 
 #### 8.3.4 Validation Scope
 
@@ -775,11 +775,11 @@ The DI01 substandard specifies:
 
 ### 17.1 Project Configuration
 
-Consumer projects declare which standards they adopt via `APSS.yaml`, defined by `APS-V1-0000.CF01` (Project Configuration substandard).
+Consumer projects declare which standards they adopt via `apss.yaml`, defined by `APS-V1-0000.CF01` (Project Configuration substandard).
 
 The CF01 substandard specifies:
 
-- The `APSS.yaml` schema for declaring standards, versions, and config
+- The `apss.yaml` schema for declaring standards, versions, and config
 - Cascading configuration for monorepos
 - Typed configuration validation via the `StandardConfig` trait (§8.3)
 - Experimental standard declarations and promoted-experiment compatibility

--- a/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/Cargo.toml
+++ b/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "APSS Project Configuration (APS-V1-0000.CF01)  -  validates APSS.yaml and typed standard configs"
+description = "APSS Project Configuration (APS-V1-0000.CF01)  -  validates apss.yaml and typed standard configs"
 
 [dependencies]
 apss-core.workspace = true

--- a/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/00_overview.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/00_overview.md
@@ -14,7 +14,7 @@ to each standard's own validator.
 Before CF01, project state was split across two files with different
 serialisation formats:
 
-- Project-level activation lived in `APSS.yaml` at the root.
+- Project-level activation lived in `apss.yaml` at the root.
 - Per-standard configuration sometimes lived under `.apss/config.toml`
   (notably for EXP-V1-0004 documentation).
 
@@ -25,7 +25,7 @@ the operator authors) and generated artifacts (which the installer writes).
 
 ## Solution
 
-CF01 specifies a single manifest, `APSS.yaml`, at the project root and gives
+CF01 specifies a single manifest, `apss.yaml`, at the project root and gives
 it three roles at once.
 
 1. **Project configuration.** Core sections owned by CF01 capture project
@@ -33,12 +33,12 @@ it three roles at once.
 2. **Standard activation.** The `standards` mapping is the project's
    dependency declaration: which standards (and which substandards) are
    active, at what version range.
-3. **Installation manifest.** The unified installer reads `APSS.yaml`,
+3. **Installation manifest.** The unified installer reads `apss.yaml`,
    resolves it through DI01, then invokes each active standard's install
    contract to produce on-disk state. Removing an entry and re-running
    uninstalls cleanly.
 
-The npm analogy is the binding model: `APSS.yaml` is to APSS what
+The npm analogy is the binding model: `apss.yaml` is to APSS what
 `package.json` is to npm. One file, one install command, one source of
 truth for what the project considers active.
 
@@ -62,5 +62,5 @@ build outputs, composed binaries). Configuration MUST NOT live there.
   `StandardCli` trait is the in-process API the unified installer uses to
   reach a standard's install contract.
 - **APS-V1-0000.SS01** Substandard Structure. Substandards nest under the
-  parent slug in `APSS.yaml` rather than receiving their own top-level slug.
+  parent slug in `apss.yaml` rather than receiving their own top-level slug.
 - **Meta-standard section 8.3** `StandardConfig` trait specification.

--- a/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/01_spec.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/01_spec.md
@@ -23,11 +23,11 @@ section, with validation delegated to each standard's own validator.
 
 Concretely, CF01 defines:
 
-- The `APSS.yaml` manifest at the project root, its schema identifier, and its
+- The `apss.yaml` manifest at the project root, its schema identifier, and its
   top-level structure.
 - The core sections owned by CF01: project identity, the standards list, the
   workspace declaration, and the tool block.
-- Cascading rules for nested `APSS.yaml` files in monorepos.
+- Cascading rules for nested `apss.yaml` files in monorepos.
 - A slug registry that every standard in the ecosystem registers into, and the
   meta-validation rules over that registry (Section 3, owned by the registry
   work block).
@@ -54,11 +54,11 @@ and it is the file the installer reads to materialize that intent on disk.
 
 ---
 
-## 2. The `APSS.yaml` Manifest
+## 2. The `apss.yaml` Manifest
 
 ### 2.1 Filename and Location
 
-A consumer project MUST place its configuration at `APSS.yaml` in the project
+A consumer project MUST place its configuration at `apss.yaml` in the project
 root.
 
 - The file MUST be valid YAML as parsed by the Rust `serde_yaml` crate.
@@ -67,7 +67,7 @@ root.
   the project's version control root (`git rev-parse --show-toplevel`) or,
   when no VCS root is available, the directory in which the operator invokes
   the bootstrap CLI.
-- A project MAY add nested `APSS.yaml` files inside workspace members. Their
+- A project MAY add nested `apss.yaml` files inside workspace members. Their
   semantics are defined in Section 4.
 
 The `.apss/` dot directory is reserved for GENERATED artifacts (resolved
@@ -159,7 +159,7 @@ Field rules:
   same standard ID MUST be rejected as `CF_DUPLICATE_STANDARD_ID`.
 - An `EXP-V1-\d{4}` entry explicitly opts the project into enforcing an
   experimental standard. Experiments MUST NOT be installed, validated, or
-  enforced unless they are declared in `APSS.yaml`.
+  enforced unless they are declared in `apss.yaml`.
 - `enabled: false` keeps the entry in the manifest but disables the standard
   for this project. The unified installer (Section 8) MUST uninstall the
   standard's artifacts cleanly when this flag flips to false.
@@ -185,10 +185,10 @@ workspace:
 
 Rules:
 
-- `workspace` MUST NOT appear in a child `APSS.yaml`. A manifest with
+- `workspace` MUST NOT appear in a child `apss.yaml`. A manifest with
   `workspace` is by definition a root manifest.
 - `members` patterns MUST resolve to directories that contain an
-  `APSS.yaml`. A pattern that matches no directory MUST raise
+  `apss.yaml`. A pattern that matches no directory MUST raise
   `CF_EMPTY_WORKSPACE_GLOB` as a warning.
 
 ### 2.7 Standard Sections (slug keys)
@@ -199,7 +199,7 @@ and hands it to the standard's validator (Section 6).
 
 Default-on philosophy:
 
-- An active standard requires NO section in `APSS.yaml`. Defaults from the
+- An active standard requires NO section in `apss.yaml`. Defaults from the
   standard's contributed schema apply.
 - A section exists only to OVERRIDE a default or to DISABLE a feature.
 - The `disable: false` flag is the convention for opt-out, both at the top of
@@ -265,13 +265,13 @@ rules that enforce uniqueness and completeness across `standards/` and
 To resolve the active configuration for a given working directory, tooling
 MUST:
 
-1. Walk upward from the working directory looking for an `APSS.yaml`
+1. Walk upward from the working directory looking for an `apss.yaml`
    containing a `workspace` key. The first such file is the **root
    manifest**.
-2. While walking, every `APSS.yaml` without a `workspace` key encountered
+2. While walking, every `apss.yaml` without a `workspace` key encountered
    between the working directory and the root manifest is a **child
    manifest**, in deepest-to-shallowest order.
-3. If no manifest with a `workspace` key is found, the closest `APSS.yaml`
+3. If no manifest with a `workspace` key is found, the closest `apss.yaml`
    to the working directory is the root manifest and there are no child
    manifests.
 
@@ -365,11 +365,11 @@ disable-inheritance matrix, and worked examples live in the sibling spec
 ## 8. Manifest-Driven Installation (Summary)
 
 The operator-approved Addendum 1 of the unified-config brief makes
-configuration, distribution, and installation a single system. `APSS.yaml`
+configuration, distribution, and installation a single system. `apss.yaml`
 is the manifest, the unified installer is the glue, and each active
 standard ships an install contract that the installer invokes.
 
-The npm-style model is the binding analogy: `APSS.yaml` is to APSS what
+The npm-style model is the binding analogy: `apss.yaml` is to APSS what
 `package.json` is to npm. The `standards` map (Section 2.5) is the
 dependency declaration; one install command reads the manifest, resolves
 versions via DI01, then drives each per-standard install contract; removing
@@ -417,7 +417,7 @@ DI01 MUST treat the promotion as a compatibility alias:
 5. The project continues to validate using the promoted standard without a
    manual manifest edit.
 
-The warning SHOULD recommend updating `APSS.yaml` from the experimental ID to
+The warning SHOULD recommend updating `apss.yaml` from the experimental ID to
 the official ID. It MUST NOT silently rewrite operator-owned configuration
 without an explicit command or flag.
 
@@ -432,7 +432,7 @@ instead of silently dropping enforcement.
 ## 9. Migration from legacy split configuration
 
 The prior project model used `apss.toml` for activation and allowed some
-per-standard configuration under `.apss/config.toml`. CF01 keeps `APSS.yaml`
+per-standard configuration under `.apss/config.toml`. CF01 keeps `apss.yaml`
 as the user-owned manifest and forbids user-authored configuration under
 `.apss/`.
 
@@ -440,7 +440,7 @@ as the user-owned manifest and forbids user-authored configuration under
 
 | Concern | Before | After |
 |---------|--------|-------|
-| File location | `apss.toml` and `.apss/config.toml` | `APSS.yaml` |
+| File location | `apss.toml` and `.apss/config.toml` | `apss.yaml` |
 | Serialisation | TOML | YAML |
 | Schema identifier | `apss.project/v1` | `apss.project/v1` |
 | Configuration in `.apss/` | Allowed (EXP-V1-0004) | Forbidden, dotdir is for generated artifacts only |
@@ -481,7 +481,7 @@ tool:
     pre_commit: true
 ```
 
-Every previously valid `apss.toml` activation field moves into `APSS.yaml`;
+Every previously valid `apss.toml` activation field moves into `apss.yaml`;
 only configuration stored under `.apss/` moves into the manifest.
 
 ### 9.2.1 Tool hook settings
@@ -501,11 +501,11 @@ another way.
 
 Tooling MUST behave as follows during the transition window:
 
-- If `APSS.yaml` exists: load it normally.
+- If `apss.yaml` exists: load it normally.
 - If only `.apss/config.toml` exists: emit `CF_LEGACY_APSS_CONFIG_TOML` at
   error severity with the same hint. Tooling MUST NOT read configuration
   from `.apss/`.
-- If both `APSS.yaml` and `.apss/config.toml` exist: load `APSS.yaml` and
+- If both `apss.yaml` and `.apss/config.toml` exist: load `apss.yaml` and
   emit `CF_LEGACY_APSS_CONFIG_TOML` for the generated-directory config.
 - A future major version of APSS MAY remove the legacy diagnostics and
   refuse to start when a legacy file is present. The diagnostics are the
@@ -515,10 +515,10 @@ Tooling MUST behave as follows during the transition window:
 
 The recommended manual conversion is:
 
-1. Keep `APSS.yaml` as the project manifest.
+1. Keep `apss.yaml` as the project manifest.
 2. Keep or set `schema: apss.project/v1`.
 3. Move keys from `.apss/config.toml` into the appropriate
-   `standards.<slug>.config` mapping in `APSS.yaml`.
+   `standards.<slug>.config` mapping in `apss.yaml`.
 4. Delete `.apss/config.toml`.
 5. Re-run the unified installer to refresh `apss.lock` and the composed
    binary.
@@ -528,7 +528,7 @@ a fast-follow; the converter is out of scope for this spec.
 
 ### 9.5 Spec-internal compatibility
 
-The authoritative project configuration file for this PR is `APSS.yaml`.
+The authoritative project configuration file for this PR is `apss.yaml`.
 
 ---
 

--- a/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/02_slug_registry.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/02_slug_registry.md
@@ -7,7 +7,7 @@
 This document is a sibling normative spec to `01_spec.md` and has
 equal precedence with it under the meta-standard's precedence rule
 (§1.1 of APS-V1-0000). It defines the slug registry that backs the
-single-file APSS.yaml configuration model.
+single-file apss.yaml configuration model.
 
 ## Terminology
 
@@ -20,7 +20,7 @@ document are to be interpreted as described in
 
 ## 1. Purpose
 
-APSS.yaml uses short slugs as top-level keys to namespace each
+apss.yaml uses short slugs as top-level keys to namespace each
 standard's configuration section. The registry is the single source
 of truth that maps slugs to standard IDs and prevents collisions.
 Every standard in the repository, including experimental standards,
@@ -29,13 +29,13 @@ MUST appear in the registry.
 The registry exists to:
 
 1. Guarantee that no two standards can claim the same top-level key
-   in APSS.yaml.
+   in apss.yaml.
 2. Allow the unified installer (Addendum 1, see `06_unified_install_seam.md`)
    to resolve a manifest entry like `docs:` back to its owning crate
    without scanning the filesystem.
 3. Power editor tooling (autocomplete, schema lookup) by exposing a
    stable list of valid top-level sections.
-4. Catch typos in APSS.yaml early: unknown top-level keys are errors
+4. Catch typos in apss.yaml early: unknown top-level keys are errors
    (see `04_validation_delegation.md`).
 
 ---
@@ -110,7 +110,7 @@ Field rules:
   ID (APS-V1-0000 §4.2).
 - `substandards[].slug` is the kebab-case slug declared in the
   substandard's `substandard.toml`; it is used as a nested key under
-  the parent slug in APSS.yaml.
+  the parent slug in apss.yaml.
 
 #### 2.2.2 Regeneration
 
@@ -164,7 +164,7 @@ used as a standard's slug:
 
 | Reserved | Owner | Purpose |
 |----------|-------|---------|
-| `schema` | CF01 | APSS.yaml schema identifier |
+| `schema` | CF01 | apss.yaml schema identifier |
 | `project` | CF01 | Project identity |
 | `workspace` | CF01 | Monorepo membership and cascade |
 | `tool` | CF01 | Installer/tooling settings |
@@ -185,9 +185,9 @@ within their parent's substandard set. Two substandards under
 different parents MAY share a slug (e.g. both `docs.adr` and
 `fitness.adr` would be legal).
 
-Substandards MUST NOT appear as top-level keys in APSS.yaml. The
+Substandards MUST NOT appear as top-level keys in apss.yaml. The
 registry artifact reflects this by nesting them inside the parent's
-`substandards` array (see §2.2.1). The full APSS.yaml shape for
+`substandards` array (see §2.2.1). The full apss.yaml shape for
 substandard toggles is specified in `05_substandard_nesting.md`.
 
 ### 3.4 Experiment Slug Lifecycle
@@ -197,7 +197,7 @@ registry with `kind = "experiment"`. On promotion to an official
 standard (APS-V1-0000 §14.3):
 
 - The experiment's slug SHOULD carry over to the promoted standard
-  to avoid breaking consumer APSS.yaml files.
+  to avoid breaking consumer apss.yaml files.
 - If the slug changes during promotion, the experiment's
   `experiment.toml` MUST record both the original slug and the
   promoted slug under `[promotion]`, and the meta-validator MUST
@@ -280,9 +280,9 @@ qualified with the substandard ID.
 
 ---
 
-## 6. Reading the Registry from APSS.yaml
+## 6. Reading the Registry from apss.yaml
 
-When the unified installer or validator parses APSS.yaml, it looks
+When the unified installer or validator parses apss.yaml, it looks
 up each top-level key in the registry to find the owning crate:
 
 1. Reserved key (§3.2): handled by CF01 directly.
@@ -358,7 +358,7 @@ Generated entry:
 }
 ```
 
-Consumer APSS.yaml then references:
+Consumer apss.yaml then references:
 
 ```yaml
 docs:

--- a/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/03_contribution_schema.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/03_contribution_schema.md
@@ -8,7 +8,7 @@ Sibling normative spec to `01_spec.md` and `02_slug_registry.md`.
 Equal precedence under APS-V1-0000 §1.1.
 
 This document specifies the schema format each standard ships to
-contribute its section to APSS.yaml. It is the APSS analog of VS Code's
+contribute its section to apss.yaml. It is the APSS analog of VS Code's
 `contributes.configuration`.
 
 ## Terminology
@@ -19,7 +19,7 @@ RFC 2119 keywords apply, as in `01_spec.md`.
 
 ## 1. Why Contribution Schemas
 
-APSS.yaml has one top-level key per registered slug (see
+apss.yaml has one top-level key per registered slug (see
 `02_slug_registry.md`). Each standard owns the contents of its own
 key. To make the file self-documenting, machine-validatable, and
 editor-friendly, every standard MUST ship a typed schema describing:
@@ -77,7 +77,7 @@ pub trait StandardConfig:
 
 pub trait ConfigContribution {
     /// The slug under which this standard's section appears in
-    /// APSS.yaml. Must equal the slug declared in metadata.
+    /// apss.yaml. Must equal the slug declared in metadata.
     fn slug() -> &'static str;
 
     /// Stable, human-readable title for the section.
@@ -116,13 +116,13 @@ Notes:
 
 Standards that take no configuration MUST use `NoConfig`. This still
 registers a slug and a (trivially empty) contribution schema, so that
-APSS.yaml can still toggle the standard on or off via the universal
+apss.yaml can still toggle the standard on or off via the universal
 `disable` key (§3.1.1) and so that the meta-validator can still
 report unknown keys for that slug.
 
 ---
 
-## 3. APSS.yaml Section Shape
+## 3. apss.yaml Section Shape
 
 ### 3.1 Universal Keys
 
@@ -135,7 +135,7 @@ Standards MUST NOT redefine them; meta-validation enforces this.
 | `version` | string | resolved by installer | Optional Cargo-style semver requirement that pins the standard's version. If absent, the workspace lockfile decides. |
 
 The `disable` key is the universal off switch. An active standard
-requires no section in APSS.yaml; a section exists only to override
+requires no section in apss.yaml; a section exists only to override
 or disable. Tooling MUST accept `disable: false` as a no-op
 (useful for documentation purposes when explicitly opting in).
 
@@ -162,7 +162,7 @@ the following restrictions and conventions:
 ### 3.3 Worked Example
 
 ```yaml
-# APSS.yaml fragment, contributed by the docs standard
+# apss.yaml fragment, contributed by the docs standard
 docs:
   enforce_adr: true
   adr_dir: docs/adrs
@@ -306,7 +306,7 @@ The contribution schema powers four concrete tooling targets:
 This document tightens the `StandardConfig` contract introduced in
 APS-V1-0000 §8.3. Existing implementations that derived
 `StandardConfig` without `ConfigContribution` MUST add the
-`ConfigContribution` impl during the APSS.yaml migration window
+`ConfigContribution` impl during the apss.yaml migration window
 described in the migration note attached to `01_spec.md`. The
 meta-validator MUST emit `CF_MISSING_CONTRIBUTION_TRAIT` as an
 error for any standard that lacks `ConfigContribution` after the
@@ -314,5 +314,5 @@ window closes.
 
 For published v1 standards, the migration is a minor bump (no
 breaking changes to consumers, since the trait extension is purely
-additive on the standards side and APSS.yaml content is unchanged
+additive on the standards side and apss.yaml content is unchanged
 by adding it).

--- a/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/04_validation_delegation.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/04_validation_delegation.md
@@ -8,7 +8,7 @@ Sibling normative spec to `01_spec.md`, `02_slug_registry.md`, and
 `03_contribution_schema.md`. Equal precedence under
 APS-V1-0000 §1.1.
 
-This document defines how APSS.yaml is validated end to end across the
+This document defines how apss.yaml is validated end to end across the
 meta-validator and the per-standard validators.
 
 ## Terminology
@@ -19,13 +19,13 @@ RFC 2119 keywords apply.
 
 ## 1. The Three Roles
 
-APSS.yaml validation has three roles, deliberately separated so that
+apss.yaml validation has three roles, deliberately separated so that
 each standard owns its own contract surface and the meta-standard
 does not become a god object:
 
 1. **Meta-validator (CF01).** Owns the file: opens it, parses TOML,
    resolves the workspace cascade (see `01_spec.md` §4 as rewritten
-   by the APSS.yaml migration), checks reserved keys and the slug
+   by the apss.yaml migration), checks reserved keys and the slug
    registry. Then routes each registered slug to its owning validator.
 2. **Standard validator (per slug).** Owns one top-level key. Receives
    the parsed config object (already deserialized into the standard's
@@ -100,12 +100,12 @@ this check is a no-op for that standard.
 
 ### 3.1 What CF01 Hands Off
 
-For each registered slug present in APSS.yaml, CF01 passes the
+For each registered slug present in apss.yaml, CF01 passes the
 following to the owning validator:
 
 ```rust
 pub struct DelegatedSection<'a> {
-    /// Path to the APSS.yaml that produced this section.
+    /// Path to the apss.yaml that produced this section.
     pub source_path: &'a Path,
 
     /// Resolved cascade level: 0 = workspace root, n = nth child.
@@ -184,8 +184,8 @@ settings validated.
 
 The meta-standard's default-on philosophy (`01_spec.md` §5, brief
 binding decision 5) requires that any active standard works without
-needing an APSS.yaml section. The flip side is that any top-level
-key in APSS.yaml MUST be one of:
+needing an apss.yaml section. The flip side is that any top-level
+key in apss.yaml MUST be one of:
 
 - a reserved CF01 key (see `02_slug_registry.md` §3.2),
 - a registered slug from the generated registry.
@@ -194,12 +194,12 @@ Anything else is an error:
 
 | Code | Severity | Rule |
 |------|----------|------|
-| `CF_UNKNOWN_TOP_LEVEL_KEY` | Error | A top-level key in APSS.yaml is neither reserved nor a registered slug. Diagnostic MUST include the closest registered slug as a suggestion if edit distance is below 3. |
+| `CF_UNKNOWN_TOP_LEVEL_KEY` | Error | A top-level key in apss.yaml is neither reserved nor a registered slug. Diagnostic MUST include the closest registered slug as a suggestion if edit distance is below 3. |
 | `CF_UNKNOWN_NESTED_KEY` | Error | A key inside a registered section is not in that section's contribution schema (`additionalProperties: false`). |
 | `CF_UNKNOWN_SUBSTANDARD_KEY` | Error | A nested key under a registered slug claims to be a substandard but no substandard with that slug exists for the parent standard. |
 
 This is deliberate: unknown-key permissiveness is what makes config
-files rot over decades. APSS.yaml errors loudly on the first run after
+files rot over decades. apss.yaml errors loudly on the first run after
 a typo is introduced.
 
 The `--allow-unknown-keys` flag MUST NOT exist. Migration paths for
@@ -210,7 +210,7 @@ emitted from `validate()`, not by relaxing the meta-validator.
 
 ## 5. Disabled and Missing Sections
 
-| State | APSS.yaml | Behavior |
+| State | apss.yaml | Behavior |
 |-------|-----------|----------|
 | Active, default config | section absent | Standard runs with `Default` config. |
 | Active, overridden | section present, no `disable` | Standard runs with section merged onto `Default`. |
@@ -219,7 +219,7 @@ emitted from `validate()`, not by relaxing the meta-validator.
 
 Section presence is never required. The meta-validator MUST NOT
 emit `CF_EMPTY_STANDARDS` or any similar diagnostic just because
-APSS.yaml has no sections for active standards: that is the
+apss.yaml has no sections for active standards: that is the
 expected state for greenfield projects.
 
 ---
@@ -230,7 +230,7 @@ The CF01 validation delegation is exposed at the CLI through:
 
 ```
 <bootstrap> v1 validate                # full repo + project pass
-<bootstrap> v1 validate --project      # only APSS.yaml + sections
+<bootstrap> v1 validate --project      # only apss.yaml + sections
 <bootstrap> v1 validate --slug <slug>  # only one section, useful for editor LSPs
 ```
 
@@ -266,7 +266,7 @@ unchanged at steps 6 and 7 respectively.
 
 ## 8. Worked Example
 
-Consumer APSS.yaml:
+Consumer apss.yaml:
 
 ```yaml
 schema: apss.project/v1

--- a/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/05_substandard_nesting.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/05_substandard_nesting.md
@@ -18,7 +18,7 @@ RFC 2119 keywords apply.
 
 Substandards MUST be configured as nested keys under the parent
 standard's slug. Substandards MUST NOT receive a top-level slug in
-APSS.yaml.
+apss.yaml.
 
 ```yaml
 docs:
@@ -69,7 +69,7 @@ can evaluate it.
 ### 2.2 Why Nested Wins
 
 - **Grouping is correct.** Substandards are scoped to their parent in
-  the meta-standard (APS-V1-0000 §4.2). Nesting in APSS.yaml matches
+  the meta-standard (APS-V1-0000 §4.2). Nesting in apss.yaml matches
   that hierarchy without lossy flattening.
 - **Disable inheritance is natural.** `disable: true` at the parent
   slug means the parent and all its substandards are off. The
@@ -86,7 +86,7 @@ can evaluate it.
   preserves operator muscle memory across the migration.
 
 The single small cost is that a substandard cannot be configured
-without naming its parent. That cost is paid in APSS.yaml only, where
+without naming its parent. That cost is paid in apss.yaml only, where
 it actually helps the reader.
 
 ---
@@ -140,7 +140,7 @@ If a standard's contribution schema declares a property with the
 same name as one of its substandard slugs, the meta-validator MUST
 emit `CF_SUBSTANDARD_KEY_SHADOW`. This is a build-time error caught
 during `<bootstrap> v1 validate repo`, not a runtime error against
-APSS.yaml. Standards are responsible for avoiding the clash; the
+apss.yaml. Standards are responsible for avoiding the clash; the
 slug registry produces the canonical list of substandard slugs
 each standard owns.
 
@@ -148,7 +148,7 @@ each standard owns.
 |------|----------|------|
 | `CF_SUBSTANDARD_KEY_SHADOW` | Error | Standard contribution schema declares a property with the same name as a substandard slug. |
 
-This rule exists so that consumers can read APSS.yaml without ever
+This rule exists so that consumers can read apss.yaml without ever
 having to disambiguate "is this a leaf property or a substandard?".
 
 ---

--- a/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/06_unified_install_seam.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/06_unified_install_seam.md
@@ -11,7 +11,7 @@ This document specifies the CF01 side of the unified installer
 introduced by Addendum 1 of the operator brief (2026-06-04 22:47):
 
 > The unification extends to THREE concerns, not two: configuration
-> plus distribution plus installation are one system. APSS.yaml is
+> plus distribution plus installation are one system. apss.yaml is
 > the MANIFEST, not just settings.
 
 DI01 owns the resolve and publish ends; CF01 owns the manifest;
@@ -25,16 +25,16 @@ examples while repo issue 64 (APS vs APSS naming) is open.
 
 ---
 
-## 1. APSS.yaml as Manifest
+## 1. apss.yaml as Manifest
 
-APSS.yaml plays the role of an npm `package.json`'s `dependencies`
+apss.yaml plays the role of an npm `package.json`'s `dependencies`
 field for the APSS ecosystem. CF01 owns the manifest surface; DI01
 owns version resolution and lockfile production.
 
 The manifest is the union of:
 
 1. **Activation declarations.** Every standard whose slug appears as
-   a key in APSS.yaml (active or disabled) is part of the project's
+   a key in apss.yaml (active or disabled) is part of the project's
    declared set. Active standards that have no section are still in
    the declared set: the default-on philosophy (`01_spec.md` §5)
    means active membership is inferred from the resolved standards
@@ -47,10 +47,10 @@ The manifest is the union of:
 How the "declared set" is computed is intentionally explicit:
 
 ```
-declared_set = explicit_keys(APSS.yaml) UNION baseline_active_set
+declared_set = explicit_keys(apss.yaml) UNION baseline_active_set
 ```
 
-`explicit_keys(APSS.yaml)` is the set of registered slugs present as
+`explicit_keys(apss.yaml)` is the set of registered slugs present as
 top-level keys (excluding reserved CF01 keys). `baseline_active_set`
 is the set of standards a project ships with by default; for the
 APSS standards repository it equals the set of all standards
@@ -61,7 +61,7 @@ MUST list every standard the project adopts.
 For an external consumer project (not the APSS repo itself):
 
 - A standard is active if and only if its slug appears as a top-level
-  key in APSS.yaml AND that section is not `disable: true`.
+  key in apss.yaml AND that section is not `disable: true`.
 - A substandard is active if its parent is active AND the substandard
   section is not `disable: true`.
 
@@ -69,7 +69,7 @@ For the APSS standards repository:
 
 - Every shipped standard is active by default (so meta-validation
   always runs across the whole tree).
-- APSS.yaml in the APSS repo MAY exist but is not required; if
+- apss.yaml in the APSS repo MAY exist but is not required; if
   present, sections override defaults.
 
 This split is the resolution of an apparent contradiction in
@@ -82,7 +82,7 @@ itself opts in to everything.
 
 ### 2.1 Purpose
 
-A single installer command reads APSS.yaml and installs (or updates,
+A single installer command reads apss.yaml and installs (or updates,
 or uninstalls) every active standard's installable artifacts. The
 brief calls this `apss install`; CF01 specs it as the unified
 installer regardless of the final binary name.
@@ -91,7 +91,7 @@ installer regardless of the final binary name.
 
 The installer consumes:
 
-- APSS.yaml (the manifest, owned by CF01),
+- apss.yaml (the manifest, owned by CF01),
 - apss.lock if present (owned by DI01),
 - the local on-disk copies of standard crates (or the registry, per
   DI01 §2),
@@ -110,14 +110,14 @@ The installer produces:
 ### 2.4 Idempotency
 
 The installer MUST be idempotent. Running it twice with the same
-APSS.yaml and the same standard versions MUST produce the same
+apss.yaml and the same standard versions MUST produce the same
 filesystem state (modulo timestamps that are not under version
 control). Per-standard install contracts MUST also be idempotent;
 see §3.2.
 
 ### 2.5 Uninstall on Removal
 
-Removing a standard from APSS.yaml and re-running the installer MUST
+Removing a standard from apss.yaml and re-running the installer MUST
 uninstall that standard's hooks and scaffolds cleanly. "Cleanly"
 means:
 
@@ -130,14 +130,14 @@ means:
   preserved otherwise (with a warning).
 
 Disabling a standard via `disable: true` MUST have the same
-uninstall semantics as removing it from APSS.yaml. The two paths
+uninstall semantics as removing it from apss.yaml. The two paths
 exist so that consumers have a discoverable way to record "we
 deliberately do not use docs" in their manifest.
 
 ### 2.6 CLI Surface
 
 ```
-<bootstrap> install                 # primary path; reads APSS.yaml
+<bootstrap> install                 # primary path; reads apss.yaml
 <bootstrap> install --locked        # CI mode; fail if apss.lock changes
 <bootstrap> install --offline       # use only cached crates
 <bootstrap> install --dry-run       # print what would happen, no writes
@@ -145,7 +145,7 @@ deliberately do not use docs" in their manifest.
 ```
 
 DI01 §3.2 already lists these commands. CF01 re-states them here to
-emphasize that they are driven by APSS.yaml, and that the manifest
+emphasize that they are driven by apss.yaml, and that the manifest
 is the sole declarative input.
 
 `<bootstrap> run <slug> <cmd>` (DI01 §3.3) remains the escape hatch for
@@ -183,14 +183,14 @@ A standard's install contract MUST specify:
 1. **Install steps.** The actions the unified installer performs
    when this standard transitions from absent to present, or when its
    version changes. Steps MUST be deterministic given the
-   `StandardConfig` resolved from APSS.yaml.
+   `StandardConfig` resolved from apss.yaml.
 2. **Uninstall steps.** The actions performed when the standard
    transitions from present to absent (removed from manifest or
    `disable: true`). MUST undo §1 cleanly per §2.5.
 3. **Update steps.** What changes between two installed versions of
    the same standard. MAY default to "uninstall + install" if the
    standard has no incremental update story.
-4. **Inputs read.** What the install contract reads from APSS.yaml.
+4. **Inputs read.** What the install contract reads from apss.yaml.
    Typically a subset of the standard's contribution schema.
 5. **Outputs written.** Every file path the install contract creates
    or modifies. Required so the uninstall step is auditable.
@@ -267,7 +267,7 @@ The unified installer's run is split into two stages with a clear seam:
 +--------+   +------------+   +-----------+
 ```
 
-1. **Resolve (DI01).** Read APSS.yaml. Resolve standard versions
+1. **Resolve (DI01).** Read apss.yaml. Resolve standard versions
    against the registry and the existing apss.lock. Apply
    `--locked` if set. Write apss.lock if changes are allowed.
 2. **Install (per-standard).** For each active standard in the
@@ -308,7 +308,7 @@ explicit. Here it is:
 | Concern | Owner | Surface |
 |---------|-------|---------|
 | Where standards come from (vendoring, registry, pinning) | DI01 | `apss.lock`, `[source]` resolution, registry config |
-| What standards are active and how they are configured | CF01 | APSS.yaml manifest, contribution schemas |
+| What standards are active and how they are configured | CF01 | apss.yaml manifest, contribution schemas |
 | How each standard installs its hooks and scaffolds | per-standard | `docs/02_install_contract.md`, `Installable` trait |
 | Orchestration: resolve then install | unified installer | the `<bootstrap> install` command, owned by DI01 §3 with manifest semantics owned by CF01 |
 
@@ -322,14 +322,14 @@ already-resolved versions through the `InstallContext`.
 ## 6. Migration Path
 
 The migration window from EXP-V1-0004's `.apss/config.toml` to the
-single `APSS.yaml` manifest is specified in the migration note attached
+single `apss.yaml` manifest is specified in the migration note attached
 to `01_spec.md`. Per brief decision 1, the `.apss/` dotdir is retained
 for generated artifacts (lockfile resolution outputs, install reports)
 but is never configuration.
 
 External consumers MAY use a shim during the window: if `.apss/config.toml`
 exists, the installer MUST report the legacy generated-directory config and
-require the consumer to move that content into `APSS.yaml`.
+require the consumer to move that content into `apss.yaml`.
 
 | Code | Severity | Rule |
 |------|----------|------|

--- a/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/07_qa_checks.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/docs/07_qa_checks.md
@@ -9,7 +9,7 @@ specs. Equal precedence under APS-V1-0000 §1.1.
 
 This document specifies how the CLI binary validates that every
 standard in the APSS repository (and every consumer project's
-APSS.yaml) conforms to the rules across the sibling specs. It is
+apss.yaml) conforms to the rules across the sibling specs. It is
 the "how do we enforce all this" section.
 
 ## Terminology
@@ -27,7 +27,7 @@ CF01 conformance has two scopes:
    every experiment in `standards-experimental/v1/` MUST conform
    to the rules from the sibling specs. This is enforced by the
    meta-validator at `<bootstrap> v1 validate repo`.
-2. **Consumer projects.** Any project whose root has an APSS.yaml
+2. **Consumer projects.** Any project whose root has an apss.yaml
    gets validated by `<bootstrap> validate` (or the editor's LSP
    integration). This is the runtime-side validation.
 
@@ -39,7 +39,7 @@ are applicable.
 
 ## 2. The Six Conformance Dimensions
 
-A standard or substandard conforms to the unified APSS.yaml model
+A standard or substandard conforms to the unified apss.yaml model
 when it satisfies six dimensions. The meta-validator MUST emit a
 distinct error code per dimension so that failures are easy to
 classify.
@@ -138,7 +138,7 @@ existing test pipelines.
 `<bootstrap> install` MUST run consumer-side validation BEFORE the
 resolve step. A failed validation exits with code 1 and runs no
 installer side effects. This is the "manifest is law" property:
-the installer never tries to massage a broken APSS.yaml into
+the installer never tries to massage a broken apss.yaml into
 working state.
 
 ### 4.3 Editor Integration
@@ -269,7 +269,7 @@ extension; the one-line marker for the install contract) so the
 migration is non-disruptive for standards that genuinely have no
 config or no install-time side effects.
 
-The migration window aligns with the APSS.yaml migration window
+The migration window aligns with the apss.yaml migration window
 specified in the migration note attached to CF01 `01_spec.md`.
 Inside the window, both checks SHOULD be downgraded to warnings;
 outside it, they MUST be errors.

--- a/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/src/lib.rs
+++ b/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/src/lib.rs
@@ -14,7 +14,7 @@ mod tests {
 
     #[test]
     fn wrapper_reexports_project_config_validation() {
-        let diags = validate_project_config(std::path::Path::new("/definitely/missing/APSS.yaml"));
+        let diags = validate_project_config(std::path::Path::new("/definitely/missing/apss.yaml"));
         assert!(diags.has_errors());
     }
 }

--- a/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/substandard.toml
+++ b/standards/v1/APS-V1-0000-meta/substandards/CF01-project-config/substandard.toml
@@ -14,5 +14,5 @@ backwards_compat = true
 maintainers = ["AgentParadise"]
 
 [metadata]
-description = "Defines the APSS.yaml project configuration schema, cascading monorepo configs, and typed standard configuration validation."
+description = "Defines the apss.yaml project configuration schema, cascading monorepo configs, and typed standard configuration validation."
 keywords = ["config", "apss", "project", "monorepo", "validation"]

--- a/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/src/lib.rs
+++ b/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/src/lib.rs
@@ -364,10 +364,10 @@ pub trait StandardCli: Send + Sync {
         vec![self.slug()]
     }
 
-    /// Receive project-specific configuration from `APSS.yaml`.
+    /// Receive project-specific configuration from `apss.yaml`.
     ///
     /// Called before `execute()` when running in a project context.
-    /// The `config` value corresponds to `[standards.<slug>.config]` from `APSS.yaml`,
+    /// The `config` value corresponds to `[standards.<slug>.config]` from `apss.yaml`,
     /// already validated against the standard's `StandardConfig` type.
     ///
     /// # Default

--- a/standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/00_overview.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/00_overview.md
@@ -7,7 +7,7 @@ resolved against a registry, installed into a project, and composed into a
 project-local CLI binary.
 
 DI01 owns the right half of the unified manifest model: given the
-`APSS.yaml` declared by the project (CF01), turn each `standards.<slug>`
+`apss.yaml` declared by the project (CF01), turn each `standards.<slug>`
 entry into a pinned, checksummed, on-disk install by resolving versions,
 invoking each standard's install contract, and producing a composed binary.
 
@@ -49,19 +49,19 @@ DI01 specifies:
 ```bash
 cargo install <bootstrap>           # one-time global install
 cd my-project
-<bootstrap> init --standard code-topology    # creates APSS.yaml
-<bootstrap> install                     # reads APSS.yaml, resolves, installs, builds composed binary
+<bootstrap> init --standard code-topology    # creates apss.yaml
+<bootstrap> install                     # reads apss.yaml, resolves, installs, builds composed binary
 <bootstrap> run code-topology analyze .      # forwards to composed binary
 ```
 
 A single `install` command materialises everything declared in the
 manifest: per-standard git hooks, validators, scaffolds, and the composed
-binary. Removing an entry from `APSS.yaml` and re-running `install` cleanly
+binary. Removing an entry from `apss.yaml` and re-running `install` cleanly
 uninstalls that standard.
 
 ## Related
 
-- **APS-V1-0000.CF01** Project Configuration. Owns the `APSS.yaml` manifest
+- **APS-V1-0000.CF01** Project Configuration. Owns the `apss.yaml` manifest
   that DI01 consumes. The unified installer crosses the CF01/DI01 boundary
   via the `ResolvedStandard` seam described in the spec.
 - **APS-V1-0000.CL01** CLI Contract. Defines the `StandardCli` trait the

--- a/standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/01_spec.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/01_spec.md
@@ -45,7 +45,7 @@ This substandard defines:
 - The bootstrap CLI binary used for project onboarding (canonical binary name
   is being resolved in repo issue 64; this spec refers to it as the
   "bootstrap" where the name can be avoided)
-- The installation workflow that reads the `APSS.yaml` manifest defined by
+- The installation workflow that reads the `apss.yaml` manifest defined by
   CF01 and resolves, fetches, locks, and composes the standards it declares
 - The lockfile format (`apss.lock`)
 - Code generation for composed project-local binaries
@@ -216,8 +216,8 @@ this spec uses `<bootstrap>` where the name can be avoided.
 
 | Command | Description |
 |---------|-------------|
-| `<bootstrap> init` | Create `APSS.yaml` |
-| `<bootstrap> install` | Read `APSS.yaml`, resolve, run per-standard install contracts, build composed binary |
+| `<bootstrap> init` | Create `apss.yaml` |
+| `<bootstrap> install` | Read `apss.yaml`, resolve, run per-standard install contracts, build composed binary |
 | `<bootstrap> install --check` | Report what install would do without writing |
 | `<bootstrap> install --locked` | CI mode, fail if lockfile would change |
 | `<bootstrap> install --update <slug>` | Update one standard |
@@ -241,7 +241,7 @@ prints a helpful error directing the user to run `<bootstrap> install`.
 
 ## 4. Installation Workflow
 
-The unified installer reads the `APSS.yaml` manifest (CF01 Section 2),
+The unified installer reads the `apss.yaml` manifest (CF01 Section 2),
 resolves the standards it declares, drives each resolved standard's install
 contract, then composes the project-local binary. CF01 owns the manifest;
 DI01 owns resolution and the lockfile; each standard owns its install
@@ -249,7 +249,7 @@ contract. The pipeline below stitches the three together.
 
 ### 4.1 Install Pipeline
 
-1. Parse and validate `APSS.yaml` via CF01 (with cascade applied for
+1. Parse and validate `apss.yaml` via CF01 (with cascade applied for
    workspaces). Refuse to proceed on any error-severity diagnostic.
 2. Resolve version ranges against crates.io (Cargo is the registry, ADR-0002),
    or against a local bundle directory or local repository when the offline
@@ -280,7 +280,7 @@ registry MUST be a no-op (no file rewrites, no rebuild, exit zero).
 
 ### 4.2 Promoted Experiment Resolution
 
-DI01 MUST support experimental standards declared in `APSS.yaml`. If an
+DI01 MUST support experimental standards declared in `apss.yaml`. If an
 `EXP-V1-XXXX` package exists in the registry, resolution proceeds normally
 and the resulting package is marked experimental in the lockfile.
 
@@ -293,14 +293,14 @@ includes:
 - The requested experimental ID and slug.
 - The resolved official ID and slug.
 - The compatibility mode.
-- A recommendation to update `APSS.yaml`.
+- A recommendation to update `apss.yaml`.
 
 If compatibility is `manual-migration-required`, DI01 MUST fail resolution
 with an error diagnostic and a migration path. It MUST NOT silently skip the
 standard, drop validation, or leave the project unenforced.
 
 Promoted alias resolution MUST be deterministic. Given the same registry
-index, `APSS.yaml`, and lockfile, resolution MUST produce the same official
+index, `apss.yaml`, and lockfile, resolution MUST produce the same official
 package and diagnostics.
 
 ### 4.3 Locked Mode
@@ -349,7 +349,7 @@ The boundary between CF01 and DI01 is explicit:
 ### 5.1 Location
 
 The lockfile MUST be at `apss.lock` in the project root, next to
-`APSS.yaml`.
+`apss.yaml`.
 
 ### 5.2 Schema
 
@@ -390,7 +390,7 @@ The `source` field supports:
 If DI01 resolves a promoted experiment, `apss.lock` MUST record both the
 requested experimental identity and the resolved official identity. This
 allows future installs to detect whether the operator has updated
-`APSS.yaml`, and it makes audit trails clear during experiment promotion.
+`apss.yaml`, and it makes audit trails clear during experiment promotion.
 
 ---
 
@@ -412,7 +412,7 @@ allows future installs to detect whether the operator has updated
 
 ### 6.2 Determinism
 
-Code generation MUST be deterministic: the same `APSS.yaml` and `apss.lock`
+Code generation MUST be deterministic: the same `apss.yaml` and `apss.lock`
 MUST produce identical generated files.
 
 ---
@@ -427,7 +427,7 @@ Consumer projects SHOULD add:
 ```
 
 And SHOULD commit:
-- `APSS.yaml`
+- `apss.yaml`
 - `apss.lock`
 
 ---
@@ -448,7 +448,7 @@ any change to system crates (`apss-core`, `aps-cli`, `apss`).
 
 Standard and substandard versions are independent: a standard MAY be at
 `3.0.0` while the system is at `1.2.0`. Consumer projects pin standard
-versions in `APSS.yaml` via semver ranges.
+versions in `apss.yaml` via semver ranges.
 
 Experimental standards MAY be distributed and pinned with `EXP-V1-XXXX`
 identities. Promotion to an official standard creates a new official identity

--- a/standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/02_unified_install_seam.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/02_unified_install_seam.md
@@ -20,7 +20,7 @@ sections 3 (bootstrap binary), 4 (installation workflow), 5
 
 RFC 2119 keywords apply. The placeholder `<bootstrap>` is used in CLI
 examples while repo issue 64 (APS vs APSS naming) is open. References
-to `APSS.yaml` in `01_spec.md` are superseded by `APSS.yaml` per the
+to `apss.yaml` in `01_spec.md` are superseded by `apss.yaml` per the
 migration note attached to CF01 `01_spec.md`.
 
 ---
@@ -29,14 +29,14 @@ migration note attached to CF01 `01_spec.md`.
 
 Configuration, distribution, and installation are one system. DI01
 owns the distribution edge (resolve, lockfile, registry,
-publishing). CF01 owns the manifest edge (APSS.yaml, slug registry,
+publishing). CF01 owns the manifest edge (apss.yaml, slug registry,
 contribution schemas). The unified installer is the glue that reads
 the CF01 manifest and drives both the DI01 resolve step and each
 standard's install contract.
 
 ```
 +------------------+  resolve  +----------------+  install  +------------------+
-| APSS.yaml (CF01) | --------> | apss.lock      | --------> | per-standard     |
+| apss.yaml (CF01) | --------> | apss.lock      | --------> | per-standard     |
 | slug registry    |  (DI01)   | composed bin   |  (per-std | install contracts|
 | schemas (CF01)   |           | bootstrap CLI  |  contract)|                  |
 +------------------+           +----------------+           +------------------+
@@ -48,18 +48,18 @@ extensions to the bootstrap CLI that drive the unified flow.
 
 ---
 
-## 2. APSS.yaml as the Resolve Input
+## 2. apss.yaml as the Resolve Input
 
 ### 2.1 What Resolution Reads
 
-DI01 resolution reads the following from APSS.yaml:
+DI01 resolution reads the following from apss.yaml:
 
 - The declared set of standards (per CF01
   `06_unified_install_seam.md` §1).
 - Each standard's optional `version:` semver requirement (universal
   key from `03_contribution_schema.md` §3.1).
 - The cascade-merged `tool` and `workspace` sections (per
-  `01_spec.md` §4 as rewritten in the APSS.yaml migration).
+  `01_spec.md` §4 as rewritten in the apss.yaml migration).
 
 Resolution MUST NOT read any standard-owned keys; those are opaque
 to DI01 and are passed through to the per-standard install contract
@@ -71,7 +71,7 @@ Resolution writes:
 
 - `apss.lock` updates per `01_spec.md` §5.
 - A resolved-config blob at `.apss/install/resolved.toml` whose schema
-  mirrors APSS.yaml but with version pins replaced by resolved
+  mirrors apss.yaml but with version pins replaced by resolved
   versions. This blob is consumed by per-standard install contracts.
   It is gitignored.
 
@@ -128,7 +128,7 @@ deterministic and reproducible.
 
 ### 3.3 Uninstall on Removal
 
-When a standard is removed from APSS.yaml or set to `disable: true`,
+When a standard is removed from apss.yaml or set to `disable: true`,
 the unified installer MUST call that standard's `uninstall()` using
 the persisted `InstallReport` from the previous run (stored at
 `.apss/install/<slug>.json`).
@@ -170,13 +170,13 @@ under the unified model.
 
 | Command | Status | Description |
 |---------|--------|-------------|
-| `<bootstrap> init` | REFINED | Creates `APSS.yaml` and an initial `.gitignore` block for `.apss/`. |
+| `<bootstrap> init` | REFINED | Creates `apss.yaml` and an initial `.gitignore` block for `.apss/`. |
 | `<bootstrap> install` | REFINED | Drives the full resolve and install flow described in §3. |
 | `<bootstrap> install --locked` | REFINED | Resolve must produce no lockfile change; per-standard install still runs. |
 | `<bootstrap> install --offline` | REFINED | Resolve uses cached crates only; per-standard install still runs (per-standard contracts MUST be offline-safe). |
 | `<bootstrap> install --dry-run` | NEW | Runs resolve and computes per-standard install diffs, but writes nothing. Prints the diff. |
 | `<bootstrap> install --update <slug>` | REFINED | Updates one standard, runs only that standard's `update()`. |
-| `<bootstrap> uninstall <slug>` | NEW | Runs one standard's `uninstall()`. Equivalent to removing the slug from APSS.yaml and re-running install, but does not require an edit. |
+| `<bootstrap> uninstall <slug>` | NEW | Runs one standard's `uninstall()`. Equivalent to removing the slug from apss.yaml and re-running install, but does not require an edit. |
 | `<bootstrap> status` | REFINED | Reports installed versions AND the persisted install reports per standard. |
 | `<bootstrap> validate` | REFINED | Delegates to CF01 per the validation delegation protocol. |
 | `<bootstrap> config show <slug>` | REFINED | Reads resolved config from `.apss/install/resolved.toml` so the output matches what the installer actually used. |
@@ -185,7 +185,7 @@ under the unified model.
 ### 4.2 Removed Surface
 
 `<bootstrap> install` no longer has the responsibility "make
-`APSS.yaml` exist if missing"; that was `<bootstrap> init`'s job and
+`apss.yaml` exist if missing"; that was `<bootstrap> init`'s job and
 remains so. Likewise, `install` MUST NOT touch the slug registry
 artifact directly; it consumes the artifact (regenerated by
 `<bootstrap> v1 generate slug-registry` per
@@ -201,14 +201,14 @@ my manifest" failure mode.
 The lockfile schema in `01_spec.md` §5.2 is unchanged. It is repeated
 here only to record one addition: the lockfile MAY include a
 `manifest_checksum` field whose value is the SHA-256 of the parsed
-APSS.yaml (after cascade resolution). The installer MUST compare
-this checksum against the current APSS.yaml on every run; a mismatch
+apss.yaml (after cascade resolution). The installer MUST compare
+this checksum against the current apss.yaml on every run; a mismatch
 in `--locked` mode is `DI_LOCKFILE_MANIFEST_DRIFT` and exits with
 code 1.
 
 | Code | Severity | Rule |
 |------|----------|------|
-| `DI_LOCKFILE_MANIFEST_DRIFT` | Error | APSS.yaml has changed since apss.lock was written; in `--locked` mode this is a hard fail. |
+| `DI_LOCKFILE_MANIFEST_DRIFT` | Error | apss.yaml has changed since apss.lock was written; in `--locked` mode this is a hard fail. |
 | `DI_INSTALL_REPORT_CORRUPT` | Error | `.apss/install/<slug>.json` cannot be read or fails schema validation. The installer falls back to a fresh install for that standard and emits this code as a warning at the second occurrence. |
 | `DI_OUTPUT_DRIFT` | Warning | A previously installed output's on-disk checksum differs from the recorded checksum (user edited the file). Uninstall preserves the file per CF01 §2.5. |
 
@@ -247,7 +247,7 @@ These extend `01_spec.md` §9.2's required-checks list.
 
 ```
 project-root/
-  APSS.yaml                       # manifest (CF01)
+  apss.yaml                       # manifest (CF01)
   apss.lock                       # resolution output (DI01 §5)
   .apss/
     bin/
@@ -264,7 +264,7 @@ project-root/
 
 `.apss/` is for generated artifacts only, per brief decision 1.
 Nothing under `.apss/` is configuration; nothing under `.apss/` is
-checked into version control. `APSS.yaml` and `apss.lock` ARE
+checked into version control. `apss.yaml` and `apss.lock` ARE
 checked in (per `01_spec.md` §7).
 
 The unified installer MUST add `.apss/` to `.gitignore` on
@@ -286,7 +286,7 @@ The unified installer MUST add `.apss/` to `.gitignore` on
 
 DI01 MUST NOT interpret per-standard configuration. CF01 MUST NOT
 own version resolution. Per-standard install contracts MUST NOT
-read APSS.yaml or apss.lock directly; they receive what they need
+read apss.yaml or apss.lock directly; they receive what they need
 through `InstallContext`.
 
 ---

--- a/standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/03_package_manager_lifecycle.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/03_package_manager_lifecycle.md
@@ -69,7 +69,7 @@ The APSS project config is user-owned. Humans and agents may edit it directly.
 Examples:
 
 ```text
-APSS.yaml
+apss.yaml
 apss.lock
 ```
 
@@ -99,7 +99,7 @@ Managed files SHOULD use this header shape, adapted to the file format:
 ```text
 Managed by APSS. Do not edit manually.
 Regenerate with: apss install
-Source: APSS.yaml
+Source: apss.yaml
 Docs: https://github.com/AgentParadise/agent-paradise-standards-system
 ```
 
@@ -190,7 +190,7 @@ Recommended layout:
 
 ```text
 repo/
-  APSS.yaml
+  apss.yaml
   apss.lock
   .apss/
     bin/
@@ -220,7 +220,7 @@ The external cache approach is preferred because it speeds repeated installs whi
 
 APSS SHOULD install managed git hooks during `apss install`.
 
-Hook installation is controlled by `tool.hooks` in `APSS.yaml`:
+Hook installation is controlled by `tool.hooks` in `apss.yaml`:
 
 ```yaml
 tool:

--- a/standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/04_bundle_format.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/DI01-distribution/docs/04_bundle_format.md
@@ -54,7 +54,7 @@ The notice MUST say:
 Managed by APSS. Do not edit this generated file directly.
 ```
 
-Operator-owned configuration files, including `APSS.yaml`, MUST NOT use that
+Operator-owned configuration files, including `apss.yaml`, MUST NOT use that
 notice because they are expected to be manually edited.
 
 ## Manifest

--- a/standards/v1/APS-V1-0001-code-topology/README.md
+++ b/standards/v1/APS-V1-0001-code-topology/README.md
@@ -23,13 +23,13 @@ binary that contains only the standards your project declares.
 
 ```bash
 cargo install apss              # install the bootstrap CLI
-apss init --standard code-topology   # declare the standard in APSS.yaml (set id to APS-V1-0001)
+apss init --standard code-topology   # declare the standard in apss.yaml (set id to APS-V1-0001)
 apss install                    # resolve, pin, and build the composed binary
 apss run code-topology analyze .            # analyze the codebase into .topology/
 apss run code-topology viz .topology --type all   # render the visualizations
 ```
 
-Commit `APSS.yaml` and `apss.lock`. The generated `.apss/` runtime is build
+Commit `apss.yaml` and `apss.lock`. The generated `.apss/` runtime is build
 output and stays out of git.
 
 ## Substandards as cargo features

--- a/standards/v1/APS-V1-0001-code-topology/src/config.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/config.rs
@@ -11,7 +11,7 @@ use crate::OutputFormat;
 
 /// Configuration for the Code Topology standard (`APS-V1-0001`).
 ///
-/// Used in `APSS.yaml`:
+/// Used in `apss.yaml`:
 /// ```yaml
 /// standards:
 ///   code-topology:

--- a/standards/v1/APS-V1-0002-architecture-fitness/docs/INTEGRATION.md
+++ b/standards/v1/APS-V1-0002-architecture-fitness/docs/INTEGRATION.md
@@ -26,7 +26,7 @@ This guide walks through wiring architectural fitness governance into a Rust pro
 ## 1. Prerequisites
 
 - A Rust project (single crate or workspace) using 2021+ edition.
-- `apss` CLI installed. The project's `APSS.yaml` declares the standards:
+- `apss` CLI installed. The project's `apss.yaml` declares the standards:
 
   ```yaml
   schema: apss.project/v1

--- a/standards/v1/APS-V1-0002-architecture-fitness/src/lib.rs
+++ b/standards/v1/APS-V1-0002-architecture-fitness/src/lib.rs
@@ -36,7 +36,7 @@ pub const ID: &str = "APS-V1-0002";
 /// Canonical slug (matches `standard.toml` `slug`). This MUST equal the
 /// `slug` in `standard.toml` and the slug registered in [`register`], because
 /// the composed consumer runner matches the registered slug against the
-/// `APSS.yaml` standard key. Aliases such as `fitness` live only in the dev
+/// `apss.yaml` standard key. Aliases such as `fitness` live only in the dev
 /// CLI's `resolve_standard`, never here.
 pub const SLUG: &str = "architecture-fitness";
 
@@ -1832,7 +1832,7 @@ impl FitnessValidator {
 ///
 /// The registered slug is the canonical [`SLUG`] (`architecture-fitness`)
 /// because the composed consumer runner matches the registered slug against
-/// the `APSS.yaml` standard key. Dev-CLI aliases (`fitness`, etc.) live only
+/// the `apss.yaml` standard key. Dev-CLI aliases (`fitness`, etc.) live only
 /// in `aps-cli::resolve_standard`.
 pub fn register(registry: &mut dyn apss_core::registry::StandardRegistry) {
     registry.register(

--- a/standards/v1/APS-V1-0003-documentation/README.md
+++ b/standards/v1/APS-V1-0003-documentation/README.md
@@ -18,7 +18,7 @@ This is an official, active standard under APS-V1-0003 (promoted from EXP-V1-000
 
 ## Examples
 
-- [`examples/`](examples/): minimal `APSS.yaml` docs section, example ADR template, and example readmes.
+- [`examples/`](examples/): minimal `apss.yaml` docs section, example ADR template, and example readmes.
 
 ## Tests
 
@@ -33,8 +33,8 @@ apss run documentation index [path]          # preview generated index tables (d
 apss run documentation index [path] --write  # write index tables into README.md files
 ```
 
-In `APSS.yaml` and `apss run`, use the canonical slug `documentation` (it must
-match the standard key in `APSS.yaml`). The `docs` and `doc` spellings are
+In `apss.yaml` and `apss run`, use the canonical slug `documentation` (it must
+match the standard key in `apss.yaml`). The `docs` and `doc` spellings are
 accepted only by the development CLI `apss-dev`, not by the composed project
 binary, so `apss run docs ...` fails in a consumer project.
 
@@ -46,7 +46,7 @@ subcommands are planned for a follow-up and are not yet implemented.
 
 ## Configuration
 
-This standard's canonical slug is `documentation` (the `docs` and `doc` spellings are dev-CLI aliases only). It contributes the `docs:` section of `APSS.yaml`, owned by the meta-standard (APS-V1-0000.CF01). Zero-config works: absence of a key means the documented default applies (per Section 3.2 of the spec). A key is written only to opt out (`disable: true`) or to override a non-`disable` default.
+This standard's canonical slug is `documentation` (the `docs` and `doc` spellings are dev-CLI aliases only). It contributes the `docs:` section of `apss.yaml`, owned by the meta-standard (APS-V1-0000.CF01). Zero-config works: absence of a key means the documented default applies (per Section 3.2 of the spec). A key is written only to opt out (`disable: true`) or to override a non-`disable` default.
 
 ## Status
 

--- a/standards/v1/APS-V1-0003-documentation/agents/skills/README.md
+++ b/standards/v1/APS-V1-0003-documentation/agents/skills/README.md
@@ -20,7 +20,7 @@ Skip this skill when the user is editing prose only; the hook handles correctnes
 
 ## Commands
 
-Implemented and runnable today. Use the canonical slug `documentation` (it must match the `APSS.yaml` key); `docs` and `doc` are accepted only by the development CLI `apss-dev`, not by the composed project binary:
+Implemented and runnable today. Use the canonical slug `documentation` (it must match the `apss.yaml` key); `docs` and `doc` are accepted only by the development CLI `apss-dev`, not by the composed project binary:
 
 ```bash
 apss run documentation validate [path]         # Validate structure. Exit 0 only when no errors.
@@ -34,7 +34,7 @@ Every command emits diagnostics in the format defined in [Section 9.2 of the spe
 
 ## What "valid" means
 
-The per-doc-type definition of valid structure is in [Section 9.4 of the spec](../../docs/01_spec.md#94-git-pre-commit-hook-contract). The configurable surface is in [Section 3](../../docs/01_spec.md#3-configuration); a full example is in [`examples/APSS.yaml`](../../examples/APSS.yaml). Configuration lives in a single root-level `APSS.yaml` owned by the meta-standard (CF01 owns the canonical filename via `apss_core::CONFIG_FILENAME`); the docs standard registers the `docs` slug and contributes the `docs:` block.
+The per-doc-type definition of valid structure is in [Section 9.4 of the spec](../../docs/01_spec.md#94-git-pre-commit-hook-contract). The configurable surface is in [Section 3](../../docs/01_spec.md#3-configuration); a full example is in [`examples/apss.yaml`](../../examples/apss.yaml). Configuration lives in a single root-level `apss.yaml` owned by the meta-standard (CF01 owns the canonical filename via `apss_core::CONFIG_FILENAME`); the docs standard registers the `docs` slug and contributes the `docs:` block.
 
 ## Backlinking
 

--- a/standards/v1/APS-V1-0003-documentation/docs/00_overview.md
+++ b/standards/v1/APS-V1-0003-documentation/docs/00_overview.md
@@ -65,7 +65,7 @@ nested config key under `docs` without changing the parent spec.
 | North Star (Mission, Vision, Position) | [`APS-V1-0003.PV01`](../substandards/PV01-purpose-and-vision/docs/01_spec.md) | `docs/north-star.md` | Single document agents read during plan and design to stay aligned with the project's intent. |
 | Retrospectives | [`APS-V1-0003.RT01`](../substandards/RT01-retrospectives/docs/01_spec.md) | `docs/retrospectives/` | Append-only record of what was learned, by period or by milestone. |
 
-Doc types are activated by their `docs.<slug>` key in `APSS.yaml`
+Doc types are activated by their `docs.<slug>` key in `apss.yaml`
 (kebab-case slugs match each substandard's `substandard.toml`). Every
 doc type is default on, switchable off.
 
@@ -81,7 +81,7 @@ shipped inventory.
 Beyond the substrate and the registry, the parent contributes a small
 amount of project-wide infrastructure:
 
-1. **A single shared config file** at `APSS.yaml`, owned by the
+1. **A single shared config file** at `apss.yaml`, owned by the
    meta-standard (APS-V1-0000.CF01). This standard's canonical slug is
    `documentation` (the `docs` and `doc` spellings are dev-CLI aliases
    only); it contributes the `docs:` section schema. Every rule is
@@ -89,7 +89,7 @@ amount of project-wide infrastructure:
    in the smallest scope that contains it. There are no scattered
    per-feature `optional` flags. Absence of a key equals the default
    value: a project that adopts every default writes nothing into
-   `APSS.yaml`, and `disable: false` is the default the validator
+   `apss.yaml`, and `disable: false` is the default the validator
    applies for absence and MUST NOT appear in real configs or examples.
 2. **An installable hook contract.** Installing the standard installs
    a git pre-commit hook that auto-refreshes indexes, runs the
@@ -120,10 +120,10 @@ amount of project-wide infrastructure:
 ## Configuration
 
 All settings live in the `docs:` section of the project's root
-`APSS.yaml` (owned by APS-V1-0000.CF01). Zero-config works; defaults
+`apss.yaml` (owned by APS-V1-0000.CF01). Zero-config works; defaults
 are documented in
 [`01_spec.md` Section 3](01_spec.md#3-configuration). A complete
-example is in [`examples/APSS.yaml`](../examples/APSS.yaml).
+example is in [`examples/apss.yaml`](../examples/apss.yaml).
 
 ## CLI
 

--- a/standards/v1/APS-V1-0003-documentation/docs/01_spec.md
+++ b/standards/v1/APS-V1-0003-documentation/docs/01_spec.md
@@ -15,7 +15,7 @@ description: "Normative rules for documentation structure, the doc type registry
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
 
-When this standard says a rule is "default-on, switchable-off", it means the rule is part of the standard, applied unconditionally unless a specific `disable` flag in `APSS.yaml` turns it off for that one project. Defaults are opinionated. Configuration is by exception, not by accumulation of optional flags.
+When this standard says a rule is "default-on, switchable-off", it means the rule is part of the standard, applied unconditionally unless a specific `disable` flag in `apss.yaml` turns it off for that one project. Defaults are opinionated. Configuration is by exception, not by accumulation of optional flags.
 
 ---
 
@@ -47,7 +47,7 @@ The unlocks layered on top of the generic mechanism are:
    to operate on docs as data.
 2. **A configurable, growing doc type registry (Section 8).** Doc
    types are default on; a project disables one by flipping a single
-   flag in `APSS.yaml`.
+   flag in `apss.yaml`.
 3. **Installable enforcement (Section 9).** Installing the standard
    installs a git pre-commit hook that auto-updates the doc index,
    validates structure against the config, and fails the commit when
@@ -65,17 +65,17 @@ Section 8.
 
 ### 1.1 Relationship to APS-V1-0000 and the unified APSS config
 
-This standard plugs into the unified APSS configuration model owned by the meta-standard APS-V1-0000 (via its CF01 substandard). Project-level configuration for every APSS standard lives in a single file at the repository root, `APSS.yaml`, whose top-level structure and slug registry are owned by CF01. Each standard registers a unique short slug and contributes a config-section schema; the meta-validator aggregates and delegates validation of each namespaced section to its owner.
+This standard plugs into the unified APSS configuration model owned by the meta-standard APS-V1-0000 (via its CF01 substandard). Project-level configuration for every APSS standard lives in a single file at the repository root, `apss.yaml`, whose top-level structure and slug registry are owned by CF01. Each standard registers a unique short slug and contributes a config-section schema; the meta-validator aggregates and delegates validation of each namespaced section to its owner.
 
 This standard:
 
 1. Registers the canonical slug `documentation` (the `docs` and `doc` spellings are dev-CLI aliases only).
-2. Contributes the schema for the `docs` section of `APSS.yaml` (Section 3 below).
+2. Contributes the schema for the `docs` section of `apss.yaml` (Section 3 below).
 3. Validates its own section: the parent validator validates the `docs` block and its core sub-blocks (`index`, `context_files`, `readme`, `root_context`, `backlinking`); each substandard validates its own nested key (`adr`, `north-star`, `retrospectives`).
 
 Substandards do NOT register their own top-level slugs. They nest under the `docs` key as namespaced sub-sections (`docs.adr`, `docs.north-star`, `docs.retrospectives`); the nesting convention is normative and is owned by the meta-standard.
 
-The `.apss/` dotdir, when it exists, holds GENERATED artifacts (such as cached indexes and validator state) only. It MUST NOT hold configuration. Earlier drafts of this standard placed configuration in the `.apss` tree; that layout is superseded by `APSS.yaml` at the repository root. Tooling MUST NOT continue to read legacy `.apss` project configuration.
+The `.apss/` dotdir, when it exists, holds GENERATED artifacts (such as cached indexes and validator state) only. It MUST NOT hold configuration. Earlier drafts of this standard placed configuration in the `.apss` tree; that layout is superseded by `apss.yaml` at the repository root. Tooling MUST NOT continue to read legacy `.apss` project configuration.
 
 This standard complements APS-V1-0000's requirement for a per-package `docs/01_spec.md` by enforcing broader documentation structure across the project's docs root, beyond each standard package's own spec file.
 
@@ -88,7 +88,7 @@ This standard complements APS-V1-0000's requirement for a per-package `docs/01_s
 - **Context file**: `CLAUDE.md` or `AGENTS.md`, one per directory, providing AI agents with lightweight orientation to that directory.
 - **Docs root**: The project's technical documentation directory. Default `docs/`, configurable via `docs.root`.
 - **Doc type**: A class of document with its own structure rules (ADR, North Star, Retrospective, ...). Each doc type is implemented as a substandard.
-- **Doc type registry**: The set of `docs.<type>` keys in `APSS.yaml` that declare which doc types are active in a given project. See Section 8.
+- **Doc type registry**: The set of `docs.<type>` keys in `apss.yaml` that declare which doc types are active in a given project. See Section 8.
 - **Backlink**: A reference from an implementation file to the governing doc (ADR, North Star, ...) that it implements. Backlinking is part of every doc type, not a per type opt in. See Section 7.
 
 ---
@@ -97,16 +97,16 @@ This standard complements APS-V1-0000's requirement for a per-package `docs/01_s
 
 ### 3.1 Config Location
 
-Project-level configuration MUST be located at `APSS.yaml` relative to the repository root. The file is owned by the meta-standard (APS-V1-0000.CF01); this standard registers and contributes the `docs` section.
+Project-level configuration MUST be located at `apss.yaml` relative to the repository root. The file is owned by the meta-standard (APS-V1-0000.CF01); this standard registers and contributes the `docs` section.
 
 Configuration MUST NOT be placed under `.apss/`. The `.apss/` dotdir is reserved for GENERATED artifacts (cached indexes, validator state) only.
 
-Monorepo cascade: a nested `APSS.yaml` inside a sub-package layers over the root file using the meta-standard's cascade rules (nearer file overrides root values). Cascade resolution is owned by CF01; this standard inherits whatever the meta-validator produces and validates the merged `docs` block.
+Monorepo cascade: a nested `apss.yaml` inside a sub-package layers over the root file using the meta-standard's cascade rules (nearer file overrides root values). Cascade resolution is owned by CF01; this standard inherits whatever the meta-validator produces and validates the merged `docs` block.
 
 ### 3.2 Default Behavior (absence equals enabled)
 
 The standard follows an absence-equals-enabled convention modelled on
-environment variables. If `APSS.yaml` does not exist, or it exists but
+environment variables. If `apss.yaml` does not exist, or it exists but
 contains no `docs` key, or a `docs` block exists but a given
 sub-section is absent, the validator MUST apply the documented
 defaults for the absent surface. The validator MUST NOT error on a
@@ -114,7 +114,7 @@ missing config file, a missing `docs` section, or a missing
 sub-section. Zero-config works; every flag defaults to the recommended
 setting and every feature defaults to enabled.
 
-A key only appears in `APSS.yaml` to do one of two things:
+A key only appears in `apss.yaml` to do one of two things:
 
 1. Opt OUT of a default-on rule with `disable: true`.
 2. Override a non-`disable` default value (for example, change
@@ -125,19 +125,19 @@ into a real or example config: it is the default that the validator
 already applies for absence. Tooling and documentation MUST NOT
 generate `disable: false` boilerplate, and operators reading examples
 MUST be shown the empty-section happy path, not a `disable: false`
-crutch. The smallest valid `APSS.yaml` for a project that adopts every
+crutch. The smallest valid `apss.yaml` for a project that adopts every
 default of this standard is:
 
 ```yaml
 docs: {}
 ```
 
-or simply no `APSS.yaml` at all (CF01 owns whether the file is
+or simply no `apss.yaml` at all (CF01 owns whether the file is
 required for other reasons).
 
 ### 3.3 Schema
 
-The schema is normative. **Scalar fields not listed here under a KNOWN nested section MUST be rejected with `unknown-config-field`.** Unknown nested keys under `docs` (for example `docs.<some-future-slug>`) are tolerated per Section 3.4 forward-compatibility. The schema below shows the `docs` block as it appears inside `APSS.yaml`. Every line below is a default that the validator applies for absence; per Section 3.2 a project only writes a key to opt out (`disable: true`) or to override a non-`disable` value. The surrounding top-level structure (schema declaration, project identity, standard activation) is owned by CF01.
+The schema is normative. **Scalar fields not listed here under a KNOWN nested section MUST be rejected with `unknown-config-field`.** Unknown nested keys under `docs` (for example `docs.<some-future-slug>`) are tolerated per Section 3.4 forward-compatibility. The schema below shows the `docs` block as it appears inside `apss.yaml`. Every line below is a default that the validator applies for absence; per Section 3.2 a project only writes a key to opt out (`disable: true`) or to override a non-`disable` value. The surrounding top-level structure (schema declaration, project identity, standard activation) is owned by CF01.
 
 **Path resolution (normative).** Every doc-type location key in this
 schema is **docs-root-relative**: the validator resolves it as
@@ -230,7 +230,7 @@ docs:
 ### 3.4 Configurability rules
 
 - Every rule listed in this spec is on by default. A project disables one rule by setting `disable: true` in the smallest scope that contains it (a single nested key under `docs`, or the top-level `docs.disable` to disable all doc validation).
-- `disable: false` is the default the validator applies for absence and MUST NOT be written into real or example configs. Examples in this spec and in `examples/APSS.yaml` MUST show empty sections (or no section at all) for surfaces a project does not override.
+- `disable: false` is the default the validator applies for absence and MUST NOT be written into real or example configs. Examples in this spec and in `examples/apss.yaml` MUST show empty sections (or no section at all) for surfaces a project does not override.
 - There MUST NOT be per feature `optional` flags scattered through the spec. The shape is always: an implicit default-on with `disable: true` as the opt-out, plus that section's content.
 - Adding a new doc type does not require changing this spec. A new substandard MAY claim its own `docs.<slug>` key; the parent standard MUST tolerate unknown `docs.<slug>` keys for forward compatibility, even though it MUST reject unknown scalar fields inside known sections.
 - Substandard keys use the substandard's kebab-case slug (for example `north-star`, not `north_star`). Scalar field names inside each section remain snake_case to match the Rust struct contract.
@@ -239,7 +239,7 @@ docs:
 
 The CLI and hook MUST emit a single human-readable diagnostic, never a panic, when the config file is malformed:
 
-- `invalid-apss-yaml`: `APSS.yaml` is not valid YAML. Severity: error.
+- `invalid-apss-yaml`: `apss.yaml` is not valid YAML. Severity: error.
 - `unknown-config-field`: a known section under `docs` contains an unknown scalar field. Severity: error.
 
 Both diagnostics MUST include the file path, the offending field or token, and a one-line hint.
@@ -546,7 +546,7 @@ The standard does not require code files to be auto generated with backlinks. It
 
 The parent standard defines the doc type registry. Each doc type is implemented as a substandard under `substandards/`. The shipped doc types are:
 
-| Doc type | Substandard | Default location (resolved with default `docs.root: docs`) | Config key in `APSS.yaml` |
+| Doc type | Substandard | Default location (resolved with default `docs.root: docs`) | Config key in `apss.yaml` |
 |----------|-------------|------------------|---------------------------|
 | Architecture Decision Records | `APS-V1-0003.AD01` | `docs/adrs/` (literal config value: `adrs`) | `docs.adr` |
 | North Star (Mission, Vision, Position) | `APS-V1-0003.PV01` | `docs/north-star.md` (literal config value: `north-star.md`) | `docs.north-star` |
@@ -593,7 +593,7 @@ typically remain `active` for long stretches.
 A new doc type is added by:
 
 1. Creating a substandard under `substandards/<ID>-<slug>/`.
-2. Documenting its nested key under `docs` in `APSS.yaml`, using the substandard's kebab-case slug (so `docs.<slug>`). Per Section 3.2 the validator MUST treat the absence of `docs.<slug>` as default-on; the substandard's spec MUST NOT instruct projects to write `disable: false`. Any non-`disable` fields are owned by the substandard. Substandards do NOT register their own top-level slug in the meta-standard registry.
+2. Documenting its nested key under `docs` in `apss.yaml`, using the substandard's kebab-case slug (so `docs.<slug>`). Per Section 3.2 the validator MUST treat the absence of `docs.<slug>` as default-on; the substandard's spec MUST NOT instruct projects to write `disable: false`. Any non-`disable` fields are owned by the substandard. Substandards do NOT register their own top-level slug in the meta-standard registry.
 3. Registering the doc type in this section's table.
 4. Defining the substandard's diagnostic codes using the human readable scheme described in Section 10.
 
@@ -621,10 +621,10 @@ aps run docs uninstall [<repo-root>]
 Behavior:
 
 - `install` MUST:
-  1. If `APSS.yaml` does not exist, ask the meta-standard's installer (CF01) to create it with the project's selected standards. If `APSS.yaml` exists, MUST NOT overwrite it; only add a `docs:` block if missing, leaving every other section untouched. The added `docs:` block uses the documented defaults from Section 3.3.
+  1. If `apss.yaml` does not exist, ask the meta-standard's installer (CF01) to create it with the project's selected standards. If `apss.yaml` exists, MUST NOT overwrite it; only add a `docs:` block if missing, leaving every other section untouched. The added `docs:` block uses the documented defaults from Section 3.3.
   2. Install the git pre-commit hook described in Section 9.4. If a pre-commit hook already exists, MUST insert an `apss-docs-hook` block delimited by sentinel comments rather than replace the user's hook.
   3. Print the resolved doc type registry so the operator sees which doc types just became active.
-- `uninstall` MUST remove only the `apss-docs-hook` block from the pre-commit hook and MUST leave `APSS.yaml` (and its `docs:` block) and the rest of the hook intact.
+- `uninstall` MUST remove only the `apss-docs-hook` block from the pre-commit hook and MUST leave `apss.yaml` (and its `docs:` block) and the rest of the hook intact.
 - Both commands MUST be idempotent.
 
 ### 9.2 Validator contract
@@ -634,7 +634,7 @@ The validator is the source of truth. The hook and the standalone CLI MUST call 
 **Inputs**:
 
 - `repo_root: Path`: absolute path to the repository root.
-- `config: ApssConfig`: the merged `docs` block from `APSS.yaml` (after CF01 cascade resolution), with defaults applied for any missing fields.
+- `config: ApssConfig`: the merged `docs` block from `apss.yaml` (after CF01 cascade resolution), with defaults applied for any missing fields.
 - `scope: ValidationScope`: one of:
   - `Full`: walk the entire docs root and every doc type directory.
   - `Changed { staged_paths: Vec<PathBuf> }`: only inspect docs touched by the staged change set; the hook MUST use this scope.
@@ -717,7 +717,7 @@ Existing numeric or composite codes (for example, `ADR01-001`) MAY be retained a
 
 | Code | Severity | Domain | Description |
 |------|----------|--------|-------------|
-| `invalid-apss-yaml` | error | Config | `APSS.yaml` is not valid YAML. |
+| `invalid-apss-yaml` | error | Config | `apss.yaml` is not valid YAML. |
 | `unknown-config-field` | error | Config | A known section under `docs` contains an unknown scalar field. |
 | `readme-missing` | error | DOC02 | Directory missing `README.md`. |
 | `claude-md-missing` | warning | DOC02 | Directory missing `CLAUDE.md`. |
@@ -762,7 +762,7 @@ Every command MUST emit the same diagnostics shape as the validator (Section 9.2
 
 ## Appendix A: Validation Checklist
 
-- [ ] `APSS.yaml` valid, or absent for defaults; the `docs:` block (if present) parses against Section 3.3.
+- [ ] `apss.yaml` valid, or absent for defaults; the `docs:` block (if present) parses against Section 3.3.
 - [ ] Every docs directory has `README.md` with a valid `## Index` section.
 - [ ] `.md` files under the docs root have closed frontmatter with the configured fields.
 - [ ] `CLAUDE.md` and `AGENTS.md` present per docs directory.

--- a/standards/v1/APS-V1-0003-documentation/docs/02_install_contract.md
+++ b/standards/v1/APS-V1-0003-documentation/docs/02_install_contract.md
@@ -34,7 +34,7 @@ The installer MUST be idempotent. Running it twice MUST be equivalent to running
 Steps, in order:
 
 1. **Resolve target.** If `<repo-root>` is omitted, use `git rev-parse --show-toplevel`. Fail with `install-no-git-root` if not in a git repository.
-2. **Ensure the `docs` block in `APSS.yaml`.** Configuration lives in a single root-level `APSS.yaml` owned by the meta-standard (APS-V1-0000.CF01); this standard contributes only the `docs:` block. If `APSS.yaml` does not exist, delegate creation to the CF01 installer. If `APSS.yaml` exists, MUST NOT overwrite it; instead, add a `docs:` block populated with the Section 3.3 defaults when one is absent and otherwise leave the existing block untouched. `--force` MAY rewrite the `docs:` block but MUST back up `APSS.yaml` to `APSS.yaml.bak.<timestamp>` first. `--no-config` skips this step entirely.
+2. **Ensure the `docs` block in `apss.yaml`.** Configuration lives in a single root-level `apss.yaml` owned by the meta-standard (APS-V1-0000.CF01); this standard contributes only the `docs:` block. If `apss.yaml` does not exist, delegate creation to the CF01 installer. If `apss.yaml` exists, MUST NOT overwrite it; instead, add a `docs:` block populated with the Section 3.3 defaults when one is absent and otherwise leave the existing block untouched. `--force` MAY rewrite the `docs:` block but MUST back up `apss.yaml` to `apss.yaml.bak.<timestamp>` first. `--no-config` skips this step entirely.
 3. **Install the pre-commit hook.** Write `.git/hooks/pre-commit` (mode `0755`). If the hook file does not exist, create it with the apss block as its only content. If it exists:
    - The hook MUST insert a block delimited by the sentinels:
      ```
@@ -54,7 +54,7 @@ Steps, in order:
 
 - Locate the pre-commit hook and remove the entire `# >>> apss-docs-hook >>>` to `# <<< apss-docs-hook <<<` block, including the sentinels.
 - Leave the rest of `.git/hooks/pre-commit` intact.
-- Leave `APSS.yaml` and its `docs:` block intact (config is the operator's, not the installer's).
+- Leave `apss.yaml` and its `docs:` block intact (config is the operator's, not the installer's).
 - Be a no-op when the sentinels are not present.
 
 ### 1.3 Install-related diagnostics
@@ -63,7 +63,7 @@ Steps, in order:
 |------|----------|-------------|
 | `install-no-git-root` | error | The target path is not inside a git repository. |
 | `install-hook-write-failed` | error | Could not write `.git/hooks/pre-commit`. |
-| `install-config-conflict` | error | `APSS.yaml` exists with a `docs:` block and `--force` was not specified. |
+| `install-config-conflict` | error | `apss.yaml` exists with a `docs:` block and `--force` was not specified. |
 | `install-template-conflict` | warning | A template file was skipped because the target already exists. The target path and the template path MUST appear in the message so the operator can reconcile manually. |
 | `install-template-write-failed` | error | Could not write a template file the installer attempted to create. |
 
@@ -83,7 +83,7 @@ components of the template's relative path as follows:
 
 1. Strip the leading `docs/` segment that matches the parent
    standard's default `docs.root` value, and replace it with the
-   resolved `<docs.root>` value from `APSS.yaml`.
+   resolved `<docs.root>` value from `apss.yaml`.
 2. For substandards that contribute a directory key
    (`docs.adr.directory`, `docs.retrospectives.directory`, etc.),
    strip the substandard's default directory segment (e.g. `adrs/`
@@ -243,7 +243,7 @@ enum ValidationScope {
 - `Full`: walk the entire docs root and every active doc type directory. Used by `aps run docs validate` and by CI.
 - `Changed`: only inspect docs touched by `staged_paths`. The hook MUST use this scope. The validator MUST still load enough surrounding state (for example, the doc type directories themselves) to detect dead backlinks introduced by the change set.
 
-When `scope = Changed` and the staged set contains an `APSS.yaml` modification, the validator MUST run the `Full` set of checks; config changes can invalidate the entire tree.
+When `scope = Changed` and the staged set contains an `apss.yaml` modification, the validator MUST run the `Full` set of checks; config changes can invalidate the entire tree.
 
 ### 2.3 Output: `ValidationReport`
 
@@ -362,7 +362,7 @@ The installed `.git/hooks/pre-commit` block MUST do nothing more than call this 
    (index regeneration) so a migration window the operator wanted
    quiet does not silently rewrite `README.md` files.
 1. **Resolve scope.** `repo_root = git rev-parse --show-toplevel`; `staged = git diff --cached --name-only --diff-filter=ACMR`. If `repo_root` is missing, exit `2` with `hook-not-in-repo`.
-2. **Load config.** If `APSS.yaml` fails to load, emit `invalid-apss-yaml` and exit `2`. The hook MUST NOT proceed with defaults when the config file exists but is malformed; the operator should fix it before committing. (The hook reads the `docs` block out of the file the meta-validator already cascade-resolved.)
+2. **Load config.** If `apss.yaml` fails to load, emit `invalid-apss-yaml` and exit `2`. The hook MUST NOT proceed with defaults when the config file exists but is malformed; the operator should fix it before committing. (The hook reads the `docs` block out of the file the meta-validator already cascade-resolved.)
 3. **Refresh indexes.** Compute the **set of docs directories
    whose contents appear in `staged`**, defined as the parent
    directory of every staged path that lies under `docs.root`, plus
@@ -402,7 +402,7 @@ afterward.
 ### 4.4 Escape hatches
 
 - `git commit --no-verify` continues to skip the hook entirely. This is a human operator escape hatch. The standard MUST NOT teach agents to use `--no-verify`.
-- Setting `docs.disable: true` in `APSS.yaml` is the supported way to keep the hook installed but silent for a temporary period (for example, during a large migration). Per Section 4.2 step 0 the kill switch short-circuits the hook (no index regeneration, no validation, exit 0) so the migration is genuinely quiet.
+- Setting `docs.disable: true` in `apss.yaml` is the supported way to keep the hook installed but silent for a temporary period (for example, during a large migration). Per Section 4.2 step 0 the kill switch short-circuits the hook (no index regeneration, no validation, exit 0) so the migration is genuinely quiet.
 
 ### 4.5 Hook diagnostics
 

--- a/standards/v1/APS-V1-0003-documentation/examples/README.md
+++ b/standards/v1/APS-V1-0003-documentation/examples/README.md
@@ -7,7 +7,7 @@ description: "Example configuration and compliant project structure for APS-V1-0
 
 ## Example Configuration
 
-Configuration lives in a single root-level `APSS.yaml` owned by the meta-standard (APS-V1-0000.CF01). This standard's canonical slug is `documentation` (the `docs` and `doc` spellings are dev-CLI aliases only); it contributes the `docs:` section. A minimal `APSS.yaml` for a project adopting the documentation standard:
+Configuration lives in a single root-level `apss.yaml` owned by the meta-standard (APS-V1-0000.CF01). This standard's canonical slug is `documentation` (the `docs` and `doc` spellings are dev-CLI aliases only); it contributes the `docs:` section. A minimal `apss.yaml` for a project adopting the documentation standard:
 
 ```yaml
 schema: apss.project/v1
@@ -20,13 +20,13 @@ docs:
       - security
 ```
 
-The full default `docs:` section (every key) is in [`APSS.yaml`](APSS.yaml).
+The full default `docs:` section (every key) is in [`apss.yaml`](apss.yaml).
 
 ## Example Compliant Directory Structure
 
 ```
 my-project/
-├── APSS.yaml                    # APSS configuration (meta-standard owned)
+├── apss.yaml                    # APSS configuration (meta-standard owned)
 ├── docs/
 │   ├── README.md                # Has ## Index auto-generated
 │   ├── AGENTS.md                # Canonical agent context for this directory

--- a/standards/v1/APS-V1-0003-documentation/examples/apss.yaml
+++ b/standards/v1/APS-V1-0003-documentation/examples/apss.yaml
@@ -1,10 +1,10 @@
-# Example APSS.yaml for a project adopting APS-V1-0003 (Documentation).
+# Example apss.yaml for a project adopting APS-V1-0003 (Documentation).
 #
-# Configuration lives in a single root-level APSS.yaml owned by the
+# Configuration lives in a single root-level apss.yaml owned by the
 # meta-standard (APS-V1-0000.CF01). The documentation standard registers
 # the slug "docs" and contributes this docs: section.
 #
-# Copy the relevant pieces into your project's APSS.yaml and customize.
+# Copy the relevant pieces into your project's apss.yaml and customize.
 # Per the absence-equals-enabled convention (parent spec Section 3.2)
 # the empty section is the happy path: write a key only to opt out
 # (disable: true) or to override a non-disable default. `disable: false`

--- a/standards/v1/APS-V1-0003-documentation/src/cli.rs
+++ b/standards/v1/APS-V1-0003-documentation/src/cli.rs
@@ -60,7 +60,7 @@ impl CommandHandler for DocumentationCommandHandler {
 ///
 /// Mirrors [`crate::config::load_config`] but works against an arbitrary path
 /// so operators can point `aps run docs validate` at a non-default
-/// `APSS.yaml`. YAML format per the unified-config brief (2026-06-04); other
+/// `apss.yaml`. YAML format per the unified-config brief (2026-06-04); other
 /// top-level sections owned by other standards are tolerated and ignored.
 fn load_docs_config(path: &str) -> Result<ApssConfig, ConfigError> {
     let path_buf = std::path::PathBuf::from(path);
@@ -304,7 +304,7 @@ fn index(args: &[String], repo_root: &std::path::Path, _verbose: bool) -> i32 {
                         "Docs root not found or contains no directories under {}.",
                         target.display(),
                     );
-                    println!("Create the docs root or configure docs.root in APSS.yaml.");
+                    println!("Create the docs root or configure docs.root in apss.yaml.");
                 } else {
                     for idx in &indexes {
                         println!("--- {} ---", idx.dir.display());
@@ -335,7 +335,7 @@ fn print_help() {
     println!("    index [path]       Generate or check README indexes from front matter");
     println!();
     println!("OPTIONS:");
-    println!("    --config <file>    Path to APSS.yaml (default: <path>/APSS.yaml)");
+    println!("    --config <file>    Path to apss.yaml (default: <path>/apss.yaml)");
     println!("    --write            Write generated indexes into README.md files (index only)");
     println!("    --json             Output validation results as JSON (validate only)");
     println!("    --help             Show this help message");

--- a/standards/v1/APS-V1-0003-documentation/src/lib.rs
+++ b/standards/v1/APS-V1-0003-documentation/src/lib.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 pub const ID: &str = "APS-V1-0003";
 /// CLI slug used in `aps run <slug>` and as the matching key for dispatch.
 /// Must equal the `slug` in standard.toml: the composed consumer runner matches
-/// this registered slug against the APSS.yaml standard key.
+/// this registered slug against the apss.yaml standard key.
 pub const SLUG: &str = "documentation";
 /// Human-readable standard name.
 pub const NAME: &str = "Documentation and Context Engineering";

--- a/standards/v1/APS-V1-0003-documentation/src/readme.rs
+++ b/standards/v1/APS-V1-0003-documentation/src/readme.rs
@@ -27,7 +27,7 @@ pub fn validate_readmes(repo_root: &Path, docs_config: &DocsConfig, diagnostics:
             )
             .with_path(&docs_root)
             .with_hint(format!(
-                "Create '{}' or configure docs.root in APSS.yaml",
+                "Create '{}' or configure docs.root in apss.yaml",
                 docs_root.display()
             )),
         );

--- a/standards/v1/APS-V1-0003-documentation/src/substandards/adr.rs
+++ b/standards/v1/APS-V1-0003-documentation/src/substandards/adr.rs
@@ -61,7 +61,7 @@ pub struct AdrValidator {
 
 impl AdrValidator {
     /// Load the ADR validator from a repository root.
-    /// Reads `APSS.yaml` for configuration.
+    /// Reads `apss.yaml` for configuration.
     pub fn load(repo_root: &Path) -> Result<Self, config::ConfigError> {
         let apss_config = config::load_config(repo_root)?;
         Ok(Self {

--- a/standards/v1/APS-V1-0003-documentation/standard.toml
+++ b/standards/v1/APS-V1-0003-documentation/standard.toml
@@ -27,7 +27,7 @@ rationale = "ADR substandard derives backlink and reference-extraction regexes f
 
 [[dependencies.allowed_external]]
 crate = "serde"
-rationale = "Workspace dependency for deserialising APSS.yaml's docs section into typed config structs"
+rationale = "Workspace dependency for deserialising apss.yaml's docs section into typed config structs"
 
 [[dependencies.allowed_external]]
 crate = "serde_json"
@@ -35,7 +35,7 @@ rationale = "Workspace dependency used by the validator for machine-readable dia
 
 [[dependencies.allowed_external]]
 crate = "serde_yaml"
-rationale = "Workspace dependency for parsing APSS.yaml during config load"
+rationale = "Workspace dependency for parsing apss.yaml during config load"
 
 [[dependencies.allowed_external]]
 crate = "walkdir"

--- a/standards/v1/APS-V1-0003-documentation/substandards/AD01-architecture-decision-records/docs/00_overview.md
+++ b/standards/v1/APS-V1-0003-documentation/substandards/AD01-architecture-decision-records/docs/00_overview.md
@@ -91,7 +91,7 @@ decisions.
 ## File naming convention
 
 The default naming pattern is `ADR-\d{3,5}-[a-zA-Z0-9-]+\.md`, configurable
-via `docs.adr.naming_pattern` in `APSS.yaml`. The canonical guidance prefers
+via `docs.adr.naming_pattern` in `apss.yaml`. The canonical guidance prefers
 present-tense imperative verb phrases in the name, lowercase, dashes for
 word separation, and the `.md` extension. Examples:
 
@@ -136,7 +136,7 @@ and have well-formed frontmatter.
 # Validate ADRs (runs as part of docs validate)
 aps run docs validate .
 
-# Configure required ADR keywords in APSS.yaml at the repo root
+# Configure required ADR keywords in apss.yaml at the repo root
 # (config is owned by APS-V1-0000.CF01; the docs standard contributes the docs: block)
 docs:
   adr:

--- a/standards/v1/APS-V1-0003-documentation/substandards/AD01-architecture-decision-records/docs/01_spec.md
+++ b/standards/v1/APS-V1-0003-documentation/substandards/AD01-architecture-decision-records/docs/01_spec.md
@@ -17,7 +17,7 @@ This substandard's vocabulary, lifecycle, naming guidance, and shipped template 
 
 The docs root (default `docs/`) MUST contain an ADR directory (default `adrs/`).
 
-- Configurable via `docs.adr.directory` in `APSS.yaml`
+- Configurable via `docs.adr.directory` in `apss.yaml`
 - Full path: `<docs.root>/<docs.adr.directory>/` (e.g., `docs/adrs/`)
 - The ADR directory SHOULD contain a `README.md` with a `## Index` section listing all ADRs (managed by the parent standard's index generation)
 
@@ -39,7 +39,7 @@ Every file in the ADR directory MUST match the configured naming pattern, with t
 
 - The number MUST be zero-padded to at least 3 digits (maximum 5 digits)
 - The name MUST use kebab-case (lowercase letters, digits, hyphens)
-- Configurable via `docs.adr.naming_pattern` in `APSS.yaml`
+- Configurable via `docs.adr.naming_pattern` in `apss.yaml`
 
 ## 3. Front Matter (ADR01-missing-frontmatter, ADR01-invalid-status)
 
@@ -206,7 +206,7 @@ reference other ADRs without tripping the validator).
 (`ADR01-superseded-reference`), warning
 (`ADR01-deprecated-reference`).
 
-**Controlled by:** `docs.backlinking.disable` in `APSS.yaml`. When backlinking
+**Controlled by:** `docs.backlinking.disable` in `apss.yaml`. When backlinking
 is disabled all three codes are suppressed.
 
 ### 6.6 Migration from `ADR01-dead-reference`

--- a/standards/v1/APS-V1-0003-documentation/substandards/AD01-architecture-decision-records/templates/docs/adrs/README.md
+++ b/standards/v1/APS-V1-0003-documentation/substandards/AD01-architecture-decision-records/templates/docs/adrs/README.md
@@ -75,7 +75,7 @@ Examples:
 - `ADR-100-manage-passwords.md`
 
 The pattern is configurable via `docs.adr.naming_pattern` in
-`APSS.yaml`.
+`apss.yaml`.
 
 ## Backlinking from code
 

--- a/standards/v1/APS-V1-0003-documentation/substandards/PV01-purpose-and-vision/docs/00_overview.md
+++ b/standards/v1/APS-V1-0003-documentation/substandards/PV01-purpose-and-vision/docs/00_overview.md
@@ -65,7 +65,7 @@ We are the project that ...
 
 ## Configuration
 
-In `APSS.yaml` (owned by APS-V1-0000.CF01); this substandard registers
+In `apss.yaml` (owned by APS-V1-0000.CF01); this substandard registers
 the kebab-case key `north-star` under the parent `docs` slug. Per the
 parent standard's absence-equals-enabled convention (Section 3.2 of
 the parent spec), a project adopting every default writes nothing for

--- a/standards/v1/APS-V1-0003-documentation/substandards/PV01-purpose-and-vision/docs/01_spec.md
+++ b/standards/v1/APS-V1-0003-documentation/substandards/PV01-purpose-and-vision/docs/01_spec.md
@@ -43,7 +43,7 @@ root are also rejected (`PV01-location-out-of-tree`).
 
 Diagnostic: `PV01-document-missing` (error). Hint: "Create the file at
 `<resolved-location>` or set `docs.north-star.disable = true` in
-`APSS.yaml`."
+`apss.yaml`."
 
 ## 3. Frontmatter (PV01-frontmatter-missing, PV01-frontmatter-field-missing)
 

--- a/standards/v1/APS-V1-0003-documentation/substandards/RT01-retrospectives/docs/00_overview.md
+++ b/standards/v1/APS-V1-0003-documentation/substandards/RT01-retrospectives/docs/00_overview.md
@@ -53,7 +53,7 @@ We shipped ...
 
 ## Configuration
 
-In `APSS.yaml` (owned by APS-V1-0000.CF01); this substandard registers the key `retrospectives` under the parent `docs` slug. Per the parent standard's absence-equals-enabled convention (Section 3.2 of the parent spec), a project adopting every default for this substandard writes nothing under `docs.retrospectives`. The substandard is opt-out, not opt-in.
+In `apss.yaml` (owned by APS-V1-0000.CF01); this substandard registers the key `retrospectives` under the parent `docs` slug. Per the parent standard's absence-equals-enabled convention (Section 3.2 of the parent spec), a project adopting every default for this substandard writes nothing under `docs.retrospectives`. The substandard is opt-out, not opt-in.
 
 To override the default directory or naming pattern:
 

--- a/standards/v1/APS-V1-0003-documentation/substandards/RT01-retrospectives/docs/01_spec.md
+++ b/standards/v1/APS-V1-0003-documentation/substandards/RT01-retrospectives/docs/01_spec.md
@@ -31,7 +31,7 @@ guess. A leading `/` (`RETRO01-absolute-directory`) and `..` escapes
 
 Diagnostic: `RETRO01-dir-not-found` (error). Hint: "Create the
 directory at `<resolved-directory>` or set
-`docs.retrospectives.disable = true` in `APSS.yaml`."
+`docs.retrospectives.disable = true` in `apss.yaml`."
 
 The retrospective directory inherits the parent rules: it MUST contain a `README.md` with a `## Index` section (auto generated from frontmatter) and per directory `CLAUDE.md` and `AGENTS.md`.
 
@@ -53,7 +53,7 @@ A retrospective file MUST be reachable from the directory's `## Index` section o
 
 Diagnostics:
 - `RETRO01-naming-mismatch` (error): a file does not match the regex.
-- `RETRO01-invalid-naming-regex` (error): the configured regex itself is not valid. Hint: "Check `docs.retrospectives.naming_pattern` in `APSS.yaml`."
+- `RETRO01-invalid-naming-regex` (error): the configured regex itself is not valid. Hint: "Check `docs.retrospectives.naming_pattern` in `apss.yaml`."
 
 ## 4. Frontmatter (RETRO01-frontmatter-missing, RETRO01-frontmatter-field-missing)
 


### PR DESCRIPTION
## Summary

Renames the canonical project manifest from `APSS.yaml` to lowercase `apss.yaml`. `apss init` now generates the lowercase name; discovery accepts both, so existing repos keep working on case-sensitive filesystems.

## Changes

- **apss-core**: `CONFIG_FILENAME` is now `"apss.yaml"`; added `LEGACY_CONFIG_FILENAME` with a `config_in_dir` fallback helper in discovery, plus tests for canonical preference and legacy fallback.
- Swept `APSS.yaml` -> `apss.yaml` across crates, standards, docs, and the `justfile`.
- `git mv` the documentation example `APSS.yaml` -> `apss.yaml`.
- **docs(runbooks)**: corrected stale language support (now Rust, Python, TypeScript, TSX) and added a fitness-gate fallback callout (native topology ~0.1s vs the dependency-cruiser fallback ~136s on a ~95-file repo).

## Compatibility

Backwards compatible: the legacy `APSS.yaml` name is still discovered. No standard version bumps in this PR; per the release-gate model, version bumps are enforced on the `main` -> `release` PR, not on merges to `main`.

## Validation

- `just check` (fmt, clippy `-D warnings`, tests): pass
- `cargo run -p aps-cli --bin apss-dev -- v1 validate repo`: 0 errors, 0 warnings, 26 packages
- New tests: config discovery canonical preference + legacy fallback; bootstrap `init` integration (now emits `apss.yaml`)
