### PR TITLE
fix(code-topology): correct cognitive-complexity nesting off-by-one and switch/match over-count

### DIFF
--- a/docs/runbooks/cognitive-complexity-fix-deployment.runbook.md
+++ b/docs/runbooks/cognitive-complexity-fix-deployment.runbook.md
@@ -21,7 +21,7 @@ baseline against the old (inflated) numbers will see its readings move.
 
 `apss-v1-0001-code-topology` is at `0.2.0` (0.x). Under SemVer, a 0.x
 minor bump signals a breaking change. Because emitted metric values
-shift — which breaks consumers pinning baselines — this is breaking in
+shift, which breaks consumers pinning baselines; this is breaking in
 practice even though it is a bug fix.
 
 Recommended bumps:
@@ -82,4 +82,4 @@ crate. Verify with `cargo search apss-v1-0001-code-topology`.
 Until `0.3.0` is published and adopted, the consumer should source
 cognitive complexity from its ts-morph `complexity.mjs` implementation,
 which is already SonarSource-correct. Do not baseline against the old
-APSS cognitive numbers — they are the inflated values this fix corrects.
+APSS cognitive numbers; they are the inflated values this fix corrects.

--- a/docs/runbooks/cognitive-complexity-fix-deployment.runbook.md
+++ b/docs/runbooks/cognitive-complexity-fix-deployment.runbook.md
@@ -1,0 +1,85 @@
+# Deployment: cognitive-complexity nesting fix
+
+This runbook covers shipping the cognitive-complexity correctness fix
+(`fix/cognitive-complexity-nesting-off-by-one`) from this repo to
+crates.io and on to the `harness-app-template` consumer.
+
+## What changed and why it matters for consumers
+
+The TS/JS cognitive-complexity metric was inflated by an off-by-one
+nesting error: the measured function's own tree-sitter node counted as a
+nesting level, charging every construct in the body one extra nesting
+penalty. Additionally `switch`/`match` were charged per case/arm instead
+of once (SonarSource charges the structure a single time).
+
+Effect on emitted values: **cognitive scores drop for real code** (e.g.
+4 flat `if`s went 8 → 4; 3 nested `if`s went 9 → 6). This is a
+behavior-changing correctness fix: any consumer that has pinned a
+baseline against the old (inflated) numbers will see its readings move.
+
+## 1. Version bump
+
+`apss-v1-0001-code-topology` is at `0.2.0` (0.x). Under SemVer, a 0.x
+minor bump signals a breaking change. Because emitted metric values
+shift — which breaks consumers pinning baselines — this is breaking in
+practice even though it is a bug fix.
+
+Recommended bumps:
+
+| Crate | Package | From | To | Why |
+|---|---|---|---|---|
+| Analyzer | `apss-v1-0001-code-topology` | 0.2.0 | **0.3.0** | Output values change → breaking for 0.x |
+| CLI | `aps-cli` (bin `apss-dev`) | 1.1.0 | **1.2.0** | Pins the analyzer; user-visible output changes |
+| Core | `apss-core` | 1.1.0 | unchanged* | No code change |
+
+\* The workspace pins `aps-cli`/`apss-core`/meta crates via
+`version.workspace = true` (currently `1.1.0`). Bumping the workspace
+version to publish the CLI will also roll the version stamp of every
+workspace-versioned crate. If you prefer to avoid dragging `apss-core`'s
+number, give `aps-cli` an explicit `version = "1.2.0"` in its own
+`[package]` instead of inheriting the workspace version. Either way,
+only the analyzer crate has a code change; the CLI must be republished
+so its pinned dependency (`code-topology = "0.3.0"`) resolves.
+
+Also update the pin in `crates/aps-cli/Cargo.toml`:
+`code-topology = { package = "apss-v1-0001-code-topology", version = "0.3.0", ... }`.
+
+## 2. Publish order (crates.io)
+
+Publish leaf-first along the dependency graph
+(`apss-core` ← `apss-v1-0001-code-topology` ← `aps-cli`):
+
+```sh
+# apss-core only if its version actually changed:
+cargo publish -p apss-core
+
+# analyzer crate (the real change):
+cargo publish -p apss-v1-0001-code-topology
+
+# CLI (after the analyzer 0.3.0 is live on crates.io):
+cargo publish -p aps-cli
+```
+
+Wait for each publish to be indexed before publishing the next dependent
+crate. Verify with `cargo search apss-v1-0001-code-topology`.
+
+## 3. Consumer update (harness-app-template)
+
+1. Bump the APSS pin in the consumer's `apss.lock` / `apss.yaml` to the
+   fixed analyzer/CLI version.
+2. **Re-derive the sensors baseline.** MT01 `max-cognitive` (and the
+   cognitive-derived floors) were ratcheted against the old inflated
+   numbers. After upgrading, run the sensors pipeline and re-baseline:
+   `just sensors gate --update-baseline` so
+   `harness/sensors/baseline.json` reflects the corrected (lower)
+   cognitive values as a reviewable, audit-trailed edit.
+3. If APSS was disabled as a cognitive source in
+   `harness/sensors/gate.mjs`, re-enable it now that its cognitive
+   numbers are SonarSource-correct.
+
+## 4. Interim (until the new version ships)
+
+Until `0.3.0` is published and adopted, the consumer should source
+cognitive complexity from its ts-morph `complexity.mjs` implementation,
+which is already SonarSource-correct. Do not baseline against the old
+APSS cognitive numbers — they are the inflated values this fix corrects.

--- a/standards/v1/APS-V1-0001-code-topology/src/adapter/complexity.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/adapter/complexity.rs
@@ -27,7 +27,11 @@ use super::grammars::Grammar;
 pub struct ComplexityCalculator<'g> {
     #[allow(dead_code)]
     grammar: &'g dyn Grammar,
-    decision_nodes: HashSet<&'static str>,
+    /// CYCLOMATIC (McCabe) decision nodes: each `switch_case`/`match_arm` counts.
+    cyclomatic_decision_nodes: HashSet<&'static str>,
+    /// COGNITIVE (SonarSource) decision nodes: a `switch`/`match` structure
+    /// counts once instead of once per branch.
+    cognitive_decision_nodes: HashSet<&'static str>,
     nesting_nodes: HashSet<&'static str>,
     ignored_nodes: HashSet<&'static str>,
 }
@@ -37,7 +41,8 @@ impl<'g> ComplexityCalculator<'g> {
     pub fn new(grammar: &'g dyn Grammar) -> Self {
         Self {
             grammar,
-            decision_nodes: grammar.decision_nodes().iter().copied().collect(),
+            cyclomatic_decision_nodes: grammar.decision_nodes().iter().copied().collect(),
+            cognitive_decision_nodes: grammar.cognitive_decision_nodes().iter().copied().collect(),
             nesting_nodes: grammar.nesting_nodes().iter().copied().collect(),
             ignored_nodes: grammar.ignored_nodes().iter().copied().collect(),
         }
@@ -114,12 +119,24 @@ impl<'g> ComplexityCalculator<'g> {
 
     /// Check if a node type represents a function.
     fn is_function_node(&self, kind: &str) -> bool {
-        // Common function node types across languages
+        // Common function node types across languages.
+        //
+        // `function_expression` (`const f = function () { ... }`) and the
+        // generator variants are extracted by TS_FUNCTION_QUERY, so they MUST be
+        // recognized here too. Otherwise `compute_metrics` misses the function
+        // node and falls back to the range path, which descends through the
+        // function node itself (a nesting node) and inflates cognitive
+        // complexity by one nesting level. Keeping this list consistent with the
+        // function extractor guarantees every measured function uses the
+        // corrected `compute_cognitive` path.
         matches!(
             kind,
             "function_item"
                 | "function_definition"
                 | "function_declaration"
+                | "function_expression"
+                | "generator_function"
+                | "generator_function_declaration"
                 | "method_definition"
                 | "arrow_function"
                 | "lambda"
@@ -160,7 +177,7 @@ impl<'g> ComplexityCalculator<'g> {
         }
 
         // Check if this is a decision node
-        if self.decision_nodes.contains(kind) {
+        if self.cyclomatic_decision_nodes.contains(kind) {
             // Handle binary expressions specially (only count && and ||)
             if kind == "binary_expression" || kind == "boolean_operator" {
                 if self.is_logical_operator(node) {
@@ -195,7 +212,7 @@ impl<'g> ComplexityCalculator<'g> {
         }
 
         // Check if this is a decision node
-        if self.decision_nodes.contains(kind) {
+        if self.cyclomatic_decision_nodes.contains(kind) {
             if kind == "binary_expression" || kind == "boolean_operator" {
                 if self.is_logical_operator(node) {
                     *cc += 1;
@@ -281,7 +298,7 @@ impl<'g> ComplexityCalculator<'g> {
         }
 
         let is_nesting = self.nesting_nodes.contains(kind);
-        let is_decision = self.decision_nodes.contains(kind);
+        let is_decision = self.cognitive_decision_nodes.contains(kind);
 
         // Decision nodes add base + nesting penalty
         if is_decision {
@@ -331,7 +348,7 @@ impl<'g> ComplexityCalculator<'g> {
         }
 
         let is_nesting = self.nesting_nodes.contains(kind);
-        let is_decision = self.decision_nodes.contains(kind);
+        let is_decision = self.cognitive_decision_nodes.contains(kind);
 
         if is_decision {
             if kind == "binary_expression" || kind == "boolean_operator" {
@@ -651,7 +668,8 @@ mod tests {
         let grammar = TestGrammar;
         let calc = ComplexityCalculator::new(&grammar);
 
-        assert!(calc.decision_nodes.contains("if_statement"));
+        assert!(calc.cyclomatic_decision_nodes.contains("if_statement"));
+        assert!(calc.cognitive_decision_nodes.contains("if_statement"));
         assert!(calc.nesting_nodes.contains("for_statement"));
     }
 
@@ -733,6 +751,17 @@ mod tests {
     /// Parse `source` with `grammar`, locate the (first/only) function that
     /// spans the whole snippet, and return its cognitive complexity.
     fn cognitive_of(grammar: &dyn Grammar, source: &str) -> u32 {
+        metrics_of(grammar, source).cognitive_complexity
+    }
+
+    /// Parse `source` with `grammar`, locate the function spanning the snippet,
+    /// and return its cyclomatic complexity.
+    fn cyclomatic_of(grammar: &dyn Grammar, source: &str) -> u32 {
+        metrics_of(grammar, source).cyclomatic_complexity
+    }
+
+    /// Parse `source` with `grammar` and compute metrics for the whole snippet.
+    fn metrics_of(grammar: &dyn Grammar, source: &str) -> FunctionMetrics {
         let mut parser = tree_sitter::Parser::new();
         parser
             .set_language(&grammar.ts_language())
@@ -740,8 +769,7 @@ mod tests {
         let tree = parser.parse(source, None).expect("parse");
         let calc = ComplexityCalculator::new(grammar);
         let end_line = source.lines().count() as u32;
-        let metrics = calc.compute_metrics(&tree, source.as_bytes(), 1, end_line);
-        metrics.cognitive_complexity
+        calc.compute_metrics(&tree, source.as_bytes(), 1, end_line)
     }
 
     #[test]
@@ -803,5 +831,53 @@ mod tests {
         // A match with 3 arms → +1 for the match structure only, not per arm.
         let src = "fn m(a: i32) -> i32 {\n    match a {\n        1 => 1,\n        2 => 2,\n        _ => 0,\n    }\n}\n";
         assert_eq!(cognitive_of(&grammar, src), 1);
+    }
+
+    // ========================================================================
+    // Metrics divergence: switch/match must count per case/arm for CYCLOMATIC
+    // (McCabe) but once for COGNITIVE (SonarSource). These paired tests guard
+    // the regression where sharing one decision set made cyclomatic under-count
+    // switches/matches after the cognitive fix.
+    // ========================================================================
+
+    #[test]
+    fn ts_cyclomatic_switch_counts_each_case() {
+        let grammar = TypeScriptGrammar::new();
+        // switch with `case 1`, `case 2`, `default` → two `switch_case` nodes
+        // (default is a `switch_default`), so McCabe == 1 (base) + 2 == 3.
+        let src = "function sw(a) {\n  switch (a) {\n    case 1: return;\n    case 2: return;\n    default: return;\n  }\n}\n";
+        assert_eq!(cyclomatic_of(&grammar, src), 3);
+        // Same snippet, cognitive charges the switch structure once.
+        assert_eq!(cognitive_of(&grammar, src), 1);
+    }
+
+    #[test]
+    fn rust_cyclomatic_match_counts_each_arm() {
+        let grammar = RustGrammar::new();
+        // match with 3 arms (including the wildcard `_`) → three `match_arm`
+        // nodes, so McCabe == 1 (base) + 3 == 4.
+        let src = "fn m(a: i32) -> i32 {\n    match a {\n        1 => 1,\n        2 => 2,\n        _ => 0,\n    }\n}\n";
+        assert_eq!(cyclomatic_of(&grammar, src), 4);
+        // Same snippet, cognitive charges the match structure once.
+        assert_eq!(cognitive_of(&grammar, src), 1);
+    }
+
+    #[test]
+    fn ts_cognitive_function_expression_not_off_by_one() {
+        let grammar = TypeScriptGrammar::new();
+        // `const f = function () { if (a) { if (b) {} } }`.
+        // The outer if is at nesting 0 (+1), the inner if at nesting 1 (+2),
+        // so cognitive == 3, identical to the equivalent function_declaration.
+        //
+        // Before recognizing `function_expression` in `is_function_node`, this
+        // fell back to the range path, which descends through the
+        // function_expression node itself (a nesting node) and inflated the
+        // result to 5. This asserts the corrected `compute_cognitive` path runs.
+        let src = "const f = function () {\n  if (a) {\n    if (b) {\n    }\n  }\n};\n";
+        assert_eq!(cognitive_of(&grammar, src), 3);
+
+        // Equivalence check: the same body as a function_declaration.
+        let decl = "function f() {\n  if (a) {\n    if (b) {\n    }\n  }\n}\n";
+        assert_eq!(cognitive_of(&grammar, decl), 3);
     }
 }

--- a/standards/v1/APS-V1-0001-code-topology/src/adapter/complexity.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/adapter/complexity.rs
@@ -232,10 +232,21 @@ impl<'g> ComplexityCalculator<'g> {
     /// Compute cognitive complexity for a node.
     ///
     /// Cognitive complexity adds a nesting penalty for each level of nesting.
+    ///
+    /// `node` is expected to be the measured function's own tree-sitter node.
+    /// We visit its CHILDREN at the incoming `nesting_level` rather than the
+    /// function node itself, so the function's own definition does not count as
+    /// a nesting level (which would inflate every construct in its body by one).
+    /// Genuinely-nested functions/closures encountered while descending the body
+    /// are still in `nesting_nodes`, so they correctly add a nesting level.
+    /// This matches the SonarSource Cognitive Complexity reference algorithm.
     pub fn compute_cognitive(&self, node: Node, nesting_level: u32) -> u32 {
         let mut cog = 0;
 
-        self.visit_for_cognitive(node, nesting_level, &mut cog);
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.visit_for_cognitive(child, nesting_level, &mut cog);
+        }
 
         cog
     }
@@ -250,7 +261,13 @@ impl<'g> ComplexityCalculator<'g> {
     ) -> u32 {
         let mut cog = 0;
 
-        self.visit_for_cognitive_range(node, start_line, end_line, nesting_level, &mut cog);
+        // Mirror `compute_cognitive`: visit the node's CHILDREN at the incoming
+        // nesting level rather than the node itself, so the enclosing
+        // function/scope does not spuriously count as a nesting level.
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.visit_for_cognitive_range(child, start_line, end_line, nesting_level, &mut cog);
+        }
 
         cog
     }
@@ -695,5 +712,96 @@ mod tests {
         assert!(calc.is_operand_node("integer_literal"));
         assert!(calc.is_operand_node("string_literal"));
         assert!(!calc.is_operand_node("+"));
+    }
+
+    // ========================================================================
+    // Cognitive Complexity — SonarSource reference-value tests
+    //
+    // These parse real source with the concrete tree-sitter grammars and
+    // assert the exact values from the SonarSource Cognitive Complexity
+    // specification (https://www.sonarsource.com/docs/CognitiveComplexity.pdf).
+    //
+    // Regression guard: before the "off-by-one nesting" fix, the measured
+    // function's OWN node was counted as a nesting level, so `flat_ifs`
+    // returned 2N instead of N and `nested_ifs_depth_3` returned 9 instead of
+    // 6. The `nested_function` case proves that genuinely-nested
+    // functions/closures STILL add a nesting level after the fix.
+    // ========================================================================
+
+    use crate::adapter::grammars::{RustGrammar, TypeScriptGrammar};
+
+    /// Parse `source` with `grammar`, locate the (first/only) function that
+    /// spans the whole snippet, and return its cognitive complexity.
+    fn cognitive_of(grammar: &dyn Grammar, source: &str) -> u32 {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&grammar.ts_language())
+            .expect("set language");
+        let tree = parser.parse(source, None).expect("parse");
+        let calc = ComplexityCalculator::new(grammar);
+        let end_line = source.lines().count() as u32;
+        let metrics = calc.compute_metrics(&tree, source.as_bytes(), 1, end_line);
+        metrics.cognitive_complexity
+    }
+
+    #[test]
+    fn ts_cognitive_flat_ifs_equals_n() {
+        let grammar = TypeScriptGrammar::new();
+        // N flat, sibling ifs → cognitive == N (each +1, no nesting).
+        let src = "function flat4(a, b, c, d) {\n  if (a) { return; }\n  if (b) { return; }\n  if (c) { return; }\n  if (d) { return; }\n}\n";
+        assert_eq!(cognitive_of(&grammar, src), 4);
+    }
+
+    #[test]
+    fn ts_cognitive_nested_ifs_depth_3_equals_6() {
+        let grammar = TypeScriptGrammar::new();
+        // 3 nested ifs → (1+0) + (1+1) + (1+2) == 6.
+        let src = "function nested3(a) {\n  if (a) {\n    if (a) {\n      if (a) { return; }\n    }\n  }\n}\n";
+        assert_eq!(cognitive_of(&grammar, src), 6);
+    }
+
+    #[test]
+    fn ts_cognitive_nested_function_adds_nesting() {
+        let grammar = TypeScriptGrammar::new();
+        // The inner arrow function nests the `if` one level deeper:
+        // the if is charged 1 + 1 == 2. If nested functions did NOT add a
+        // nesting level, this would be 1 — so this proves the fix preserves
+        // real nesting from inner functions/closures.
+        let src = "function outer(a) {\n  const inner = (b) => {\n    if (b) { return; }\n  };\n  inner(a);\n}\n";
+        assert_eq!(cognitive_of(&grammar, src), 2);
+    }
+
+    #[test]
+    fn ts_cognitive_switch_counted_once_not_per_case() {
+        let grammar = TypeScriptGrammar::new();
+        // A switch with 3 cases → +1 for the switch structure only (nesting 0),
+        // NOT +1 per case. SonarSource treats a switch as a single structural
+        // increment.
+        let src = "function sw(a) {\n  switch (a) {\n    case 1: return;\n    case 2: return;\n    default: return;\n  }\n}\n";
+        assert_eq!(cognitive_of(&grammar, src), 1);
+    }
+
+    #[test]
+    fn rust_cognitive_flat_ifs_equals_n() {
+        let grammar = RustGrammar::new();
+        // Rust's nesting set excludes `function_item`, so the top-level path was
+        // already correct; this asserts the fix is a no-op for Rust.
+        let src = "fn flat2(a: bool) {\n    if a { return; }\n    if a { return; }\n}\n";
+        assert_eq!(cognitive_of(&grammar, src), 2);
+    }
+
+    #[test]
+    fn rust_cognitive_nested_ifs_depth_3_equals_6() {
+        let grammar = RustGrammar::new();
+        let src = "fn nested3(a: bool) {\n    if a {\n        if a {\n            if a { return; }\n        }\n    }\n}\n";
+        assert_eq!(cognitive_of(&grammar, src), 6);
+    }
+
+    #[test]
+    fn rust_cognitive_match_counted_once_not_per_arm() {
+        let grammar = RustGrammar::new();
+        // A match with 3 arms → +1 for the match structure only, not per arm.
+        let src = "fn m(a: i32) -> i32 {\n    match a {\n        1 => 1,\n        2 => 2,\n        _ => 0,\n    }\n}\n";
+        assert_eq!(cognitive_of(&grammar, src), 1);
     }
 }

--- a/standards/v1/APS-V1-0001-code-topology/src/adapter/complexity.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/adapter/complexity.rs
@@ -715,7 +715,7 @@ mod tests {
     }
 
     // ========================================================================
-    // Cognitive Complexity — SonarSource reference-value tests
+    // Cognitive Complexity: SonarSource reference-value tests
     //
     // These parse real source with the concrete tree-sitter grammars and
     // assert the exact values from the SonarSource Cognitive Complexity
@@ -765,7 +765,7 @@ mod tests {
         let grammar = TypeScriptGrammar::new();
         // The inner arrow function nests the `if` one level deeper:
         // the if is charged 1 + 1 == 2. If nested functions did NOT add a
-        // nesting level, this would be 1 — so this proves the fix preserves
+        // nesting level, this would be 1, so this proves the fix preserves
         // real nesting from inner functions/closures.
         let src = "function outer(a) {\n  const inner = (b) => {\n    if (b) { return; }\n  };\n  inner(a);\n}\n";
         assert_eq!(cognitive_of(&grammar, src), 2);

--- a/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/mod.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/mod.rs
@@ -104,15 +104,36 @@ pub trait Grammar: Send + Sync {
     /// ```
     fn import_query(&self) -> &str;
 
-    /// Node types that increase cyclomatic complexity.
+    /// Node types that increase cyclomatic complexity (McCabe).
     ///
     /// Each occurrence of these node types adds 1 to the cyclomatic complexity.
+    /// McCabe counts every branch, so `switch`/`match` are modelled per
+    /// `case`/`arm` (each `switch_case`/`match_arm` is a separate decision).
     /// Common examples:
     /// - `if_statement`, `else_clause`
     /// - `for_statement`, `while_statement`
     /// - `match_arm`, `switch_case`
     /// - `binary_expression` (for && and ||)
+    ///
+    /// This is the CYCLOMATIC decision set. Cognitive complexity uses
+    /// [`Grammar::cognitive_decision_nodes`], which models a `switch`/`match`
+    /// as a single structural decision instead of one per branch.
     fn decision_nodes(&self) -> &'static [&'static str];
+
+    /// Node types that increase cognitive complexity (SonarSource) as a
+    /// structural decision.
+    ///
+    /// Defaults to [`Grammar::decision_nodes`], which is correct for languages
+    /// where the McCabe and SonarSource decision sets coincide. They diverge
+    /// for `switch`/`match`: McCabe charges each `case`/`arm` (+1 apiece), while
+    /// SonarSource charges the `switch`/`match` STRUCTURE once (+1 plus its
+    /// nesting penalty). Grammars with such constructs override this to return
+    /// `switch_statement`/`match_expression` in place of
+    /// `switch_case`/`match_arm`. The structural node is also expected to appear
+    /// in [`Grammar::nesting_nodes`] so its body raises the nesting level.
+    fn cognitive_decision_nodes(&self) -> &'static [&'static str] {
+        self.decision_nodes()
+    }
 
     /// Node types that increase cognitive complexity nesting penalty.
     ///

--- a/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/rust.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/rust.rs
@@ -55,12 +55,26 @@ impl Grammar for RustGrammar {
     }
 
     fn decision_nodes(&self) -> &'static [&'static str] {
+        // CYCLOMATIC (McCabe): each `match_arm` is a separate decision (+1
+        // apiece), matching the McCabe count for a match.
         &[
             "if_expression",
             "else_clause",
-            // SonarSource charges a match structure ONCE (+1, plus its nesting
-            // penalty), not once per arm. We increment on `match_expression`
-            // (which is also a nesting node), not on each `match_arm`.
+            "match_arm",
+            "while_expression",
+            "loop_expression",
+            "for_expression",
+            "binary_expression", // For && and || operators
+        ]
+    }
+
+    fn cognitive_decision_nodes(&self) -> &'static [&'static str] {
+        // COGNITIVE (SonarSource): a match is charged ONCE on `match_expression`
+        // (+1, plus its nesting penalty), not once per arm. `match_expression`
+        // is also a nesting node, so its arms raise the nesting level.
+        &[
+            "if_expression",
+            "else_clause",
             "match_expression",
             "while_expression",
             "loop_expression",
@@ -258,10 +272,23 @@ mod tests {
         let nodes = grammar.decision_nodes();
 
         assert!(nodes.contains(&"if_expression"));
-        // Match is charged once on the expression node (SonarSource), not per arm.
+        // CYCLOMATIC (McCabe): each arm is a decision, so the per-arm node is in
+        // the set and the match expression node is not.
+        assert!(nodes.contains(&"match_arm"));
+        assert!(!nodes.contains(&"match_expression"));
+        assert!(nodes.contains(&"for_expression"));
+    }
+
+    #[test]
+    fn test_rust_cognitive_decision_nodes() {
+        let grammar = RustGrammar::new();
+        let nodes = grammar.cognitive_decision_nodes();
+
+        // COGNITIVE (SonarSource): a match is charged once on the expression
+        // node, not per arm.
         assert!(nodes.contains(&"match_expression"));
         assert!(!nodes.contains(&"match_arm"));
-        assert!(nodes.contains(&"for_expression"));
+        assert!(nodes.contains(&"if_expression"));
     }
 
     #[test]

--- a/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/rust.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/rust.rs
@@ -58,7 +58,10 @@ impl Grammar for RustGrammar {
         &[
             "if_expression",
             "else_clause",
-            "match_arm",
+            // SonarSource charges a match structure ONCE (+1, plus its nesting
+            // penalty), not once per arm. We increment on `match_expression`
+            // (which is also a nesting node), not on each `match_arm`.
+            "match_expression",
             "while_expression",
             "loop_expression",
             "for_expression",
@@ -255,7 +258,9 @@ mod tests {
         let nodes = grammar.decision_nodes();
 
         assert!(nodes.contains(&"if_expression"));
-        assert!(nodes.contains(&"match_arm"));
+        // Match is charged once on the expression node (SonarSource), not per arm.
+        assert!(nodes.contains(&"match_expression"));
+        assert!(!nodes.contains(&"match_arm"));
         assert!(nodes.contains(&"for_expression"));
     }
 

--- a/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/typescript.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/typescript.rs
@@ -10,7 +10,7 @@
 //! - if/else branches
 //! - for/for-in/for-of loops
 //! - while/do-while loops
-//! - switch cases
+//! - switch statements (counted once, per SonarSource — not once per case)
 //! - catch clauses
 //! - ternary expressions
 //! - logical operators (&& and ||)
@@ -167,7 +167,10 @@ const TS_DECISION_NODES: &[&str] = &[
     "for_in_statement",
     "while_statement",
     "do_statement",
-    "switch_case",
+    // SonarSource charges a switch structure ONCE (+1, plus its nesting
+    // penalty), not once per case. We increment on `switch_statement` (which is
+    // also a nesting node) rather than on each `switch_case`.
+    "switch_statement",
     "catch_clause",
     "ternary_expression",
     "binary_expression", // && and ||
@@ -337,7 +340,9 @@ mod tests {
         assert!(nodes.contains(&"for_in_statement"));
         assert!(nodes.contains(&"while_statement"));
         assert!(nodes.contains(&"do_statement"));
-        assert!(nodes.contains(&"switch_case"));
+        // Switch is charged once on the statement node (SonarSource), not per case.
+        assert!(nodes.contains(&"switch_statement"));
+        assert!(!nodes.contains(&"switch_case"));
         assert!(nodes.contains(&"catch_clause"));
         assert!(nodes.contains(&"ternary_expression"));
         assert!(nodes.contains(&"binary_expression"));

--- a/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/typescript.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/typescript.rs
@@ -77,6 +77,10 @@ impl Grammar for TypeScriptGrammar {
         TS_DECISION_NODES
     }
 
+    fn cognitive_decision_nodes(&self) -> &'static [&'static str] {
+        TS_COGNITIVE_DECISION_NODES
+    }
+
     fn nesting_nodes(&self) -> &'static [&'static str] {
         TS_NESTING_NODES
     }
@@ -143,6 +147,10 @@ impl Grammar for TsxGrammar {
         TS_DECISION_NODES
     }
 
+    fn cognitive_decision_nodes(&self) -> &'static [&'static str] {
+        TS_COGNITIVE_DECISION_NODES
+    }
+
     fn nesting_nodes(&self) -> &'static [&'static str] {
         TS_NESTING_NODES
     }
@@ -160,6 +168,8 @@ impl Grammar for TsxGrammar {
 // Shared complexity rules
 // ============================================================================
 
+// CYCLOMATIC (McCabe) decision set. Each `switch_case` is a separate decision
+// (+1 apiece), matching the pre-SonarSource McCabe count for a switch.
 const TS_DECISION_NODES: &[&str] = &[
     "if_statement",
     "else_clause",
@@ -167,9 +177,23 @@ const TS_DECISION_NODES: &[&str] = &[
     "for_in_statement",
     "while_statement",
     "do_statement",
-    // SonarSource charges a switch structure ONCE (+1, plus its nesting
-    // penalty), not once per case. We increment on `switch_statement` (which is
-    // also a nesting node) rather than on each `switch_case`.
+    "switch_case",
+    "catch_clause",
+    "ternary_expression",
+    "binary_expression", // && and ||
+];
+
+// COGNITIVE (SonarSource) decision set. Identical to the cyclomatic set except
+// a switch is charged ONCE on `switch_statement` (+1, plus its nesting penalty)
+// rather than once per `switch_case`. `switch_statement` is also a nesting node,
+// so its body raises the nesting level.
+const TS_COGNITIVE_DECISION_NODES: &[&str] = &[
+    "if_statement",
+    "else_clause",
+    "for_statement",
+    "for_in_statement",
+    "while_statement",
+    "do_statement",
     "switch_statement",
     "catch_clause",
     "ternary_expression",
@@ -340,12 +364,25 @@ mod tests {
         assert!(nodes.contains(&"for_in_statement"));
         assert!(nodes.contains(&"while_statement"));
         assert!(nodes.contains(&"do_statement"));
-        // Switch is charged once on the statement node (SonarSource), not per case.
-        assert!(nodes.contains(&"switch_statement"));
-        assert!(!nodes.contains(&"switch_case"));
+        // CYCLOMATIC (McCabe): each case is a decision, so the per-case node is
+        // in the set and the switch statement node is not.
+        assert!(nodes.contains(&"switch_case"));
+        assert!(!nodes.contains(&"switch_statement"));
         assert!(nodes.contains(&"catch_clause"));
         assert!(nodes.contains(&"ternary_expression"));
         assert!(nodes.contains(&"binary_expression"));
+    }
+
+    #[test]
+    fn test_cognitive_decision_nodes() {
+        let grammar = TypeScriptGrammar::new();
+        let nodes = grammar.cognitive_decision_nodes();
+
+        // COGNITIVE (SonarSource): a switch is charged once on the statement
+        // node, not per case.
+        assert!(nodes.contains(&"switch_statement"));
+        assert!(!nodes.contains(&"switch_case"));
+        assert!(nodes.contains(&"if_statement"));
     }
 
     #[test]

--- a/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/typescript.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/typescript.rs
@@ -10,7 +10,7 @@
 //! - if/else branches
 //! - for/for-in/for-of loops
 //! - while/do-while loops
-//! - switch statements (counted once, per SonarSource — not once per case)
+//! - switch statements (counted once, per SonarSource, not once per case)
 //! - catch clauses
 //! - ternary expressions
 //! - logical operators (&& and ||)


### PR DESCRIPTION
## The bug

APSS's cognitive-complexity metric for **TypeScript/JavaScript** was inflated. The module header claims "Cognitive Complexity (SonarSource)" but deviated from the [SonarSource reference algorithm](https://www.sonarsource.com/docs/CognitiveComplexity.pdf) on two counts.

### Root cause 1 — off-by-one nesting

`compute_cognitive(node, 0)` was called with the **function's own** tree-sitter node (from `find_node_in_range`). `visit_for_cognitive` immediately checks `is_nesting = self.nesting_nodes.contains(kind)`, and for TS `TS_NESTING_NODES` includes `function_declaration`, `arrow_function`, `function`, `function_expression`, `method_definition`. So the measured function's own node bumped `nesting_level` 0 → 1 before visiting its body, charging every construct in the body one extra nesting penalty (compounding with real nesting).

### Root cause 2 — switch/match charged per case

`switch_case` (TS) and `match_arm` (Rust) were in `decision_nodes`, so each case/arm added to cognitive. SonarSource charges a `switch`/`match` **structure once** (+1, plus nesting), not per case — [confirmed against the spec](https://www.sonarsource.com/blog/cognitive-complexity-because-testability-understandability/): "a switch and all its cases combined incurs a single structural increment."

## SonarSource reference-value proof (before / after)

| Snippet | SonarSource correct | APSS before | APSS after |
|---|---|---|---|
| `flat4` — 4 flat `if`s | **4** | 8 | **4** |
| `nested3` — 3 nested `if`s | **6** | 9 | **6** |
| `switch` — 3 cases | **1** | 2 | **1** |

End-to-end via the CLI (`apss-dev run topology analyze`), the fixed analyzer emits `flat4 → cognitive 4` and `nested3 → cognitive 6`.

## The fix

`compute_cognitive` now visits the function node's **children** at the incoming nesting level rather than the function node itself, so the measured function does not count its own definition as a nesting level — while genuinely-nested functions/closures inside the body **still** add nesting. The same fix is applied to the `compute_cognitive_range` / `visit_for_cognitive_range` fallback path (identical structure and bug).

For switch/match: cognitive is now charged on `switch_statement` / `match_expression` (both already nesting nodes) instead of on each `switch_case` / `match_arm`.

**Rust is unaffected by the nesting fix** — its nesting set excludes `function_item`, so the top-level function node never bumped nesting; the change is a verified no-op there (a Rust flat-ifs test passes both before and after).

## Tests

This bug shipped because there were **no reference-value tests**. Added unit tests in `complexity.rs` that parse real TS/Rust and assert exact SonarSource values:

- flat `if`s → cognitive == N
- nested `if`s (depth 3) → cognitive == 6
- nested arrow/function inside a function with an `if` → inner `if` gets +1 nesting (proves nested functions still add nesting after the fix)
- switch (TS) / match (Rust) → counted once

Verified the flat/nested TS tests **fail before the fix** (flat4 → 8, nested3 → 9) and **pass after**. Full crate suite: `127 passed; 0 failed`. `cargo fmt --check` and `cargo clippy` clean.

## switch/match verdict

Genuine deviation, **fixed in this PR** (not deferred) with a repro test. SonarSource charges the switch/match structure a single +1; APSS charged per case/arm.

## Deployment

See `docs/runbooks/cognitive-complexity-fix-deployment.runbook.md`. In short: this changes emitted metric values (cognitive drops for real code), so it is breaking-in-practice for consumers pinning baselines — recommend `apss-v1-0001-code-topology` `0.2.0 → 0.3.0` (0.x minor = breaking), republish the CLI (`aps-cli`) with the bumped pin, then consumers bump their APSS pin and re-derive the sensors baseline (MT01 `max-cognitive`) against the corrected numbers.

https://claude.ai/code/session_01Dm4SiDBJYWVpJsNmxMt8L1
