### PR TITLE
chore(release): bump versions for apss aps-alias fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "aps-cli"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aps-v1-0000-meta",
  "apss-core",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "apss"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "apss-core",
  "clap",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "apss-core"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "handlebars",
  "semver",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "apss-v1-0001-code-topology"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "apss-core",
  "chrono",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "apss-v1-0002-architecture-fitness"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "apss-core",
  "chrono",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "apss-v1-0003-documentation"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "apss-core",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/AgentParadise/agent-paradise-standards-system"

--- a/standards/v1/APS-V1-0001-code-topology/Cargo.toml
+++ b/standards/v1/APS-V1-0001-code-topology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apss-v1-0001-code-topology"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/standards/v1/APS-V1-0001-code-topology/standard.toml
+++ b/standards/v1/APS-V1-0001-code-topology/standard.toml
@@ -4,7 +4,7 @@ schema = "aps.standard/v1"
 id = "APS-V1-0001"
 name = "Code Topology and Coupling Analysis"
 slug = "code-topology"
-version = "0.2.0"
+version = "0.2.1"
 category = "technical"
 status = "active"
 

--- a/standards/v1/APS-V1-0002-architecture-fitness/Cargo.toml
+++ b/standards/v1/APS-V1-0002-architecture-fitness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apss-v1-0002-architecture-fitness"
-version = "1.0.0"
+version = "1.0.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/standards/v1/APS-V1-0002-architecture-fitness/standard.toml
+++ b/standards/v1/APS-V1-0002-architecture-fitness/standard.toml
@@ -4,7 +4,7 @@ schema = "aps.standard/v1"
 id = "APS-V1-0002"
 name = "Architecture Fitness Functions"
 slug = "architecture-fitness"
-version = "1.0.0"
+version = "1.0.1"
 category = "technical"
 status = "active"
 

--- a/standards/v1/APS-V1-0003-documentation/Cargo.toml
+++ b/standards/v1/APS-V1-0003-documentation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apss-v1-0003-documentation"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/standards/v1/APS-V1-0003-documentation/standard.toml
+++ b/standards/v1/APS-V1-0003-documentation/standard.toml
@@ -4,7 +4,7 @@ schema = "aps.standard/v1"
 id = "APS-V1-0003"
 name = "Documentation and Context Engineering"
 slug = "documentation"
-version = "0.1.0"
+version = "0.1.1"
 category = "governance"
 status = "active"
 


### PR DESCRIPTION
## Summary
- Bumps the workspace version 1.1.0 -> 1.2.0 (minor): `apss-bootstrap` gained the new deprecated `aps` alias binary in #91, a backward-compatible feature addition.
- Patch-bumps the three official standards whose non-`docs/` files changed in #91's `aps` -> `apss` command-literal sweep (agent skills, examples, proto comments, CI templates, Rust doc comments): APS-V1-0001-code-topology, APS-V1-0002-architecture-fitness, APS-V1-0003-documentation.

This is prep for bootstrapping the release pipeline: the `release` branch was just created at the last commit matching what's currently published on crates.io (`30b5504`), so these bumps are required before the first `main -> release` PR can pass the release gate's version-bump-check.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo run -p aps-cli --bin apss-dev -- v1 validate repo` - 0 errors, 0 warnings
- [x] `just check` - passes