### PR TITLE
fix(deps): update bytes and rustls-webpki to clear 5 RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,9 +327,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -1584,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
Ran \`cargo audit\` manually while bootstrapping the release pipeline (the release-gate's own cargo-audit job has never successfully triggered, see #96). Found 5 unresolved advisories, both transitive:
- RUSTSEC-2026-0007: integer overflow in bytes::BytesMut::reserve (bytes 1.11.0, fixed 1.11.1)
- RUSTSEC-2026-0104/0098/0099/0049: four rustls-webpki advisories (name-constraint and CRL parsing), fixed by 0.103.9 -> 0.103.13

\`cargo update -p bytes -p rustls-webpki\` resolves all five within existing semver constraints.

## Test plan
- [x] \`cargo audit\` - 0 vulnerabilities (was 5)
- [x] \`cargo build --workspace\`
- [x] \`cargo test --workspace\` - all pass
- [x] \`cargo fmt --all --check\`