### PR TITLE
fix(init): resolve known standard slugs to a real id + version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "aps-cli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "apss-core",
  "apss-distribution",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "apss"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "apss-core",
  "clap",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "apss-core"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "handlebars",
  "semver",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "apss-v1-0001-code-topology"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "apss-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/AgentParadise/agent-paradise-standards-system"

--- a/crates/apss-bootstrap/src/init.rs
+++ b/crates/apss-bootstrap/src/init.rs
@@ -43,7 +43,12 @@ pub fn run(args: InitArgs) -> i32 {
         for spec in &args.standards {
             let (slug, version) = parse_standard_spec(spec);
             content.push_str(&format!("  {slug}:\n"));
-            content.push_str("    id: APS-V1-XXXX  # FIXME: Replace with correct standard ID (e.g. APS-V1-0001)\n");
+            match resolve_standard_id(&slug) {
+                Some(id) => content.push_str(&format!("    id: {id}\n")),
+                None => content.push_str(
+                    "    id: APS-V1-XXXX  # FIXME: Replace with correct standard ID (e.g. APS-V1-0001)\n",
+                ),
+            }
             content.push_str(&format!("    version: \"{version}\"\n"));
         }
     }
@@ -77,6 +82,25 @@ pub fn run(args: InitArgs) -> i32 {
     println!("  3. Run 'apss run <standard> <command>' to use it");
 
     0
+}
+
+/// Slug -> standard ID for officially published standards, so `apss init
+/// --standard <slug>` can write a real `id:` instead of a FIXME placeholder
+/// for standards it can actually resolve without a network call. Kept in
+/// sync manually as standards are promoted; experimental standards are
+/// deliberately excluded since their IDs are unstable pre-promotion and they
+/// are not installable via crates.io.
+const KNOWN_STANDARD_IDS: &[(&str, &str)] = &[
+    ("code-topology", "APS-V1-0001"),
+    ("architecture-fitness", "APS-V1-0002"),
+    ("documentation", "APS-V1-0003"),
+];
+
+fn resolve_standard_id(slug: &str) -> Option<&'static str> {
+    KNOWN_STANDARD_IDS
+        .iter()
+        .find(|(known_slug, _)| *known_slug == slug)
+        .map(|(_, id)| *id)
 }
 
 fn parse_standard_spec(spec: &str) -> (String, String) {

--- a/crates/apss-bootstrap/tests/init_integration.rs
+++ b/crates/apss-bootstrap/tests/init_integration.rs
@@ -79,7 +79,7 @@ fn test_init_preserves_existing_root_gitignore() {
 }
 
 #[test]
-fn test_init_with_standard_flag() {
+fn test_init_with_known_standard_flag_resolves_real_id() {
     let temp = tempfile::tempdir().unwrap();
 
     let status = Command::new(APSS_BIN)
@@ -98,8 +98,39 @@ fn test_init_with_standard_flag() {
         apss_yaml.contains("version: \">=1.0.0\""),
         "missing version requirement:\n{apss_yaml}"
     );
+    // code-topology is a known, officially published standard, so init
+    // should resolve its real ID directly instead of leaving a FIXME for
+    // the user to fill in by hand.
+    assert!(
+        apss_yaml.contains("id: APS-V1-0001"),
+        "missing resolved standard id:\n{apss_yaml}"
+    );
+    assert!(
+        !apss_yaml.contains("FIXME"),
+        "known standard should not need a FIXME placeholder:\n{apss_yaml}"
+    );
+}
+
+#[test]
+fn test_init_with_unknown_standard_flag_falls_back_to_fixme() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let status = Command::new(APSS_BIN)
+        .args(["init", "--standard", "some-future-standard@>=1.0.0"])
+        .current_dir(temp.path())
+        .status()
+        .expect("failed to invoke apss init --standard");
+    assert!(status.success(), "apss init exited non-zero: {status}");
+
+    let apss_yaml = std::fs::read_to_string(temp.path().join("apss.yaml")).unwrap();
+    assert!(
+        apss_yaml.contains("  some-future-standard:"),
+        "missing standards.some-future-standard section:\n{apss_yaml}"
+    );
+    // An unrecognized slug can't be resolved without a network call, so it
+    // must still fall back to the FIXME placeholder hint.
     assert!(
         apss_yaml.contains("FIXME"),
-        "missing FIXME placeholder hint for standard id:\n{apss_yaml}"
+        "missing FIXME placeholder hint for unresolvable standard id:\n{apss_yaml}"
     );
 }

--- a/standards/v1/APS-V1-0001-code-topology/Cargo.toml
+++ b/standards/v1/APS-V1-0001-code-topology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apss-v1-0001-code-topology"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/standards/v1/APS-V1-0001-code-topology/standard.toml
+++ b/standards/v1/APS-V1-0001-code-topology/standard.toml
@@ -4,7 +4,7 @@ schema = "aps.standard/v1"
 id = "APS-V1-0001"
 name = "Code Topology and Coupling Analysis"
 slug = "code-topology"
-version = "0.2.1"
+version = "0.2.2"
 category = "technical"
 status = "active"
 


### PR DESCRIPTION
## Summary
- Fixes a real rough edge found while dogfooding: `apss init --standard code-topology` always wrote a literal `id: APS-V1-XXXX  # FIXME: ...` placeholder even for standards this repo actually publishes and could resolve on its own. Added a small known-slug lookup table (the three currently published official standards) so init writes the real ID directly for those; unknown slugs still fall back to FIXME (no network call, compile-time only).
- Bumps the workspace version 1.2.0 -> 1.3.0 (`aps-cli` changed: gained the agent-recipe standard's registration in #89).
- Bumps `APS-V1-0001-code-topology` 0.2.2 -> ... wait, patch (the cognitive-complexity fix in #90).

## Test plan
- [x] `cargo test --workspace` - all pass, including 2 new/updated tests for the init resolution behavior
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo run -p aps-cli --bin apss-dev -- v1 validate repo` - 0 errors
- [x] Manual smoke test: `apss init --standard code-topology` now writes `id: APS-V1-0001` directly, no FIXME