### PR TITLE
chore(ci): add temporary workflow_dispatch trigger to release gate (diagnostic)

### DIFF
--- a/.github/workflows/main-to-release-gate.yml
+++ b/.github/workflows/main-to-release-gate.yml
@@ -20,6 +20,13 @@ name: Release Gate
 on:
   pull_request:
     branches: [release]
+  # TEMPORARY diagnostic trigger: this workflow's pull_request trigger has
+  # never fired in this repo's history. workflow_dispatch lets us invoke it
+  # manually to isolate whether the workflow itself is broken (it isn't,
+  # per actionlint and local simulation) or whether GitHub's pull_request
+  # event matching for this specific workflow/repo is the actual problem.
+  # Remove once the pull_request trigger is confirmed working again.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Diagnostic only, will be reverted once the underlying issue is understood. The release gate's \`pull_request\` trigger has never fired in this repo's history (see #93-#98 for the investigation). Adding \`workflow_dispatch\` lets us invoke it manually via \`gh workflow run\` to check whether GitHub can run the workflow at all, isolating whether this is a content problem (already ruled out via actionlint + local simulation) or a GitHub-side pull_request event matching problem specific to this repo.

## Test plan
- [x] actionlint clean