### PR TITLE
fix(ci): stop using vacuous substring test filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Validate distribution compliance (DI01)
         run: cargo run -p aps-cli --release -- v1 validate distribution
       - name: Run self-validation tests
-        run: cargo test -p aps-cli --release -- self_validation
+        run: cargo test -p aps-cli --release --test self_validation_test
       - name: Run backwards compatibility tests
-        run: cargo test -p aps-cli --release -- backwards_compat
+        run: cargo test -p aps-cli --release --test backwards_compat_test
       - name: Run CF01 config validation tests
         run: cargo test -p apss-project-config --release
       - name: Run DI01 distribution tests

--- a/.github/workflows/main-to-release-gate.yml
+++ b/.github/workflows/main-to-release-gate.yml
@@ -89,10 +89,10 @@ jobs:
         run: cargo run -p aps-cli --release -- v1 validate distribution
 
       - name: Run self-validation tests
-        run: cargo test -p aps-cli --release -- self_validation
+        run: cargo test -p aps-cli --release --test self_validation_test
 
       - name: Run backwards compatibility tests
-        run: cargo test -p aps-cli --release -- backwards_compat
+        run: cargo test -p aps-cli --release --test backwards_compat_test
 
       - name: Run CF01 config validation tests
         run: cargo test -p apss-project-config --release

--- a/justfile
+++ b/justfile
@@ -239,10 +239,10 @@ aps-generate:
 [group('aps')]
 aps-test:
     @echo '{{ YELLOW }}Running APS validation tests...{{ NORMAL }}'
-    cargo test -p aps-cli -- --test-threads=1 self_validation
-    cargo test -p aps-cli -- --test-threads=1 backwards_compat
-    cargo test -p aps-cli -- --test-threads=1 template_test
-    cargo test -p aps-cli -- --test-threads=1 workflow_test
+    cargo test -p aps-cli --test self_validation_test -- --test-threads=1
+    cargo test -p aps-cli --test backwards_compat_test -- --test-threads=1
+    cargo test -p aps-cli --test template_test -- --test-threads=1
+    cargo test -p aps-cli --test workflow_test -- --test-threads=1
     @echo '{{ GREEN }}✓ APS tests passed{{ NORMAL }}'
 
 # Validate distribution compliance for all standard crates (DI01)


### PR DESCRIPTION
## Summary
\`cargo test\`'s positional filter matches against the full test name, not the file name. \`self_validation_test.rs\`'s tests don't contain the literal substring "self_validation" in their names (e.g. \`test_meta_standard_passes_validation\`), so \`cargo test -p aps-cli -- self_validation\` (used in ci.yml, release-gate.yml, and \`just aps-test\`) has always matched zero tests and silently reported success. \`template_test\` and \`workflow_test\` filters were equally vacuous; \`backwards_compat\` matched only 3 of 5 tests in that file.

Discovered while manually verifying what the release gate checks, since the gate itself has never successfully executed (see #96).

Replaced with \`--test <file>\`, confirmed locally: self_validation_test 5/5, backwards_compat_test 5/5, template_test 4/4, workflow_test 4/4, all genuinely passing now.

## Test plan
- [x] \`just aps-test\` now runs 18 real tests (was 0 meaningfully asserted)
- [x] \`just check\` passes
- [x] \`actionlint\` clean