### PR TITLE
chore(ci): remove diagnostic workflow_dispatch trigger from release gate

### DIFF
--- a/.github/workflows/main-to-release-gate.yml
+++ b/.github/workflows/main-to-release-gate.yml
@@ -20,13 +20,6 @@ name: Release Gate
 on:
   pull_request:
     branches: [release]
-  # TEMPORARY diagnostic trigger: this workflow's pull_request trigger has
-  # never fired in this repo's history. workflow_dispatch lets us invoke it
-  # manually to isolate whether the workflow itself is broken (it isn't,
-  # per actionlint and local simulation) or whether GitHub's pull_request
-  # event matching for this specific workflow/repo is the actual problem.
-  # Remove once the pull_request trigger is confirmed working again.
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Removes the temporary \`workflow_dispatch\` trigger added in #99 for diagnosing why the release gate never fired. Root cause found and fixed in #100 (reusable workflows in a \`checks/\` subdirectory, which GitHub Actions rejects), confirmed working via a manual dispatch run.

## Test plan
- [x] actionlint clean