### PR TITLE
chore(release): bump versions the release gate flagged as missed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "apss-v1-0000-meta"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "apss-core",
  "tempfile",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "apss-v1-0000-ss01-substandard-structure"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "apss-core",
  "regex",

--- a/standards-experimental/v1/EXP-V1-0001-code-topology/Cargo.toml
+++ b/standards-experimental/v1/EXP-V1-0001-code-topology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apss-v1-0001-code-topology-experimental"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/standards-experimental/v1/EXP-V1-0001-code-topology/experiment.toml
+++ b/standards-experimental/v1/EXP-V1-0001-code-topology/experiment.toml
@@ -4,7 +4,7 @@ schema = "aps.experiment/v1"
 id = "EXP-V1-0001"
 name = "Code Topology and Coupling Analysis"
 slug = "code-topology"
-version = "0.1.0"
+version = "0.1.1"
 category = "technical"
 
 [aps]

--- a/standards/v1/APS-V1-0000-meta/Cargo.toml
+++ b/standards/v1/APS-V1-0000-meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apss-v1-0000-meta"
-version = "1.5.0"
+version = "1.5.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/standards/v1/APS-V1-0000-meta/standard.toml
+++ b/standards/v1/APS-V1-0000-meta/standard.toml
@@ -4,7 +4,7 @@ schema = "aps.standard/v1"
 id = "APS-V1-0000"
 name = "APS Meta-Standard"
 slug = "meta"
-version = "1.5.0"
+version = "1.5.1"
 category = "governance"
 status = "active"
 

--- a/standards/v1/APS-V1-0000-meta/substandards/SS01-substandard-structure/Cargo.toml
+++ b/standards/v1/APS-V1-0000-meta/substandards/SS01-substandard-structure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apss-v1-0000-ss01-substandard-structure"
-version = "1.1.0"
+version = "1.1.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/standards/v1/APS-V1-0000-meta/substandards/SS01-substandard-structure/substandard.toml
+++ b/standards/v1/APS-V1-0000-meta/substandards/SS01-substandard-structure/substandard.toml
@@ -4,7 +4,7 @@ schema = "aps.substandard/v1"
 id = "APS-V1-0000.SS01"
 name = "Substandard Structure"
 slug = "substandard-structure"
-version = "1.1.0"
+version = "1.1.1"
 parent_id = "APS-V1-0000"
 parent_major = "1"
 

--- a/standards/v1/APS-V1-0001-code-topology/substandards/CI01-github-actions/substandard.toml
+++ b/standards/v1/APS-V1-0001-code-topology/substandards/CI01-github-actions/substandard.toml
@@ -4,7 +4,7 @@ schema = "aps.substandard/v1"
 id = "APS-V1-0001.CI01"
 name = "GitHub Actions CI Integration"
 slug = "github-actions"
-version = "0.1.0"
+version = "0.1.1"
 parent_id = "APS-V1-0001"
 parent_major = "0"
 

--- a/standards/v1/APS-V1-0001-code-topology/substandards/VZ01-dashboard/substandard.toml
+++ b/standards/v1/APS-V1-0001-code-topology/substandards/VZ01-dashboard/substandard.toml
@@ -4,7 +4,7 @@ schema = "aps.substandard/v1"
 id = "APS-V1-0001.VZ01"
 name = "Topology Visualization Dashboard"
 slug = "dashboard"
-version = "0.1.0"
+version = "0.1.1"
 parent_id = "APS-V1-0001"
 parent_major = "0"
 


### PR DESCRIPTION
## Summary
The release gate finally fired for real on PR #102 and its \`version-bump-check\` job caught real gaps: 5 packages had non-docs file changes in the earlier aps->apss doc sweep and meta-crate rename work, but were never version-bumped.

- APS-V1-0000 (meta-standard): 1.5.0 -> 1.5.1
- SS01-substandard-structure: 1.1.0 -> 1.1.1
- CI01-github-actions (APS-V1-0001 substandard): 0.1.0 -> 0.1.1
- VZ01-dashboard (APS-V1-0001 substandard): 0.1.0 -> 0.1.1
- EXP-V1-0001-code-topology: 0.1.0 -> 0.1.1

## Test plan
- [x] \`cargo build --workspace\`
- [x] \`cargo run -p aps-cli --bin apss-dev -- v1 validate repo\` - 0 errors
- [x] \`just check\` passes