### PR TITLE
feat: EXP-V1-0003 Agent Recipe Standard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,6 @@ dependencies = [
  "apss-core",
  "serde",
  "serde_yaml_ng",
- "tempfile",
  "thiserror",
  "toml",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "apss-v1-0003-agent-recipe"
+version = "0.1.0"
+dependencies = [
+ "apss-core",
+ "serde",
+ "serde_yaml_ng",
+ "tempfile",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "apss-v1-0003-documentation"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "standards/v1/APS-V1-0003-documentation",
     # Experimental standards
     "standards-experimental/v1/EXP-V1-0002-todo-tracker",
+    "standards-experimental/v1/EXP-V1-0003-agent-recipe",
 ]
 exclude = [
 ]

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/Cargo.toml
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "apss-v1-0003-agent-recipe"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Agent Recipe Standard (Experimental)"
+readme = "README.md"
+keywords = ["agent", "recipe", "harness", "schema"]
+categories = ["config", "development-tools"]
+
+[lib]
+name = "agent_recipe"
+
+[dependencies]
+apss-core.workspace = true
+serde.workspace = true
+serde_yaml.workspace = true
+thiserror.workspace = true
+toml.workspace = true
+
+[dev-dependencies]
+tempfile = "3.14"
+

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/Cargo.toml
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/Cargo.toml
@@ -20,6 +20,3 @@ serde_yaml.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 
-[dev-dependencies]
-tempfile = "3.14"
-

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/README.md
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/README.md
@@ -39,6 +39,6 @@ system_instructions:
 
 ```bash
 cargo run -p aps-cli --bin apss-dev -- v1 validate experiment EXP-V1-0003
-cargo test -p agent-recipe
+cargo test -p apss-v1-0003-agent-recipe
 ```
 

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/README.md
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/README.md
@@ -1,0 +1,44 @@
+# Agent Recipe Standard
+
+**ID:** `EXP-V1-0003`
+**Type:** Experiment
+**Slug:** `agent-recipe`
+**Version:** `0.1.0`
+
+⚠️ **EXPERIMENTAL**: This standard is in incubation and may change significantly before promotion.
+
+A declarative, harness-neutral schema for an **agent recipe**: what agent to run (harness, model,
+reasoning effort, skills, system instructions), independent of where or how it executes. Adopted
+from the `pi.recipes` shape. See [docs/00_overview.md](docs/00_overview.md) for a quick tour and
+[docs/01_spec.md](docs/01_spec.md) for the normative specification.
+
+```yaml
+name: pr-reviewer
+agent: claude
+model:
+  name: anthropic/claude-opus-4-8
+  effort: high
+skills:
+  - code-review
+system_instructions:
+  mode: append
+  content: |
+    Focus exclusively on correctness and security issues.
+```
+
+## Index
+
+- [experiment.toml](experiment.toml)
+- [Overview](docs/00_overview.md)
+- [Specification](docs/01_spec.md)
+- [Examples](examples/)
+- [Tests](tests/)
+- [Agent Skills](agents/skills/)
+
+## Validation
+
+```bash
+cargo run -p aps-cli --bin apss-dev -- v1 validate experiment EXP-V1-0003
+cargo test -p agent-recipe
+```
+

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/agents/skills/README.md
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/agents/skills/README.md
@@ -1,0 +1,31 @@
+# Agent Recipe Standard Agent Skills (Experimental)
+
+⚠️ This experiment is in incubation. Skills may change.
+
+## Usage
+
+An AI agent authoring or reviewing an agent recipe file (see `docs/01_spec.md`) should:
+
+1. Confirm the document is a single YAML mapping with the required fields:
+   `name`, `agent`, `model.name`, `model.effort`.
+2. Confirm `agent` is one of the v1 harness values: `claude`, `codex`.
+3. Confirm `model.effort` is one of `low`, `medium`, `high`.
+4. If `skills` is present, confirm every entry is a non-empty string reference.
+5. If `system_instructions` is present, confirm `mode` is `append` or `replace`
+   and `content` is non-empty.
+6. Reject any field not in the schema (`AGENT_RECIPE_UNKNOWN_FIELD`) rather than
+   guessing at its intent.
+7. Never place credentials, tokens, or other secrets inside a recipe document
+   (see spec section 8.1); recipes are expected to be committed to version
+   control.
+
+No CLI subcommand is exposed for this experiment yet. The reference validator
+is `agent_recipe::validate_document` in `src/lib.rs`, callable from Rust:
+
+```rust
+let diagnostics = agent_recipe::validate_document(yaml_text);
+if diagnostics.has_errors() {
+    // report diagnostics
+}
+```
+

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/docs/00_overview.md
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/docs/00_overview.md
@@ -1,0 +1,79 @@
+# Agent Recipe Standard - Overview
+
+## What is this?
+
+**EXP-V1-0003** defines a declarative, harness-neutral schema for an **agent recipe**: a YAML document describing *what agent to run* (which harness, which model, which skills, which system instructions) without any knowledge of *where* or *how* it executes.
+
+## Why does it matter?
+
+As agent orchestration spreads across multiple harnesses (Claude Code, Codex, and others to come), tooling needs a stable, harness-neutral way to say "run this agent, configured this way" that does not hard-code any one harness's flags or SDK shape. This standard provides:
+
+1. **A single schema** - the same recipe document works whether the consumer targets Claude Code or Codex.
+2. **Forward compatibility** - the `agent` enum is designed to grow (`opencode`, `gemini`, ...) without breaking existing recipes.
+3. **Separation of concerns** - a recipe never contains task input, credentials, or infrastructure details, so it is safe to commit and diff.
+
+## Quick Example
+
+```yaml
+name: pr-reviewer
+agent: claude
+model:
+  name: anthropic/claude-opus-4-8
+  effort: high
+skills:
+  - code-review
+  - security-review
+system_instructions:
+  mode: append
+  content: |
+    Focus exclusively on correctness and security issues.
+```
+
+## Key Fields
+
+| Field | Purpose |
+|-------|---------|
+| `name` | Identifier for the recipe |
+| `agent` | Which harness runs it (`claude` \| `codex` in v1) |
+| `model.name` | Provider-qualified model id |
+| `model.effort` | Coarse reasoning effort: `low` \| `medium` \| `high` |
+| `skills` | Harness-agnostic skill references to inject |
+| `system_instructions` | Optional append/replace system prompt text |
+
+## Where a Recipe Fits
+
+A recipe is the core of a larger execution request (informative, not part of this standard):
+
+```
+RunSpec = recipe + task + input_artifacts + credentials + observability + limits
+```
+
+A workspace (an executor living in another repository) consumes a `RunSpec` and produces a `RunResult`. This standard defines only `recipe`.
+
+## Status
+
+**Experimental** - This standard is in incubation. Feedback welcome!
+
+### What's Working
+
+- Schema defined (`docs/01_spec.md`)
+- Rust reference types with serde (de)serialization
+- Validation producing structured `Diagnostics` with stable error codes
+- Example recipes (valid and invalid) for conformance testing
+
+### Next Steps
+
+1. Gather feedback from consumers in other repositories (e.g. workspace executors)
+2. Add JSON Schema artifact generation for editor tooling
+3. Define the full `RunSpec` envelope as a follow-on standard once a real consumer exists
+4. Iterate toward promotion
+
+## Learn More
+
+- Read the [full specification](./01_spec.md)
+- Check out [examples](../examples/)
+- See [agent skills](../agents/skills/)
+
+---
+
+*This is an experimental standard. It may change significantly before promotion to official status.*

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/docs/01_spec.md
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/docs/01_spec.md
@@ -65,7 +65,7 @@ An **agent recipe** (or **recipe**) is a declarative document that identifies wh
 
 ### 2.2 Harness
 
-A **harness** is the underlying agent CLI or SDK that executes the recipe (for example, Claude Code or OpenAI Codex CLI). The recipe schema is harness-neutral: the `agent` field is an open, extensible enumeration so additional harnesses (e.g. `opencode`, `gemini`) MAY be added in future minor versions without breaking existing recipes.
+A **harness** is the underlying agent CLI or SDK that executes the recipe (for example, Claude Code or OpenAI Codex CLI). The recipe schema is harness-neutral: the `agent` field is a closed enumeration within any single version of this standard, but is version-extensible, so additional harnesses (e.g. `opencode`, `gemini`) MAY be added in future minor versions without breaking existing recipes.
 
 ### 2.3 Skill Reference
 

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/docs/01_spec.md
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/docs/01_spec.md
@@ -1,0 +1,251 @@
+# EXP-V1-0003 - Agent Recipe Standard (Experimental Specification)
+
+**Version**: 0.1.0
+**Status**: Experimental
+**Category**: technical
+
+⚠️ **EXPERIMENTAL**: This standard is in incubation and may change significantly before promotion.
+
+---
+
+## Terminology
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+---
+
+## 1. Scope and Authority
+
+### 1.1 Purpose
+
+This standard defines a **declarative, harness-neutral schema for an agent recipe**: a description of *what agent to run*, independent of *where* or *how* it is executed. A recipe answers "which harness, which model, which skills, which system instructions" without any knowledge of workspace provisioning, task input, credentials, or observability wiring.
+
+The schema is adopted from the `pi.recipes` shape used in earlier internal tooling and generalized so it is not tied to any single harness.
+
+### 1.2 Scope
+
+This standard covers:
+
+- **The recipe document schema** - required and optional fields, their types, and their allowed values.
+- **Harness-neutrality rules** - how the `agent` field is extended to support additional harnesses over time without breaking existing recipes.
+- **Validation rules** - what makes a recipe document valid or invalid.
+- **Serialization format** - YAML as the canonical on-disk format, with a JSON-compatible in-memory model.
+
+This standard does NOT cover:
+
+- **Workspace or executor behavior.** A recipe is a pure data document. The component that consumes a recipe and actually runs an agent (a "workspace" or equivalent executor) is out of scope for this standard. See section 1.4 for the consumer contract this standard exists to support.
+- **Task input, input artifacts, credentials, observability, or execution limits.** These are sibling concerns that combine with a recipe to form a larger execution request (a `RunSpec`, informative only, see 1.4).
+- **Skill content or system instruction authoring guidance.** This standard defines how skill references and system instructions are *represented* in a recipe, not how skills or instructions should be authored.
+- **Per-harness configuration details** (for example, provider-specific API parameters). Those live in harness adapters that consume the recipe, not in the recipe itself.
+
+### 1.3 Relationship to Other Standards
+
+This standard is independent but is designed so that:
+
+- **CI/CD substandards** can validate committed recipe files as part of a pipeline.
+- **Consumer SDKs** (e.g. workspace executors in other repositories) can depend on this schema as their input contract without depending on any harness-specific code.
+
+### 1.4 Informative: Consumer Contract
+
+A recipe is designed to be the core of a larger execution request, informally:
+
+```text
+RunSpec = recipe + task + input_artifacts + credentials + observability + limits
+```
+
+A workspace (an executor living outside this repository) consumes a `RunSpec`, provisions an isolated environment, runs the harness named by `recipe.agent` configured per the recipe, and produces a `RunResult`. None of `task`, `input_artifacts`, `credentials`, `observability`, or `limits` are defined by this standard; they are noted here only so implementors understand where the recipe schema fits. This standard defines `recipe` alone.
+
+---
+
+## 2. Core Definitions
+
+### 2.1 Recipe
+
+An **agent recipe** (or **recipe**) is a declarative document that identifies which harness to run, which model and reasoning effort to configure it with, which skills to inject, and what system instructions to apply. A recipe MUST NOT contain task-specific input, credentials, or infrastructure configuration.
+
+### 2.2 Harness
+
+A **harness** is the underlying agent CLI or SDK that executes the recipe (for example, Claude Code or OpenAI Codex CLI). The recipe schema is harness-neutral: the `agent` field is an open, extensible enumeration so additional harnesses (e.g. `opencode`, `gemini`) MAY be added in future minor versions without breaking existing recipes.
+
+### 2.3 Skill Reference
+
+A **skill reference** is a harness-agnostic string identifier for a reusable capability to inject into the agent's context (for example a Claude Code skill name, or an equivalent construct in another harness). This standard treats skill references as opaque strings; resolving a skill reference to actual content is the consumer's responsibility.
+
+### 2.4 System Instructions
+
+**System instructions** are natural-language text to be applied to the agent's system/instructions channel, combined with the harness's own default system prompt according to a declared `mode`.
+
+---
+
+## 3. Recipe Schema
+
+### 3.1 Canonical Format
+
+The canonical on-disk format is YAML. A recipe document MUST be a single YAML mapping (object) at the document root, with the following shape:
+
+```yaml
+name: <recipe-name>              # identifier
+agent: claude | codex            # which harness (v1: claude|codex; extensible)
+model:
+  name: <provider/model>         # e.g. anthropic/claude-opus-4-8
+  effort: low | medium | high    # maps to thinking_level / reasoning effort
+skills:                          # harness-agnostic skill refs to inject
+  - <skill-ref>
+system_instructions:
+  mode: append | replace
+  content: |
+    <text>
+```
+
+### 3.2 Field Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | YES | Identifier for the recipe. MUST be non-empty. RECOMMENDED to be kebab-case. |
+| `agent` | enum string | YES | Which harness runs this recipe. v1 values: `claude`, `codex`. See 3.3 for extensibility. |
+| `model` | object | YES | Model selection. See 3.4. |
+| `model.name` | string | YES | Provider-qualified model identifier (e.g. `anthropic/claude-opus-4-8`). MUST be non-empty. This standard does NOT validate that the named model exists; that is a harness/provider concern. |
+| `model.effort` | enum string | YES | Reasoning/thinking effort level: `low`, `medium`, or `high`. Maps to harness-specific concepts such as `thinking_level` (Claude) or reasoning effort (Codex). |
+| `skills` | array[string] | NO | Harness-agnostic skill references to inject into the agent's context. Defaults to an empty array when omitted. Each entry MUST be a non-empty string. |
+| `system_instructions` | object | NO | Additional system instructions. Omit entirely if the harness default system prompt is sufficient. |
+| `system_instructions.mode` | enum string | REQUIRED if `system_instructions` present | `append` to add `content` after the harness's default system prompt, or `replace` to use `content` in place of it. |
+| `system_instructions.content` | string | REQUIRED if `system_instructions` present | The instruction text. MUST be non-empty. |
+
+### 3.3 The `agent` Field and Harness Extensibility
+
+`agent` is a closed enumeration in this version of the standard, with values `claude` and `codex`. The standard is explicitly designed for this set to grow (for example `opencode`, `gemini`) in future MINOR versions of this experimental standard, without requiring existing recipes to change. Consumers MUST reject a recipe whose `agent` value is not recognized, using error code `AGENT_RECIPE_UNKNOWN_AGENT` (see section 5), rather than silently ignoring or coercing it.
+
+### 3.4 The `model` Object
+
+`model.name` is an opaque, provider-qualified string. This standard RECOMMENDS the `<provider>/<model>` shape (e.g. `anthropic/claude-opus-4-8`, `openai/gpt-5-codex`) but does not enforce a specific provider list, since new models and providers are added independently of this standard's release cycle.
+
+`model.effort` MUST be one of `low`, `medium`, or `high`. These three levels are intentionally coarse so they map cleanly across harnesses that expose different granularities of reasoning effort (for example Claude's `thinking_level` and Codex's `reasoning effort`); a harness adapter is responsible for translating the coarse level into its own native parameter.
+
+### 3.5 Skills
+
+`skills` is an ordered list of skill references. Order MAY be meaningful to a consumer (for example, injection order) but this standard does not mandate any particular consumer behavior beyond preserving the order given. An empty or omitted `skills` list means no skills are injected.
+
+### 3.6 System Instructions
+
+When `system_instructions` is present:
+
+- `mode: append` MUST cause the harness's own default system prompt (if any) to be used first, with `content` appended after it.
+- `mode: replace` MUST cause `content` to be used in place of the harness's default system prompt.
+
+When `system_instructions` is omitted, the harness's default system prompt MUST be used unmodified.
+
+---
+
+## 4. Serialization and Encoding
+
+### 4.1 File Extension and Encoding
+
+Recipe documents SHOULD be stored with a `.yaml` or `.yml` extension, UTF-8 encoded, and SHOULD end with a trailing newline.
+
+### 4.2 Unknown Fields
+
+A conforming validator MUST reject unrecognized top-level or nested fields with error code `AGENT_RECIPE_UNKNOWN_FIELD` rather than silently ignoring them, so that typos and drift from future schema versions are caught early. (See `examples/invalid/unknown-field.yaml`.)
+
+### 4.3 Round-Tripping
+
+A conforming implementation MUST be able to deserialize a valid recipe document and re-serialize it to an equivalent YAML document without loss of information (field values MUST be preserved; field order and formatting MAY differ).
+
+---
+
+## 5. Validation Rules and Error Codes
+
+A recipe document is **valid** if and only if all of the following hold. Each rule references the machine-readable error code a conforming validator MUST emit on violation.
+
+| Rule | Error Code | Severity |
+|------|-----------|----------|
+| `name` is present and non-empty | `AGENT_RECIPE_MISSING_NAME` | error |
+| `agent` is present | `AGENT_RECIPE_MISSING_AGENT` | error |
+| `agent` is one of the recognized values (3.3) | `AGENT_RECIPE_UNKNOWN_AGENT` | error |
+| `model` is present | `AGENT_RECIPE_MISSING_MODEL` | error |
+| `model.name` is present and non-empty | `AGENT_RECIPE_MISSING_MODEL_NAME` | error |
+| `model.effort` is present and is one of `low`/`medium`/`high` | `AGENT_RECIPE_INVALID_MODEL_EFFORT` | error |
+| Each entry in `skills` (if present) is a non-empty string | `AGENT_RECIPE_INVALID_SKILL_REF` | error |
+| If `system_instructions` is present, `mode` is one of `append`/`replace` | `AGENT_RECIPE_INVALID_INSTRUCTIONS_MODE` | error |
+| If `system_instructions` is present, `content` is non-empty | `AGENT_RECIPE_EMPTY_INSTRUCTIONS_CONTENT` | error |
+| No unrecognized fields are present anywhere in the document | `AGENT_RECIPE_UNKNOWN_FIELD` | error |
+
+A validator MUST collect and report all applicable violations rather than stopping at the first one, matching this repository's `Diagnostics` convention.
+
+---
+
+## 6. Compliance Checklist
+
+A recipe document is **compliant** with this standard if:
+
+- [ ] It parses as a single YAML mapping at the document root.
+- [ ] All required fields (`name`, `agent`, `model.name`, `model.effort`) are present.
+- [ ] `agent` is a recognized harness value.
+- [ ] `model.effort` is one of `low`, `medium`, `high`.
+- [ ] `skills`, if present, contains only non-empty string entries.
+- [ ] `system_instructions`, if present, has a valid `mode` and non-empty `content`.
+- [ ] No unrecognized fields are present.
+
+---
+
+## 7. Future Extensions
+
+Potential future additions (not in v0.1.0), to be pursued only after this experiment gathers feedback:
+
+- Additional `agent` values (`opencode`, `gemini`, others) as those harnesses gain first-class support.
+- A substandard defining the full `RunSpec` envelope (`recipe` + `task` + `input_artifacts` + `credentials` + `observability` + `limits`) referenced informatively in 1.4.
+- Recipe inheritance / composition (`extends: <recipe-name>`).
+- Per-skill configuration parameters, if injected skills need arguments beyond a bare reference.
+- JSON Schema artifact generation for editor tooling and IDE autocompletion.
+
+---
+
+## 8. Security Considerations
+
+### 8.1 No Credentials in Recipes
+
+Recipe documents MUST NOT contain credentials, tokens, or other secrets. Recipes are expected to be committed to version control; secret material belongs in the `credentials` component of a `RunSpec` (informative, see 1.4), not in the recipe.
+
+### 8.2 System Instruction Content
+
+`system_instructions.content` is free-form text that becomes part of the agent's effective system prompt. Consumers SHOULD treat recipe sources with the same trust level as other executable configuration (for example, CI workflow files): a recipe from an untrusted source can materially change agent behavior via `mode: replace` or injected `skills`.
+
+---
+
+## 9. References
+
+- [RFC 2119: Key words for use in RFCs](https://datatracker.ietf.org/doc/html/rfc2119)
+- [Semantic Versioning](https://semver.org/)
+
+---
+
+## Appendix A: Complete Example
+
+```yaml
+name: pr-reviewer
+agent: claude
+model:
+  name: anthropic/claude-opus-4-8
+  effort: high
+skills:
+  - code-review
+  - security-review
+system_instructions:
+  mode: append
+  content: |
+    Focus exclusively on correctness and security issues.
+    Do not comment on style unless it affects readability of a security-relevant path.
+```
+
+## Appendix B: Minimal Example
+
+```yaml
+name: quick-fix
+agent: codex
+model:
+  name: openai/gpt-5-codex
+  effort: low
+```
+
+---
+
+*End of Specification*

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/README.md
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/README.md
@@ -1,0 +1,27 @@
+# Agent Recipe Standard Examples
+
+This directory contains examples demonstrating the experimental standard, and is
+loaded directly by the crate's tests via `include_str!`.
+
+## Available Examples
+
+| Example | Description |
+|---------|-------------|
+| `valid/full.yaml` | All fields populated: skills and a system instruction override |
+| `valid/minimal.yaml` | Only the required fields: `name`, `agent`, `model.name`, `model.effort` |
+| `invalid/missing-required-fields.yaml` | Missing `agent` and `model`, empty `name` |
+| `invalid/unknown-agent.yaml` | `agent: gemini`, not a recognized v1 harness |
+| `invalid/unknown-field.yaml` | A field (`temperature`) not part of the schema |
+| `invalid/invalid-effort-and-mode.yaml` | Bad `model.effort` and `system_instructions.mode` values |
+
+Each invalid example documents, in a leading comment, which error code(s) it is
+expected to trigger.
+
+## Purpose
+
+Examples in experiments serve to:
+1. Demonstrate proposed patterns
+2. Gather feedback from users
+3. Validate the approach before promotion
+4. Exercise the validator's error-code coverage in automated tests
+

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/invalid/invalid-effort-and-mode.yaml
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/invalid/invalid-effort-and-mode.yaml
@@ -1,0 +1,11 @@
+# Invalid: `model.effort` is not one of low/medium/high, and
+# `system_instructions.mode` is not one of append/replace.
+# Expect: AGENT_RECIPE_INVALID_MODEL_EFFORT, AGENT_RECIPE_INVALID_INSTRUCTIONS_MODE
+name: bad-recipe
+agent: claude
+model:
+  name: anthropic/claude-opus-4-8
+  effort: extreme
+system_instructions:
+  mode: overwrite
+  content: "do the thing"

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/invalid/missing-required-fields.yaml
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/invalid/missing-required-fields.yaml
@@ -1,0 +1,3 @@
+# Invalid: missing `agent` and `model` entirely, and `name` is empty.
+# Expect: AGENT_RECIPE_MISSING_NAME, AGENT_RECIPE_MISSING_AGENT, AGENT_RECIPE_MISSING_MODEL
+name: ""

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/invalid/non-string-key.yaml
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/invalid/non-string-key.yaml
@@ -1,0 +1,10 @@
+# Invalid: a non-string mapping key (`1`) is not a recognized schema field.
+# All required fields are present and valid, so this guards against the
+# validator silently accepting a stray non-string key.
+# Expect: AGENT_RECIPE_UNKNOWN_FIELD
+name: bad-recipe
+agent: claude
+model:
+  name: anthropic/claude-opus-4-8
+  effort: high
+1: stray-value

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/invalid/unknown-agent.yaml
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/invalid/unknown-agent.yaml
@@ -1,0 +1,7 @@
+# Invalid: `agent` is not one of the recognized v1 harness values.
+# Expect: AGENT_RECIPE_UNKNOWN_AGENT
+name: bad-recipe
+agent: gemini
+model:
+  name: google/gemini-3-pro
+  effort: medium

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/invalid/unknown-field.yaml
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/invalid/unknown-field.yaml
@@ -1,0 +1,8 @@
+# Invalid: `temperature` is not part of the recipe schema.
+# Expect: AGENT_RECIPE_UNKNOWN_FIELD
+name: bad-recipe
+agent: claude
+model:
+  name: anthropic/claude-opus-4-8
+  effort: high
+temperature: 0.7

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/valid/full.yaml
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/valid/full.yaml
@@ -1,0 +1,13 @@
+name: pr-reviewer
+agent: claude
+model:
+  name: anthropic/claude-opus-4-8
+  effort: high
+skills:
+  - code-review
+  - security-review
+system_instructions:
+  mode: append
+  content: |
+    Focus exclusively on correctness and security issues.
+    Do not comment on style unless it affects readability of a security-relevant path.

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/valid/minimal.yaml
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/examples/valid/minimal.yaml
@@ -1,0 +1,5 @@
+name: quick-fix
+agent: codex
+model:
+  name: openai/gpt-5-codex
+  effort: low

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/experiment.toml
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/experiment.toml
@@ -1,0 +1,21 @@
+schema = "aps.experiment/v1"
+
+[experiment]
+id = "EXP-V1-0003"
+name = "Agent Recipe Standard"
+slug = "agent-recipe"
+version = "0.1.0"
+category = "technical"
+backwards_compat = true  # Set to false when introducing breaking changes
+
+[aps]
+aps_major = "v1"
+
+[ownership]
+maintainers = ["AgentParadise"]
+
+# Promotion metadata (added after promotion, do not edit manually)
+# [promotion]
+# promoted_to = "APS-V1-XXXX"
+# promoted_at = "YYYY-MM-DD"
+

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/src/lib.rs
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/src/lib.rs
@@ -408,7 +408,18 @@ fn check_unknown_keys(
     diagnostics: &mut Diagnostics,
 ) {
     for key in mapping.keys() {
-        let Some(key) = key.as_str() else { continue };
+        let Some(key) = key.as_str() else {
+            // A non-string key (e.g. `1: value`) can never be a recognized
+            // schema field, so it is reported rather than silently skipped.
+            diagnostics.push(
+                Diagnostic::error(
+                    error_codes::UNKNOWN_FIELD,
+                    format!("`{prefix}<non-string key>` is not a recognized field"),
+                )
+                .with_hint(format!("recognized fields: {}", allowed.join(", "))),
+            );
+            continue;
+        };
         if !allowed.contains(&key) {
             diagnostics.push(
                 Diagnostic::error(
@@ -497,6 +508,16 @@ mod tests {
     fn unknown_top_level_field_is_rejected() {
         let yaml = "name: x\nagent: claude\nmodel:\n  name: foo\n  effort: low\nnotarealfield: 1\n";
         let diagnostics = validate_document(yaml);
+        let codes: Vec<&str> = diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(codes.contains(&error_codes::UNKNOWN_FIELD));
+    }
+
+    #[test]
+    fn non_string_key_is_rejected() {
+        // Required fields are all valid; the only problem is a non-string key.
+        let yaml = "name: x\nagent: claude\nmodel:\n  name: foo\n  effort: low\n1: stray\n";
+        let diagnostics = validate_document(yaml);
+        assert!(diagnostics.has_errors());
         let codes: Vec<&str> = diagnostics.iter().map(|d| d.code.as_str()).collect();
         assert!(codes.contains(&error_codes::UNKNOWN_FIELD));
     }

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/src/lib.rs
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/src/lib.rs
@@ -1,0 +1,544 @@
+//! Agent Recipe Standard (Experimental)
+//!
+//! This crate is the reference implementation of **EXP-V1-0003**, a declarative,
+//! harness-neutral schema for an "agent recipe": a description of *what agent to
+//! run* (harness, model, reasoning effort, skills, system instructions),
+//! independent of *where* or *how* it is executed.
+//!
+//! See `docs/01_spec.md` for the normative specification. This module provides:
+//!
+//! - Typed Rust structures for the recipe schema ([`Recipe`], [`ModelSpec`],
+//!   [`SystemInstructions`], [`AgentKind`], [`EffortLevel`], [`InstructionMode`]).
+//! - A validator ([`validate_document`]) that checks a raw YAML document against
+//!   every rule in spec section 5 and reports *all* violations at once via
+//!   [`apss_core::Diagnostics`], rather than failing fast on the first one.
+//! - A convenience loader ([`Recipe::from_yaml_str`]) for the common case of
+//!   "parse a known-good recipe".
+//!
+//! ⚠️ EXPERIMENTAL: This standard is in incubation and may change significantly.
+
+use apss_core::{Diagnostic, Diagnostics};
+use serde::{Deserialize, Serialize};
+
+/// Register this package with a composed APSS runner.
+///
+/// No composed CLI commands are exposed yet: this experiment's surface area
+/// is the [`validate_document`] library function, consumed directly by Rust
+/// callers (see `agents/skills/README.md`). A CLI subcommand (e.g. `aps
+/// agent-recipe validate <file>`) is a natural follow-up once this schema has
+/// a real consumer.
+pub fn register(registry: &mut dyn apss_core::registry::StandardRegistry) {
+    registry.register(
+        apss_core::registry::RegisteredStandard {
+            id: "EXP-V1-0003".to_string(),
+            slug: "agent-recipe".to_string(),
+            name: "Agent Recipe Standard".to_string(),
+            description: "Harness-neutral agent recipe schema experiment".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            commands: Vec::new(),
+        },
+        Box::new(NoopCommandHandler),
+    );
+}
+
+struct NoopCommandHandler;
+
+impl apss_core::registry::CommandHandler for NoopCommandHandler {
+    fn execute(&self, _command: &str, _args: &[String], _config: &toml::Value) -> i32 {
+        eprintln!("No composed CLI commands are registered for agent-recipe yet.");
+        5
+    }
+
+    fn commands(&self) -> Vec<apss_core::registry::CommandInfo> {
+        Vec::new()
+    }
+}
+
+/// Machine-readable error codes emitted by [`validate_document`].
+///
+/// These correspond one-to-one with the rules in `docs/01_spec.md` section 5.
+pub mod error_codes {
+    /// `name` is missing or empty.
+    pub const MISSING_NAME: &str = "AGENT_RECIPE_MISSING_NAME";
+    /// `agent` is missing.
+    pub const MISSING_AGENT: &str = "AGENT_RECIPE_MISSING_AGENT";
+    /// `agent` is present but not a recognized harness value.
+    pub const UNKNOWN_AGENT: &str = "AGENT_RECIPE_UNKNOWN_AGENT";
+    /// `model` is missing.
+    pub const MISSING_MODEL: &str = "AGENT_RECIPE_MISSING_MODEL";
+    /// `model.name` is missing or empty.
+    pub const MISSING_MODEL_NAME: &str = "AGENT_RECIPE_MISSING_MODEL_NAME";
+    /// `model.effort` is missing or not one of `low`/`medium`/`high`.
+    pub const INVALID_MODEL_EFFORT: &str = "AGENT_RECIPE_INVALID_MODEL_EFFORT";
+    /// A `skills` entry is not a non-empty string.
+    pub const INVALID_SKILL_REF: &str = "AGENT_RECIPE_INVALID_SKILL_REF";
+    /// `system_instructions.mode` is not one of `append`/`replace`.
+    pub const INVALID_INSTRUCTIONS_MODE: &str = "AGENT_RECIPE_INVALID_INSTRUCTIONS_MODE";
+    /// `system_instructions.content` is missing or empty.
+    pub const EMPTY_INSTRUCTIONS_CONTENT: &str = "AGENT_RECIPE_EMPTY_INSTRUCTIONS_CONTENT";
+    /// A field was present that is not part of the schema.
+    pub const UNKNOWN_FIELD: &str = "AGENT_RECIPE_UNKNOWN_FIELD";
+    /// The document did not parse as YAML at all, or was not a mapping.
+    pub const MALFORMED_DOCUMENT: &str = "AGENT_RECIPE_MALFORMED_DOCUMENT";
+}
+
+/// Which harness executes the recipe.
+///
+/// This is intentionally a closed enum in v1. Per spec section 3.3, future
+/// MINOR versions of this standard MAY add variants (e.g. `opencode`,
+/// `gemini`) without breaking existing recipes; consumers on an older version
+/// of this crate will report `AGENT_RECIPE_UNKNOWN_AGENT` for values they do
+/// not yet recognize rather than silently accepting them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentKind {
+    /// Claude Code.
+    Claude,
+    /// OpenAI Codex CLI.
+    Codex,
+}
+
+impl AgentKind {
+    /// Parse a raw string into a known [`AgentKind`], if recognized.
+    pub fn from_str_opt(value: &str) -> Option<Self> {
+        match value {
+            "claude" => Some(Self::Claude),
+            "codex" => Some(Self::Codex),
+            _ => None,
+        }
+    }
+}
+
+/// Coarse reasoning/thinking effort level.
+///
+/// Maps to harness-specific concepts such as `thinking_level` (Claude) or
+/// reasoning effort (Codex). See spec section 3.4.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EffortLevel {
+    Low,
+    Medium,
+    High,
+}
+
+impl EffortLevel {
+    /// Parse a raw string into a known [`EffortLevel`], if recognized.
+    pub fn from_str_opt(value: &str) -> Option<Self> {
+        match value {
+            "low" => Some(Self::Low),
+            "medium" => Some(Self::Medium),
+            "high" => Some(Self::High),
+            _ => None,
+        }
+    }
+}
+
+/// How `system_instructions.content` combines with the harness's default
+/// system prompt. See spec section 3.6.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InstructionMode {
+    /// Add `content` after the harness's default system prompt.
+    Append,
+    /// Use `content` in place of the harness's default system prompt.
+    Replace,
+}
+
+impl InstructionMode {
+    /// Parse a raw string into a known [`InstructionMode`], if recognized.
+    pub fn from_str_opt(value: &str) -> Option<Self> {
+        match value {
+            "append" => Some(Self::Append),
+            "replace" => Some(Self::Replace),
+            _ => None,
+        }
+    }
+}
+
+/// Model selection: `model.name` and `model.effort` (spec section 3.4).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelSpec {
+    /// Provider-qualified model identifier, e.g. `anthropic/claude-opus-4-8`.
+    pub name: String,
+    /// Coarse reasoning effort level.
+    pub effort: EffortLevel,
+}
+
+/// Optional system instruction override (spec section 3.6).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SystemInstructions {
+    /// Whether `content` appends to or replaces the harness default.
+    pub mode: InstructionMode,
+    /// The instruction text.
+    pub content: String,
+}
+
+/// A validated agent recipe document (spec section 3).
+///
+/// This type intentionally mirrors the YAML schema exactly: it is the
+/// consumer-facing contract, not an internal representation. See
+/// `docs/01_spec.md` for field-by-field semantics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Recipe {
+    /// Identifier for the recipe.
+    pub name: String,
+    /// Which harness runs this recipe.
+    pub agent: AgentKind,
+    /// Model selection.
+    pub model: ModelSpec,
+    /// Harness-agnostic skill references to inject. Defaults to empty.
+    #[serde(default)]
+    pub skills: Vec<String>,
+    /// Optional system instruction override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_instructions: Option<SystemInstructions>,
+}
+
+/// Error produced while loading a recipe from YAML text.
+#[derive(Debug, thiserror::Error)]
+pub enum RecipeError {
+    /// The document was not well-formed YAML matching the recipe schema.
+    #[error("failed to parse recipe YAML: {0}")]
+    Parse(#[from] serde_yaml::Error),
+}
+
+impl Recipe {
+    /// Deserialize a recipe directly from YAML text.
+    ///
+    /// This is the fast, typed path for a document already known to be
+    /// valid (for example, after [`validate_document`] reported no errors).
+    /// It does not perform the full rule-by-rule validation in section 5 of
+    /// the spec, and will simply fail on the first structural problem via
+    /// [`RecipeError::Parse`]. Callers that need a complete list of
+    /// violations (e.g. a linter or CI check) should use
+    /// [`validate_document`] instead.
+    pub fn from_yaml_str(yaml: &str) -> Result<Self, RecipeError> {
+        Ok(serde_yaml::from_str(yaml)?)
+    }
+
+    /// Serialize this recipe back to a YAML string.
+    pub fn to_yaml_string(&self) -> Result<String, RecipeError> {
+        Ok(serde_yaml::to_string(self)?)
+    }
+}
+
+/// The full set of top-level and nested field names recognized by the schema.
+mod known_fields {
+    pub const TOP_LEVEL: &[&str] = &["name", "agent", "model", "skills", "system_instructions"];
+    pub const MODEL: &[&str] = &["name", "effort"];
+    pub const SYSTEM_INSTRUCTIONS: &[&str] = &["mode", "content"];
+}
+
+/// Validate a raw recipe YAML document against every rule in spec section 5,
+/// collecting *all* violations rather than stopping at the first one.
+///
+/// Returns an empty [`Diagnostics`] if and only if the document is fully
+/// compliant with the standard.
+pub fn validate_document(yaml: &str) -> Diagnostics {
+    let mut diagnostics = Diagnostics::new();
+
+    let value: serde_yaml::Value = match serde_yaml::from_str(yaml) {
+        Ok(value) => value,
+        Err(err) => {
+            diagnostics.push(Diagnostic::error(
+                error_codes::MALFORMED_DOCUMENT,
+                format!("recipe document is not valid YAML: {err}"),
+            ));
+            return diagnostics;
+        }
+    };
+
+    let Some(root) = value.as_mapping() else {
+        diagnostics.push(
+            Diagnostic::error(
+                error_codes::MALFORMED_DOCUMENT,
+                "recipe document must be a YAML mapping at the root",
+            )
+            .with_hint("wrap the recipe fields in a single top-level mapping"),
+        );
+        return diagnostics;
+    };
+
+    check_unknown_keys(root, known_fields::TOP_LEVEL, "", &mut diagnostics);
+
+    // name
+    match root.get("name").and_then(|v| v.as_str()) {
+        Some(name) if !name.trim().is_empty() => {}
+        _ => diagnostics.push(Diagnostic::error(
+            error_codes::MISSING_NAME,
+            "`name` must be present and non-empty",
+        )),
+    }
+
+    // agent
+    match root.get("agent") {
+        None => diagnostics.push(Diagnostic::error(
+            error_codes::MISSING_AGENT,
+            "`agent` is required",
+        )),
+        Some(value) => match value.as_str() {
+            Some(raw) if AgentKind::from_str_opt(raw).is_some() => {}
+            Some(raw) => diagnostics.push(
+                Diagnostic::error(
+                    error_codes::UNKNOWN_AGENT,
+                    format!("`agent: {raw}` is not a recognized harness"),
+                )
+                .with_hint("use one of: claude, codex"),
+            ),
+            None => diagnostics.push(Diagnostic::error(
+                error_codes::UNKNOWN_AGENT,
+                "`agent` must be a string",
+            )),
+        },
+    }
+
+    // model
+    match root.get("model").and_then(|v| v.as_mapping()) {
+        None => {
+            if root.get("model").is_some() {
+                diagnostics.push(Diagnostic::error(
+                    error_codes::MISSING_MODEL,
+                    "`model` must be a mapping",
+                ));
+            } else {
+                diagnostics.push(Diagnostic::error(
+                    error_codes::MISSING_MODEL,
+                    "`model` is required",
+                ));
+            }
+        }
+        Some(model) => {
+            check_unknown_keys(model, known_fields::MODEL, "model.", &mut diagnostics);
+
+            match model.get("name").and_then(|v| v.as_str()) {
+                Some(name) if !name.trim().is_empty() => {}
+                _ => diagnostics.push(Diagnostic::error(
+                    error_codes::MISSING_MODEL_NAME,
+                    "`model.name` must be present and non-empty",
+                )),
+            }
+
+            match model.get("effort").and_then(|v| v.as_str()) {
+                Some(raw) if EffortLevel::from_str_opt(raw).is_some() => {}
+                Some(raw) => diagnostics.push(
+                    Diagnostic::error(
+                        error_codes::INVALID_MODEL_EFFORT,
+                        format!("`model.effort: {raw}` is not a recognized effort level"),
+                    )
+                    .with_hint("use one of: low, medium, high"),
+                ),
+                None => diagnostics.push(Diagnostic::error(
+                    error_codes::INVALID_MODEL_EFFORT,
+                    "`model.effort` must be one of: low, medium, high",
+                )),
+            }
+        }
+    }
+
+    // skills
+    if let Some(skills) = root.get("skills") {
+        match skills.as_sequence() {
+            Some(items) => {
+                for (index, item) in items.iter().enumerate() {
+                    let valid = item.as_str().is_some_and(|s| !s.trim().is_empty());
+                    if !valid {
+                        diagnostics.push(Diagnostic::error(
+                            error_codes::INVALID_SKILL_REF,
+                            format!("`skills[{index}]` must be a non-empty string"),
+                        ));
+                    }
+                }
+            }
+            None => diagnostics.push(Diagnostic::error(
+                error_codes::INVALID_SKILL_REF,
+                "`skills` must be an array of strings",
+            )),
+        }
+    }
+
+    // system_instructions
+    if let Some(instructions) = root.get("system_instructions") {
+        match instructions.as_mapping() {
+            Some(instructions) => {
+                check_unknown_keys(
+                    instructions,
+                    known_fields::SYSTEM_INSTRUCTIONS,
+                    "system_instructions.",
+                    &mut diagnostics,
+                );
+
+                match instructions.get("mode").and_then(|v| v.as_str()) {
+                    Some(raw) if InstructionMode::from_str_opt(raw).is_some() => {}
+                    Some(raw) => diagnostics.push(
+                        Diagnostic::error(
+                            error_codes::INVALID_INSTRUCTIONS_MODE,
+                            format!("`system_instructions.mode: {raw}` is not recognized"),
+                        )
+                        .with_hint("use one of: append, replace"),
+                    ),
+                    None => diagnostics.push(Diagnostic::error(
+                        error_codes::INVALID_INSTRUCTIONS_MODE,
+                        "`system_instructions.mode` must be one of: append, replace",
+                    )),
+                }
+
+                match instructions.get("content").and_then(|v| v.as_str()) {
+                    Some(content) if !content.trim().is_empty() => {}
+                    _ => diagnostics.push(Diagnostic::error(
+                        error_codes::EMPTY_INSTRUCTIONS_CONTENT,
+                        "`system_instructions.content` must be present and non-empty",
+                    )),
+                }
+            }
+            None => diagnostics.push(Diagnostic::error(
+                error_codes::MALFORMED_DOCUMENT,
+                "`system_instructions` must be a mapping",
+            )),
+        }
+    }
+
+    diagnostics
+}
+
+/// Report `AGENT_RECIPE_UNKNOWN_FIELD` for any mapping key not in `allowed`.
+fn check_unknown_keys(
+    mapping: &serde_yaml::Mapping,
+    allowed: &[&str],
+    prefix: &str,
+    diagnostics: &mut Diagnostics,
+) {
+    for key in mapping.keys() {
+        let Some(key) = key.as_str() else { continue };
+        if !allowed.contains(&key) {
+            diagnostics.push(
+                Diagnostic::error(
+                    error_codes::UNKNOWN_FIELD,
+                    format!("`{prefix}{key}` is not a recognized field"),
+                )
+                .with_hint(format!("recognized fields: {}", allowed.join(", "))),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_FULL: &str = include_str!("../examples/valid/full.yaml");
+    const VALID_MINIMAL: &str = include_str!("../examples/valid/minimal.yaml");
+
+    #[test]
+    fn valid_full_recipe_has_no_diagnostics() {
+        let diagnostics = validate_document(VALID_FULL);
+        assert!(
+            !diagnostics.has_errors(),
+            "expected no errors, got: {diagnostics:?}"
+        );
+
+        let recipe = Recipe::from_yaml_str(VALID_FULL).expect("should parse");
+        assert_eq!(recipe.name, "pr-reviewer");
+        assert_eq!(recipe.agent, AgentKind::Claude);
+        assert_eq!(recipe.model.effort, EffortLevel::High);
+        assert_eq!(recipe.skills, vec!["code-review", "security-review"]);
+        assert!(recipe.system_instructions.is_some());
+    }
+
+    #[test]
+    fn valid_minimal_recipe_has_no_diagnostics() {
+        let diagnostics = validate_document(VALID_MINIMAL);
+        assert!(
+            !diagnostics.has_errors(),
+            "expected no errors, got: {diagnostics:?}"
+        );
+
+        let recipe = Recipe::from_yaml_str(VALID_MINIMAL).expect("should parse");
+        assert_eq!(recipe.agent, AgentKind::Codex);
+        assert!(recipe.skills.is_empty());
+        assert!(recipe.system_instructions.is_none());
+    }
+
+    #[test]
+    fn round_trips_through_yaml() {
+        let recipe = Recipe::from_yaml_str(VALID_FULL).expect("should parse");
+        let serialized = recipe.to_yaml_string().expect("should serialize");
+        let reparsed = Recipe::from_yaml_str(&serialized).expect("should reparse");
+        assert_eq!(recipe, reparsed);
+    }
+
+    #[test]
+    fn missing_required_fields_are_all_reported() {
+        let yaml = "name: \"\"\n";
+        let diagnostics = validate_document(yaml);
+
+        let codes: Vec<&str> = diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(codes.contains(&error_codes::MISSING_NAME));
+        assert!(codes.contains(&error_codes::MISSING_AGENT));
+        assert!(codes.contains(&error_codes::MISSING_MODEL));
+    }
+
+    #[test]
+    fn unknown_agent_is_rejected() {
+        let yaml = "name: x\nagent: gemini\nmodel:\n  name: foo\n  effort: low\n";
+        let diagnostics = validate_document(yaml);
+        let codes: Vec<&str> = diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(codes.contains(&error_codes::UNKNOWN_AGENT));
+    }
+
+    #[test]
+    fn invalid_effort_is_rejected() {
+        let yaml = "name: x\nagent: claude\nmodel:\n  name: foo\n  effort: extreme\n";
+        let diagnostics = validate_document(yaml);
+        let codes: Vec<&str> = diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(codes.contains(&error_codes::INVALID_MODEL_EFFORT));
+    }
+
+    #[test]
+    fn unknown_top_level_field_is_rejected() {
+        let yaml = "name: x\nagent: claude\nmodel:\n  name: foo\n  effort: low\nnotarealfield: 1\n";
+        let diagnostics = validate_document(yaml);
+        let codes: Vec<&str> = diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(codes.contains(&error_codes::UNKNOWN_FIELD));
+    }
+
+    #[test]
+    fn empty_skill_ref_is_rejected() {
+        let yaml =
+            "name: x\nagent: claude\nmodel:\n  name: foo\n  effort: low\nskills:\n  - \"\"\n";
+        let diagnostics = validate_document(yaml);
+        let codes: Vec<&str> = diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(codes.contains(&error_codes::INVALID_SKILL_REF));
+    }
+
+    #[test]
+    fn invalid_instructions_mode_is_rejected() {
+        let yaml = "name: x\nagent: claude\nmodel:\n  name: foo\n  effort: low\nsystem_instructions:\n  mode: overwrite\n  content: hi\n";
+        let diagnostics = validate_document(yaml);
+        let codes: Vec<&str> = diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(codes.contains(&error_codes::INVALID_INSTRUCTIONS_MODE));
+    }
+
+    #[test]
+    fn empty_instructions_content_is_rejected() {
+        let yaml = "name: x\nagent: claude\nmodel:\n  name: foo\n  effort: low\nsystem_instructions:\n  mode: append\n  content: \"\"\n";
+        let diagnostics = validate_document(yaml);
+        let codes: Vec<&str> = diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(codes.contains(&error_codes::EMPTY_INSTRUCTIONS_CONTENT));
+    }
+
+    #[test]
+    fn malformed_yaml_is_reported() {
+        let yaml = "name: [unterminated\n";
+        let diagnostics = validate_document(yaml);
+        let codes: Vec<&str> = diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(codes.contains(&error_codes::MALFORMED_DOCUMENT));
+    }
+
+    #[test]
+    fn non_mapping_document_is_reported() {
+        let yaml = "- 1\n- 2\n";
+        let diagnostics = validate_document(yaml);
+        let codes: Vec<&str> = diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(codes.contains(&error_codes::MALFORMED_DOCUMENT));
+    }
+}

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/tests/README.md
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/tests/README.md
@@ -1,0 +1,17 @@
+# Agent Recipe Standard Tests
+
+Tests for the experimental standard.
+
+- Unit tests live alongside the implementation in `src/lib.rs` and cover
+  each validation rule / error code in `docs/01_spec.md` section 5.
+- `conformance_test.rs` in this directory is an integration test that walks
+  every file under `examples/valid/` and `examples/invalid/` and asserts the
+  expected pass/fail outcome, so the shipped examples never drift from the
+  validator's actual behavior.
+
+## Running Tests
+
+```bash
+cargo test -p agent-recipe
+```
+

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/tests/README.md
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/tests/README.md
@@ -12,6 +12,6 @@ Tests for the experimental standard.
 ## Running Tests
 
 ```bash
-cargo test -p agent-recipe
+cargo test -p apss-v1-0003-agent-recipe
 ```
 

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/tests/conformance_test.rs
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/tests/conformance_test.rs
@@ -1,0 +1,72 @@
+//! Conformance test: every example under `examples/valid/` must validate
+//! cleanly, and every example under `examples/invalid/` must produce at
+//! least one diagnostic. This keeps the shipped examples honest as the
+//! validator evolves.
+
+use std::fs;
+use std::path::Path;
+
+fn examples_dir(sub: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join(sub)
+}
+
+#[test]
+fn all_valid_examples_pass_validation() {
+    let dir = examples_dir("valid");
+    let mut checked = 0;
+
+    for entry in fs::read_dir(&dir).expect("examples/valid must exist") {
+        let entry = entry.expect("readable directory entry");
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+            continue;
+        }
+
+        let content = fs::read_to_string(&path).expect("readable example file");
+        let diagnostics = agent_recipe::validate_document(&content);
+        assert!(
+            !diagnostics.has_errors(),
+            "expected {} to be valid, got diagnostics: {diagnostics:?}",
+            path.display()
+        );
+
+        // Every valid example must also deserialize into the typed Recipe.
+        agent_recipe::Recipe::from_yaml_str(&content)
+            .unwrap_or_else(|err| panic!("expected {} to parse as Recipe: {err}", path.display()));
+
+        checked += 1;
+    }
+
+    assert!(checked > 0, "expected at least one valid example to check");
+}
+
+#[test]
+fn all_invalid_examples_fail_validation() {
+    let dir = examples_dir("invalid");
+    let mut checked = 0;
+
+    for entry in fs::read_dir(&dir).expect("examples/invalid must exist") {
+        let entry = entry.expect("readable directory entry");
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+            continue;
+        }
+
+        let content = fs::read_to_string(&path).expect("readable example file");
+        let diagnostics = agent_recipe::validate_document(&content);
+        assert!(
+            diagnostics.has_errors(),
+            "expected {} to be invalid, but validation produced no errors",
+            path.display()
+        );
+
+        checked += 1;
+    }
+
+    assert!(
+        checked > 0,
+        "expected at least one invalid example to check"
+    );
+}

--- a/standards-experimental/v1/EXP-V1-0003-agent-recipe/tests/conformance_test.rs
+++ b/standards-experimental/v1/EXP-V1-0003-agent-recipe/tests/conformance_test.rs
@@ -1,7 +1,7 @@
 //! Conformance test: every example under `examples/valid/` must validate
-//! cleanly, and every example under `examples/invalid/` must produce at
-//! least one diagnostic. This keeps the shipped examples honest as the
-//! validator evolves.
+//! cleanly, and every example under `examples/invalid/` must produce exactly
+//! the error code(s) its header comment documents. This keeps the shipped
+//! examples honest as the validator evolves.
 
 use std::fs;
 use std::path::Path;
@@ -10,6 +10,22 @@ fn examples_dir(sub: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("examples")
         .join(sub)
+}
+
+/// Parse the `# Expect: CODE1, CODE2` header line from an invalid example.
+///
+/// Every invalid example MUST declare the error code(s) it is expected to
+/// trigger, so the test can assert the validator emits precisely those.
+fn expected_codes(content: &str) -> Vec<String> {
+    let line = content
+        .lines()
+        .find_map(|line| line.trim_start_matches('#').trim().strip_prefix("Expect:"))
+        .expect("invalid example must contain an `# Expect:` header line");
+
+    line.split(',')
+        .map(|code| code.trim().to_string())
+        .filter(|code| !code.is_empty())
+        .collect()
 }
 
 #[test]
@@ -43,7 +59,7 @@ fn all_valid_examples_pass_validation() {
 }
 
 #[test]
-fn all_invalid_examples_fail_validation() {
+fn all_invalid_examples_emit_their_declared_codes() {
     let dir = examples_dir("invalid");
     let mut checked = 0;
 
@@ -55,12 +71,23 @@ fn all_invalid_examples_fail_validation() {
         }
 
         let content = fs::read_to_string(&path).expect("readable example file");
-        let diagnostics = agent_recipe::validate_document(&content);
+        let expected = expected_codes(&content);
         assert!(
-            diagnostics.has_errors(),
-            "expected {} to be invalid, but validation produced no errors",
+            !expected.is_empty(),
+            "{} declares no expected error codes",
             path.display()
         );
+
+        let diagnostics = agent_recipe::validate_document(&content);
+        let actual: Vec<&str> = diagnostics.iter().map(|d| d.code.as_str()).collect();
+
+        for code in &expected {
+            assert!(
+                actual.contains(&code.as_str()),
+                "expected {} to emit `{code}`, got: {actual:?}",
+                path.display()
+            );
+        }
 
         checked += 1;
     }


### PR DESCRIPTION
Adds the experimental **AgentRecipeStandard** (`standards-experimental/v1/EXP-V1-0003-agent-recipe/`): the harness-neutral schema for an agent recipe (agent + model{name,effort} + skills + system_instructions), adopted from the pi.recipes shape. It is the config surface a workspace executes (the core of a RunSpec) in the Workspace Standard effort (agentic-primitives). Harness-neutral so codex/opencode/gemini extend the same schema.

Typed Rust schema + `validate_document()` with per-rule error codes + YAML round-trip + `register()` (NoopCommandHandler, matching EXP-V1-0002 - no consumer yet) + 14 tests + valid/invalid examples + normative spec. `just check` green (0 errors/warnings). RunSpec envelope + JSON Schema artifact are explicitly future work (spec section 7). Tracks okrs-51p.3 / okrs-o78.