### PR TITLE
refactor(meta): rename aps-v1-0000-* crates to apss-v1-0000-*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,10 +88,10 @@ dependencies = [
 name = "aps-cli"
 version = "1.2.0"
 dependencies = [
- "aps-v1-0000-meta",
  "apss-core",
  "apss-distribution",
  "apss-project-config",
+ "apss-v1-0000-meta",
  "apss-v1-0001-code-topology",
  "apss-v1-0002-architecture-fitness",
  "apss-v1-0003-documentation",
@@ -102,35 +102,6 @@ dependencies = [
  "tempfile",
  "toml",
  "walkdir",
-]
-
-[[package]]
-name = "aps-v1-0000-cli01-cli-contract"
-version = "1.2.1"
-dependencies = [
- "apss-core",
- "serde",
- "serde_json",
- "thiserror",
- "toml",
-]
-
-[[package]]
-name = "aps-v1-0000-meta"
-version = "1.5.0"
-dependencies = [
- "apss-core",
- "tempfile",
- "toml",
-]
-
-[[package]]
-name = "aps-v1-0000-ss01-substandard-structure"
-version = "1.1.0"
-dependencies = [
- "apss-core",
- "regex",
- "toml",
 ]
 
 [[package]]
@@ -183,6 +154,35 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml",
+]
+
+[[package]]
+name = "apss-v1-0000-cli01-cli-contract"
+version = "1.2.1"
+dependencies = [
+ "apss-core",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "apss-v1-0000-meta"
+version = "1.5.0"
+dependencies = [
+ "apss-core",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
+name = "apss-v1-0000-ss01-substandard-structure"
+version = "1.1.0"
+dependencies = [
+ "apss-core",
+ "regex",
  "toml",
 ]
 

--- a/crates/aps-cli/Cargo.toml
+++ b/crates/aps-cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 apss-core.workspace = true
-aps-v1-0000-meta = { version = "1.5.0", path = "../../standards/v1/APS-V1-0000-meta" }
+apss-v1-0000-meta = { version = "1.5.0", path = "../../standards/v1/APS-V1-0000-meta" }
 code-topology = { package = "apss-v1-0001-code-topology", version = "0.2.0", path = "../../standards/v1/APS-V1-0001-code-topology" }
 architecture-fitness = { package = "apss-v1-0002-architecture-fitness", path = "../../standards/v1/APS-V1-0002-architecture-fitness" }
 documentation = { package = "apss-v1-0003-documentation", version = "0.1.0", path = "../../standards/v1/APS-V1-0003-documentation" }

--- a/crates/aps-cli/src/main.rs
+++ b/crates/aps-cli/src/main.rs
@@ -25,7 +25,6 @@
 
 mod cli_exemptions;
 
-use aps_v1_0000_meta::{MetaStandard, Standard};
 use apss_core::discovery::{
     PackageMetadata, PackageType, count_packages, discover_v1_packages, find_package_by_id,
 };
@@ -34,6 +33,7 @@ use apss_core::{
     Diagnostic, Diagnostics, StandardContext, TemplateEngine, bump_version, generate_all_views,
     get_version, promote_experiment,
 };
+use apss_v1_0000_meta::{MetaStandard, Standard};
 use clap::Parser;
 use std::env;
 use std::fs;

--- a/crates/aps-cli/tests/self_validation_test.rs
+++ b/crates/aps-cli/tests/self_validation_test.rs
@@ -5,8 +5,8 @@
 
 mod fixtures;
 
-use aps_v1_0000_meta::{MetaStandard, Standard};
 use apss_core::discovery::{PackageType, discover_v1_packages};
+use apss_v1_0000_meta::{MetaStandard, Standard};
 use fixtures::repo_root;
 use std::process::Command;
 

--- a/crates/aps-cli/tests/substandard_test.rs
+++ b/crates/aps-cli/tests/substandard_test.rs
@@ -5,7 +5,7 @@
 
 mod fixtures;
 
-use aps_v1_0000_meta::{MetaStandard, Standard, error_codes};
+use apss_v1_0000_meta::{MetaStandard, Standard, error_codes};
 use fixtures::{
     InvalidSubstandardKind, create_invalid_substandard, create_test_workspace,
     create_valid_standard, create_valid_substandard,

--- a/crates/aps-cli/tests/template_test.rs
+++ b/crates/aps-cli/tests/template_test.rs
@@ -5,8 +5,8 @@
 
 mod fixtures;
 
-use aps_v1_0000_meta::{MetaStandard, Standard};
 use apss_core::templates::{ExperimentContext, StandardContext, TemplateEngine};
+use apss_v1_0000_meta::{MetaStandard, Standard};
 use fixtures::create_test_workspace;
 use std::fs;
 use std::path::Path;

--- a/crates/aps-cli/tests/validation_test.rs
+++ b/crates/aps-cli/tests/validation_test.rs
@@ -5,7 +5,7 @@
 
 mod fixtures;
 
-use aps_v1_0000_meta::{MetaStandard, Standard, error_codes};
+use apss_v1_0000_meta::{MetaStandard, Standard, error_codes};
 use fixtures::{
     InvalidKind, create_invalid_standard, create_test_workspace, create_valid_standard,
 };

--- a/crates/aps-cli/tests/workflow_test.rs
+++ b/crates/aps-cli/tests/workflow_test.rs
@@ -4,9 +4,9 @@
 
 mod fixtures;
 
-use aps_v1_0000_meta::{MetaStandard, Standard};
 use apss_core::promotion::promote_experiment;
 use apss_core::versioning::{BumpPart, bump_version, get_version};
+use apss_v1_0000_meta::{MetaStandard, Standard};
 use fixtures::{create_test_workspace, create_valid_experiment, create_valid_standard};
 use std::fs;
 

--- a/crates/apss-core/src/distribution/mod.rs
+++ b/crates/apss-core/src/distribution/mod.rs
@@ -756,7 +756,7 @@ mod tests {
         // enough; the full matrix lives in crate::ecosystem's own tests.
         assert!(crate::ecosystem::is_ecosystem_crate("apss-core"));
         assert!(crate::ecosystem::is_ecosystem_crate(
-            "aps-v1-0000-cf01-project-config"
+            "apss-v1-0000-cf01-project-config"
         ));
         assert!(!crate::ecosystem::is_ecosystem_crate(
             "apss-v1-0001-code-topology"

--- a/crates/apss-core/src/ecosystem.rs
+++ b/crates/apss-core/src/ecosystem.rs
@@ -4,9 +4,10 @@
 //! Non-standard-shaped ecosystem crates fall into two buckets:
 //!
 //! - Named literals: `apss-core`, `apss`, `apss-project-config`,
-//!   `apss-distribution`  -  shared engine and CLI bootstrap.
-//! - Meta-substandard prefix: `aps-v1-0000-*`  -  substandards belonging to the
-//!   meta standard (e.g. CF01, DI01, SS01).
+//!   `apss-distribution`  -  shared engine and CLI bootstrap, plus CF01 and
+//!   DI01, whose crates use bespoke names rather than the prefix below.
+//! - Meta-substandard prefix: `apss-v1-0000-*`  -  substandards belonging to
+//!   the meta standard that do follow the prefix (e.g. CL01, SS01).
 //!
 //! This list is shared by DI01 (distribution validation) and any future
 //! tooling that needs to distinguish ecosystem crates from standards.
@@ -19,8 +20,8 @@ pub const ECOSYSTEM_CRATE_NAMES: &[&str] = &[
     "apss-distribution",
 ];
 
-/// Prefix identifying meta-substandard crates (e.g. `aps-v1-0000-cf01-project-config`).
-pub const META_SUBSTANDARD_PREFIX: &str = "aps-v1-0000";
+/// Prefix identifying meta-substandard crates (e.g. `apss-v1-0000-cf01-project-config`).
+pub const META_SUBSTANDARD_PREFIX: &str = "apss-v1-0000";
 
 /// Returns `true` if the crate is an ecosystem crate rather than a published standard.
 pub fn is_ecosystem_crate(name: &str) -> bool {
@@ -41,9 +42,11 @@ mod tests {
 
     #[test]
     fn meta_substandard_prefix_is_ecosystem() {
-        assert!(is_ecosystem_crate("aps-v1-0000-meta"));
-        assert!(is_ecosystem_crate("aps-v1-0000-ss01-substandard-structure"));
-        assert!(is_ecosystem_crate("aps-v1-0000-cf01-project-config"));
+        assert!(is_ecosystem_crate("apss-v1-0000-meta"));
+        assert!(is_ecosystem_crate(
+            "apss-v1-0000-ss01-substandard-structure"
+        ));
+        assert!(is_ecosystem_crate("apss-v1-0000-cf01-project-config"));
     }
 
     #[test]

--- a/standards-experimental/v1/EXP-V1-0001-code-topology/src/lib.rs
+++ b/standards-experimental/v1/EXP-V1-0001-code-topology/src/lib.rs
@@ -959,7 +959,7 @@ impl Default for CodeTopologyStandard {
 }
 
 // TODO: Implement Standard trait in Milestone 4
-// impl aps_v1_0000_meta::Standard for CodeTopologyStandard {
+// impl apss_v1_0000_meta::Standard for CodeTopologyStandard {
 //     fn validate_package(&self, path: &Path) -> Diagnostics { ... }
 //     fn validate_repo(&self, path: &Path) -> Diagnostics { ... }
 // }

--- a/standards/v1/APS-V1-0000-meta/Cargo.toml
+++ b/standards/v1/APS-V1-0000-meta/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "aps-v1-0000-meta"
+name = "apss-v1-0000-meta"
 version = "1.5.0"
 edition.workspace = true
 license.workspace = true

--- a/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/Cargo.toml
+++ b/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "aps-v1-0000-cli01-cli-contract"
+name = "apss-v1-0000-cli01-cli-contract"
 version = "1.2.1"
 edition.workspace = true
 license.workspace = true

--- a/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/examples/README.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/examples/README.md
@@ -7,7 +7,7 @@ See the Code Topology standard (EXP-V1-0001) for a complete implementation.
 ### Basic Implementation
 
 ```rust
-use aps_v1_0000_cli01_cli_contract::{
+use apss_v1_0000_cli01_cli_contract::{
     StandardCli, CliResult, CliCommandInfo, CliDiagnostic
 };
 

--- a/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/src/lib.rs
+++ b/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/src/lib.rs
@@ -19,7 +19,7 @@
 //! Standards that expose CLI commands implement the `StandardCli` trait:
 //!
 //! ```ignore
-//! use aps_v1_0000_cli01_cli_contract::{StandardCli, CliResult, CliCommandInfo};
+//! use apss_v1_0000_cli01_cli_contract::{StandardCli, CliResult, CliCommandInfo};
 //!
 //! struct TopologyCli;
 //!

--- a/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/tests/README.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/CL01-cli-contract/tests/README.md
@@ -5,7 +5,7 @@ Tests for the CLI contract are included in `src/lib.rs`.
 Run tests with:
 
 ```bash
-cargo test -p aps-v1-0000-cli01-cli-contract
+cargo test -p apss-v1-0000-cli01-cli-contract
 ```
 
 ## Test Coverage

--- a/standards/v1/APS-V1-0000-meta/substandards/SS01-substandard-structure/Cargo.toml
+++ b/standards/v1/APS-V1-0000-meta/substandards/SS01-substandard-structure/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "aps-v1-0000-ss01-substandard-structure"
+name = "apss-v1-0000-ss01-substandard-structure"
 version = "1.1.0"
 edition.workspace = true
 license.workspace = true

--- a/standards/v1/APS-V1-0000-meta/substandards/SS01-substandard-structure/src/lib.rs
+++ b/standards/v1/APS-V1-0000-meta/substandards/SS01-substandard-structure/src/lib.rs
@@ -35,7 +35,7 @@ pub fn is_valid_substandard_id(id: &str) -> bool {
 ///
 /// # Example
 /// ```
-/// use aps_v1_0000_ss01_substandard_structure::extract_parent_id;
+/// use apss_v1_0000_ss01_substandard_structure::extract_parent_id;
 /// assert_eq!(extract_parent_id("APS-V1-0000.SS01"), Some("APS-V1-0000".to_string()));
 /// ```
 pub fn extract_parent_id(substandard_id: &str) -> Option<String> {

--- a/standards/v1/APS-V1-0000-meta/substandards/SS01-substandard-structure/tests/README.md
+++ b/standards/v1/APS-V1-0000-meta/substandards/SS01-substandard-structure/tests/README.md
@@ -40,7 +40,7 @@ Tests should verify that `substandard.toml` parsing works correctly and validati
 
 ```bash
 # Run substandard tests
-cargo test -p aps-v1-0000-ss01-substandard-structure
+cargo test -p apss-v1-0000-ss01-substandard-structure
 
 # Run via CLI
 cargo run -p aps-cli --bin apss-dev -- v1 validate substandard APS-V1-0000.SS01

--- a/standards/v1/APS-V1-0000-meta/templates/standard/skeleton/src/lib.rs
+++ b/standards/v1/APS-V1-0000-meta/templates/standard/skeleton/src/lib.rs
@@ -29,7 +29,7 @@ impl Default for {{id}}Standard {
 }
 
 // TODO: Implement the Standard trait
-// impl aps_v1_0000_meta::Standard for {{id}}Standard {
+// impl apss_v1_0000_meta::Standard for {{id}}Standard {
 //     fn validate_package(&self, path: &Path) -> Diagnostics {
 //         Diagnostics::new()
 //     }

--- a/standards/v1/APS-V1-0000-meta/tests/README.md
+++ b/standards/v1/APS-V1-0000-meta/tests/README.md
@@ -24,10 +24,10 @@ Test complete validation workflows:
 
 ```bash
 # Run all tests for this crate
-cargo test -p aps-v1-0000-meta
+cargo test -p apss-v1-0000-meta
 
 # Run with verbose output
-cargo test -p aps-v1-0000-meta -- --nocapture
+cargo test -p apss-v1-0000-meta -- --nocapture
 ```
 
 ## Test Requirements

--- a/standards/v1/APS-V1-0001-code-topology/src/lib.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/lib.rs
@@ -962,7 +962,7 @@ impl Default for CodeTopologyStandard {
 }
 
 // TODO: Implement Standard trait in Milestone 4
-// impl aps_v1_0000_meta::Standard for CodeTopologyStandard {
+// impl apss_v1_0000_meta::Standard for CodeTopologyStandard {
 //     fn validate_package(&self, path: &Path) -> Diagnostics { ... }
 //     fn validate_repo(&self, path: &Path) -> Diagnostics { ... }
 // }


### PR DESCRIPTION
## Summary
Three of the meta-standard's own crates used the stale single-s \`aps-\` prefix instead of \`apss-\`: the meta-standard itself (\`aps-v1-0000-meta\`), CL01 (\`aps-v1-0000-cli01-cli-contract\`), and SS01 (\`aps-v1-0000-ss01-substandard-structure\`). None of these publish to crates.io (the meta-standard and its internal substandards are excluded from the publish job), so this is a pure naming-consistency fix.

Renamed all three package names, the path dependency in \`crates/aps-cli/Cargo.toml\`, every \`use aps_v1_0000_*::\` import, and \`apss-core\`'s \`ecosystem.rs\` (which encodes \`aps-v1-0000\` as the recognized prefix for DI01 distribution validation). Also fixed that module's doc comment, which had CF01/DI01 miscategorized.

CF01 and DI01 keep their existing bespoke \`apss-project-config\` / \`apss-distribution\` names, a separate deliberate design choice, out of scope here.

## Test plan
- [x] \`cargo build --workspace\`
- [x] \`cargo test --workspace\` - all pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all --check\`
- [x] \`cargo run -p aps-cli --bin apss-dev -- v1 validate repo\` - 0 errors, 0 warnings