### PR TITLE
fix(code-topology): full SonarSource alignment for cognitive complexity (6 follow-ups to #90)

### DIFF
--- a/standards/v1/APS-V1-0001-code-topology/src/adapter/complexity.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/adapter/complexity.rs
@@ -117,32 +117,56 @@ impl<'g> ComplexityCalculator<'g> {
         None
     }
 
-    /// Find the outermost function-like node fully ENCLOSED by `[start, end]`.
+    /// Find the SINGLE outermost function-like node fully ENCLOSED by
+    /// `[start, end]`, or `None` if the range encloses zero or several sibling
+    /// functions.
     ///
     /// Complements `find_node_in_range` (which finds a function CONTAINING the
     /// range). Used by the fallback so a function whose enclosing construct
     /// (class body, export wrapper) is the outer node is still measured at
     /// nesting level 0 rather than descended-through and inflated (finding 1).
+    ///
+    /// We only delegate to `compute_cognitive` when EXACTLY ONE function is
+    /// enclosed. When the range encloses multiple sibling top-level functions,
+    /// returning the first preorder match would silently measure just that one
+    /// function and ignore the rest. In that case we return `None` so the caller
+    /// retains the range-traversal path and accounts for every enclosed function.
     fn find_enclosed_function<'a>(
         &self,
         node: Node<'a>,
         start_line: u32,
         end_line: u32,
     ) -> Option<Node<'a>> {
+        let mut found = Vec::new();
+        self.collect_enclosed_functions(node, start_line, end_line, &mut found);
+        match found.as_slice() {
+            [only] => Some(*only),
+            _ => None,
+        }
+    }
+
+    /// Collect the outermost function-like nodes fully ENCLOSED by
+    /// `[start, end]` without descending into a function once one is found (so
+    /// nested functions are not double-collected).
+    fn collect_enclosed_functions<'a>(
+        &self,
+        node: Node<'a>,
+        start_line: u32,
+        end_line: u32,
+        out: &mut Vec<Node<'a>>,
+    ) {
         let node_start = node.start_position().row as u32 + 1;
         let node_end = node.end_position().row as u32 + 1;
 
         if node_start >= start_line && node_end <= end_line && self.is_function_node(node.kind()) {
-            return Some(node);
+            out.push(node);
+            return;
         }
 
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            if let Some(found) = self.find_enclosed_function(child, start_line, end_line) {
-                return Some(found);
-            }
+            self.collect_enclosed_functions(child, start_line, end_line, out);
         }
-        None
     }
 
     /// Check if a node type represents a function.
@@ -497,17 +521,32 @@ impl<'g> ComplexityCalculator<'g> {
         None
     }
 
-    /// Whether `node`'s parent is a logical binary using the same operator.
-    /// Used to charge only the FIRST node of each same-operator run (finding 5).
+    /// Whether `node`'s effective logical parent is a logical binary using the
+    /// same operator. Used to charge only the FIRST node of each same-operator
+    /// run (finding 5).
+    ///
+    /// Parentheses are TRANSPARENT for operator continuation: SonarSource charges
+    /// +1 per RUN of the same operator, and a parenthesized subexpression does
+    /// NOT split a run. tree-sitter models `a && (b && c)` so the inner `&&`'s
+    /// direct parent is a `parenthesized_expression`, not the outer
+    /// `binary_expression`/`boolean_operator`. We therefore walk UP through any
+    /// `parenthesized_expression` ancestors before comparing the operator token;
+    /// otherwise a parenthesized same-operator subexpression is mistaken for a
+    /// fresh run and over-counted by one.
     fn parent_is_same_logical_operator(&self, node: Node, op: &str) -> bool {
-        match node.parent() {
-            Some(parent)
-                if parent.kind() == "binary_expression" || parent.kind() == "boolean_operator" =>
-            {
-                self.logical_operator_of(parent) == Some(op)
+        let mut current = node;
+        while let Some(parent) = current.parent() {
+            match parent.kind() {
+                "parenthesized_expression" => {
+                    current = parent;
+                }
+                "binary_expression" | "boolean_operator" => {
+                    return self.logical_operator_of(parent) == Some(op);
+                }
+                _ => return false,
             }
-            _ => false,
         }
+        false
     }
 
     // ========================================================================
@@ -1062,6 +1101,28 @@ mod tests {
         assert_eq!(cognitive_of(&grammar, method), 3);
     }
 
+    #[test]
+    fn ts_cognitive_range_with_multiple_sibling_functions_measures_all() {
+        // When a range encloses several sibling top-level functions, the fallback
+        // must NOT collapse to just the first function's value. Before the fix,
+        // `find_enclosed_function` returned the first preorder function, so only
+        // `a`'s single decision was measured (cognitive == 1). The fix returns
+        // `None` for a multi-function range so the range-traversal path accounts
+        // for both functions' decisions, yielding a value greater than 1.
+        let grammar = TypeScriptGrammar::new();
+        let src = "function a() {\n  if (x) {\n  }\n}\nfunction b() {\n  if (y) {\n  }\n}\n";
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&grammar.ts_language()).unwrap();
+        let tree = parser.parse(src, None).unwrap();
+        let calc = ComplexityCalculator::new(&grammar);
+        let end = src.lines().count() as u32;
+        let cognitive = calc.compute_cognitive_range(tree.root_node(), 1, end, 0);
+        assert!(
+            cognitive > 1,
+            "multi-function range must not collapse to the first function's value of 1, got {cognitive}"
+        );
+    }
+
     // --- Finding 2: try does not nest; catch increments and nests --------
 
     #[test]
@@ -1131,6 +1192,69 @@ mod tests {
             cognitive_of(
                 &grammar,
                 "function f() {\n  if (a || b || c && d) {\n  }\n}\n"
+            ),
+            3
+        );
+    }
+
+    // --- Parenthesized same-operator runs are transparent ----------------
+    //
+    // SonarSource charges +1 per RUN of the same logical operator, and
+    // parentheses do NOT split a run. Before walking up through
+    // `parenthesized_expression` ancestors, the inner logical node's direct
+    // parent was the parens (not a logical binary), so it was mistaken for a
+    // fresh run and over-counted by one.
+
+    #[test]
+    fn ts_cognitive_parenthesized_same_operator_run_not_overcounted() {
+        let grammar = TypeScriptGrammar::new();
+        // if (a && (b && c)): one `&&` run (+1) plus the `if` (+1) == 2.
+        // Before the fix this returned 3 (the parenthesized inner `&&` counted
+        // as a second run).
+        assert_eq!(
+            cognitive_of(&grammar, "function f() {\n  if (a && (b && c)) {\n  }\n}\n"),
+            2
+        );
+        // if (a && (b || c) && d): outer `&&` run (+1), the parenthesized `||`
+        // differs from its `&&` parent (+1), plus the `if` (+1) == 3. This value
+        // must be unchanged by the fix (it was already 3, not 4).
+        assert_eq!(
+            cognitive_of(
+                &grammar,
+                "function f() {\n  if (a && (b || c) && d) {\n  }\n}\n"
+            ),
+            3
+        );
+        // Unparenthesized regressions must stay put: `&&` + `||` + `if` == 3.
+        assert_eq!(
+            cognitive_of(&grammar, "function f() {\n  if (a && b || c) {\n  }\n}\n"),
+            3
+        );
+        // and a single `&&` run + `if` == 2.
+        assert_eq!(
+            cognitive_of(&grammar, "function f() {\n  if (a && b && c) {\n  }\n}\n"),
+            2
+        );
+    }
+
+    #[test]
+    fn python_cognitive_parenthesized_same_operator_run_not_overcounted() {
+        let grammar = PythonGrammar::new();
+        // if a and (b and c): one `and` run (+1) plus the `if` (+1) == 2.
+        // Before the fix this returned 3.
+        assert_eq!(
+            cognitive_of(
+                &grammar,
+                "def f(a, b, c):\n    if a and (b and c):\n        pass\n"
+            ),
+            2
+        );
+        // if a and (b or c) and d: `and` run (+1), parenthesized `or` differs
+        // (+1), plus `if` (+1) == 3.
+        assert_eq!(
+            cognitive_of(
+                &grammar,
+                "def f(a, b, c, d):\n    if a and (b or c) and d:\n        pass\n"
             ),
             3
         );

--- a/standards/v1/APS-V1-0001-code-topology/src/adapter/complexity.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/adapter/complexity.rs
@@ -117,6 +117,34 @@ impl<'g> ComplexityCalculator<'g> {
         None
     }
 
+    /// Find the outermost function-like node fully ENCLOSED by `[start, end]`.
+    ///
+    /// Complements `find_node_in_range` (which finds a function CONTAINING the
+    /// range). Used by the fallback so a function whose enclosing construct
+    /// (class body, export wrapper) is the outer node is still measured at
+    /// nesting level 0 rather than descended-through and inflated (finding 1).
+    fn find_enclosed_function<'a>(
+        &self,
+        node: Node<'a>,
+        start_line: u32,
+        end_line: u32,
+    ) -> Option<Node<'a>> {
+        let node_start = node.start_position().row as u32 + 1;
+        let node_end = node.end_position().row as u32 + 1;
+
+        if node_start >= start_line && node_end <= end_line && self.is_function_node(node.kind()) {
+            return Some(node);
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if let Some(found) = self.find_enclosed_function(child, start_line, end_line) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
     /// Check if a node type represents a function.
     fn is_function_node(&self, kind: &str) -> bool {
         // Common function node types across languages.
@@ -243,32 +271,51 @@ impl<'g> ComplexityCalculator<'g> {
     }
 
     // ========================================================================
-    // Cognitive Complexity
+    // Cognitive Complexity (SonarSource reference algorithm)
+    //
+    // Three ingredients from the SonarSource paper
+    // (https://www.sonarsource.com/docs/CognitiveComplexity.pdf):
+    //
+    // - B1 (increment +1): each `if`, `else if`, `else`, ternary, `switch`,
+    //   loop, `catch`, and each SEQUENCE of like logical operators (`&&`/`||`).
+    // - B2 (nesting): `if`, `else`/`else if`, ternary, `switch`, loop, `catch`,
+    //   and nested functions/lambdas raise the nesting level of their body.
+    // - B3 (nesting penalty): a structure that BOTH increments AND nests
+    //   (`if`, ternary, `switch`, loop, `catch`) adds the current nesting level
+    //   on top of its +1. `else`/`else if`, logical operators, and recursion
+    //   increment but take NO penalty.
+    //
+    // The measured function's own node is nesting level 0: `compute_cognitive`
+    // visits its CHILDREN at the incoming level, so the function definition is
+    // never itself counted as a nesting level.
     // ========================================================================
 
-    /// Compute cognitive complexity for a node.
+    /// Compute cognitive complexity for a function node (visited at level 0).
     ///
-    /// Cognitive complexity adds a nesting penalty for each level of nesting.
-    ///
-    /// `node` is expected to be the measured function's own tree-sitter node.
-    /// We visit its CHILDREN at the incoming `nesting_level` rather than the
-    /// function node itself, so the function's own definition does not count as
-    /// a nesting level (which would inflate every construct in its body by one).
-    /// Genuinely-nested functions/closures encountered while descending the body
-    /// are still in `nesting_nodes`, so they correctly add a nesting level.
-    /// This matches the SonarSource Cognitive Complexity reference algorithm.
+    /// `node` is the measured function's own tree-sitter node. Its CHILDREN are
+    /// visited at the incoming `nesting_level`, so the function's own definition
+    /// does not count as a nesting level. Genuinely-nested functions/closures
+    /// encountered while descending the body ARE in `nesting_nodes`, so they
+    /// correctly raise the nesting level. Matches the SonarSource reference.
     pub fn compute_cognitive(&self, node: Node, nesting_level: u32) -> u32 {
         let mut cog = 0;
 
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            self.visit_for_cognitive(child, nesting_level, &mut cog);
+            self.visit_for_cognitive(child, nesting_level, None, &mut cog);
         }
 
         cog
     }
 
-    /// Compute cognitive complexity within a line range.
+    /// Compute cognitive complexity within a line range (fallback path).
+    ///
+    /// Finding 1: if a function-like node bounds this range, delegate to
+    /// `compute_cognitive` so the function's own node stays at nesting level 0.
+    /// Visiting the range's raw children would descend THROUGH the function node
+    /// (a nesting node) and inflate every construct in its body by one level.
+    /// Only when no function node bounds the range (module-level code) do we
+    /// visit children directly.
     fn compute_cognitive_range(
         &self,
         node: Node,
@@ -276,43 +323,78 @@ impl<'g> ComplexityCalculator<'g> {
         end_line: u32,
         nesting_level: u32,
     ) -> u32 {
-        let mut cog = 0;
-
-        // Mirror `compute_cognitive`: visit the node's CHILDREN at the incoming
-        // nesting level rather than the node itself, so the enclosing
-        // function/scope does not spuriously count as a nesting level.
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            self.visit_for_cognitive_range(child, start_line, end_line, nesting_level, &mut cog);
+        // Prefer a function-like node that CONTAINS the range; failing that, one
+        // ENCLOSED by the range (e.g. a method whose class is the outer node, or
+        // an export/const wrapper measured with the whole file's range). Either
+        // way we measure it at nesting level 0 via `compute_cognitive`.
+        if let Some(function_node) = self
+            .find_node_in_range(node, start_line, end_line)
+            .or_else(|| self.find_enclosed_function(node, start_line, end_line))
+        {
+            return self.compute_cognitive(function_node, nesting_level);
         }
 
+        let mut cog = 0;
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.visit_for_cognitive(child, nesting_level, Some((start_line, end_line)), &mut cog);
+        }
         cog
     }
 
-    fn visit_for_cognitive(&self, node: Node, nesting_level: u32, cog: &mut u32) {
+    /// Core cognitive-complexity visitor.
+    ///
+    /// `range` optionally restricts counting to nodes whose start line is inside
+    /// `[start, end]` (used only by the module-level fallback path).
+    fn visit_for_cognitive(
+        &self,
+        node: Node,
+        nesting_level: u32,
+        range: Option<(u32, u32)>,
+        cog: &mut u32,
+    ) {
+        if let Some((start_line, end_line)) = range {
+            let node_line = node.start_position().row as u32 + 1;
+            if node_line < start_line || node_line > end_line {
+                return;
+            }
+        }
+
         let kind = node.kind();
 
-        // Skip ignored nodes
+        // Skip ignored nodes (e.g. `?.`, `?`, `try`-`?` operators).
         if self.ignored_nodes.contains(kind) {
             return;
         }
 
-        let is_nesting = self.nesting_nodes.contains(kind);
-        let is_decision = self.cognitive_decision_nodes.contains(kind);
-
-        // Decision nodes add base + nesting penalty
-        if is_decision {
-            if kind == "binary_expression" || kind == "boolean_operator" {
-                if self.is_logical_operator(node) {
-                    *cog += 1; // Logical operators don't get nesting penalty
+        // Logical operator sequences (B1). SonarSource charges +1 per RUN of the
+        // same operator, plus +1 whenever the operator changes within a chain,
+        // and NO nesting penalty. tree-sitter left-associates `a && b && c` as
+        // `((a && b) && c)`, so we charge a logical node only when it STARTS a
+        // new run: i.e. when its parent is not a logical binary with the same
+        // operator (finding 5). The nesting level is unchanged by a logical op.
+        if (kind == "binary_expression" || kind == "boolean_operator")
+            && self.cognitive_decision_nodes.contains(kind)
+        {
+            if let Some(op) = self.logical_operator_of(node) {
+                if !self.parent_is_same_logical_operator(node, op) {
+                    *cog += 1;
                 }
-            } else {
-                *cog += 1 + nesting_level; // Base + nesting penalty
             }
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                self.visit_for_cognitive(child, nesting_level, range, cog);
+            }
+            return;
         }
 
-        // Recurse with updated nesting level
-        let new_nesting = if is_nesting {
+        let (increment, penalty, bump) = self.cognitive_effect(node);
+
+        if increment {
+            *cog += 1 + if penalty { nesting_level } else { 0 };
+        }
+
+        let new_nesting = if bump {
             nesting_level + 1
         } else {
             nesting_level
@@ -320,55 +402,111 @@ impl<'g> ComplexityCalculator<'g> {
 
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            self.visit_for_cognitive(child, new_nesting, cog);
+            self.visit_for_cognitive(child, new_nesting, range, cog);
         }
     }
 
-    fn visit_for_cognitive_range(
-        &self,
-        node: Node,
-        start_line: u32,
-        end_line: u32,
-        nesting_level: u32,
-        cog: &mut u32,
-    ) {
-        // Convert 0-indexed tree-sitter position to 1-indexed line number
-        let node_line = node.start_position().row as u32 + 1;
-
-        // Skip nodes outside our range
-        if node_line < start_line || node_line > end_line {
-            return;
-        }
-
+    /// SonarSource classification for a single node.
+    ///
+    /// Returns `(increment, nesting_penalty, increases_nesting)`:
+    /// - `increment`: adds +1 (B1).
+    /// - `nesting_penalty`: the +1 also carries the current nesting level (B3).
+    /// - `increases_nesting`: the body is one level deeper (B2).
+    ///
+    /// Logical operators are handled by the caller (run detection), so they are
+    /// reported as no-ops here.
+    fn cognitive_effect(&self, node: Node) -> (bool, bool, bool) {
         let kind = node.kind();
 
-        // Skip ignored nodes
-        if self.ignored_nodes.contains(kind) {
-            return;
+        if kind == "binary_expression" || kind == "boolean_operator" {
+            return (false, false, false);
         }
 
-        let is_nesting = self.nesting_nodes.contains(kind);
+        // `break`/`continue` to a LABEL is a B1 increment (+1, no nesting
+        // penalty, no nesting). An unlabeled break/continue is not counted. A
+        // labeled form carries a label identifier child (`statement_identifier`
+        // in TS/JS, `label` in Rust).
+        if kind == "break_statement"
+            || kind == "continue_statement"
+            || kind == "break_expression"
+            || kind == "continue_expression"
+        {
+            let mut cursor = node.walk();
+            let has_label = node
+                .children(&mut cursor)
+                .any(|c| c.kind() == "statement_identifier" || c.kind() == "label");
+            return (has_label, false, false);
+        }
+
+        // `else if`: TS/Rust model it as an `if` nested inside an `else_clause`.
+        // It increments +1 with NO nesting penalty and does NOT add a nesting
+        // level (its body sits at the same level as the original `if` body).
+        // The wrapping `else_clause` must NOT also increment (finding 4).
+        if self.is_else_if(node) {
+            return (true, false, false);
+        }
+
+        // `else_clause`: a plain `else` (wrapping a block) increments +1 with no
+        // penalty. An `else_clause` wrapping an `if` (the "else if" case) does
+        // NOT increment here; the inner `if` carries the single +1. Either way
+        // it does not raise nesting: the enclosing `if` already did (finding 4).
+        if kind == "else_clause" {
+            let wraps_if = self.node_has_if_child(node);
+            return (!wraps_if, false, false);
+        }
+
+        // General structures. A node that both increments and nests (if,
+        // ternary, switch/match, loops, catch/except) takes the B3 penalty; a
+        // pure nesting node (function/lambda/closure/with) only raises nesting.
         let is_decision = self.cognitive_decision_nodes.contains(kind);
+        let is_nesting = self.nesting_nodes.contains(kind);
+        let increment = is_decision;
+        let penalty = is_decision && is_nesting;
+        (increment, penalty, is_nesting)
+    }
 
-        if is_decision {
-            if kind == "binary_expression" || kind == "boolean_operator" {
-                if self.is_logical_operator(node) {
-                    *cog += 1;
-                }
-            } else {
-                *cog += 1 + nesting_level;
-            }
+    /// Whether `node` is an `else if`: an `if` node whose parent is an
+    /// `else_clause` (TypeScript and Rust structure).
+    fn is_else_if(&self, node: Node) -> bool {
+        if node.kind() != "if_statement" && node.kind() != "if_expression" {
+            return false;
         }
+        node.parent().map(|p| p.kind()) == Some("else_clause")
+    }
 
-        let new_nesting = if is_nesting {
-            nesting_level + 1
-        } else {
-            nesting_level
-        };
+    /// Whether `node` has a direct child that is an `if` (used to distinguish an
+    /// `else if` `else_clause` from a plain `else`).
+    fn node_has_if_child(&self, node: Node) -> bool {
+        let mut cursor = node.walk();
+        node.children(&mut cursor)
+            .any(|c| c.kind() == "if_statement" || c.kind() == "if_expression")
+    }
 
+    /// Return the logical operator token of a logical binary node, if any.
+    fn logical_operator_of(&self, node: Node) -> Option<&'static str> {
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            self.visit_for_cognitive_range(child, start_line, end_line, new_nesting, cog);
+            match child.kind() {
+                "&&" => return Some("&&"),
+                "||" => return Some("||"),
+                "and" => return Some("and"),
+                "or" => return Some("or"),
+                _ => {}
+            }
+        }
+        None
+    }
+
+    /// Whether `node`'s parent is a logical binary using the same operator.
+    /// Used to charge only the FIRST node of each same-operator run (finding 5).
+    fn parent_is_same_logical_operator(&self, node: Node, op: &str) -> bool {
+        match node.parent() {
+            Some(parent)
+                if parent.kind() == "binary_expression" || parent.kind() == "boolean_operator" =>
+            {
+                self.logical_operator_of(parent) == Some(op)
+            }
+            _ => false,
         }
     }
 
@@ -746,7 +884,7 @@ mod tests {
     // functions/closures STILL add a nesting level after the fix.
     // ========================================================================
 
-    use crate::adapter::grammars::{RustGrammar, TypeScriptGrammar};
+    use crate::adapter::grammars::{PythonGrammar, RustGrammar, TypeScriptGrammar};
 
     /// Parse `source` with `grammar`, locate the (first/only) function that
     /// spans the whole snippet, and return its cognitive complexity.
@@ -879,5 +1017,194 @@ mod tests {
         // Equivalence check: the same body as a function_declaration.
         let decl = "function f() {\n  if (a) {\n    if (b) {\n    }\n  }\n}\n";
         assert_eq!(cognitive_of(&grammar, decl), 3);
+    }
+
+    // ========================================================================
+    // SonarSource panel findings 1-6: each has a reference-value micro-test
+    // that FAILS before its fix and PASSES after. Values are taken directly
+    // from the SonarSource Cognitive Complexity specification.
+    // ========================================================================
+
+    // --- Finding 1: range-fallback off-by-one + routing ------------------
+
+    #[test]
+    fn ts_cognitive_range_fallback_not_off_by_one() {
+        // Directly exercise the fallback path `compute_cognitive_range`. Before
+        // the fix it visited `root`'s children, descending THROUGH the
+        // `function_declaration` (a nesting node) and charging the whole body one
+        // level too deep: (1+1) + (1+2) == 5. The fix delegates to
+        // `compute_cognitive` on the located function node (nesting 0), so the
+        // outer if is +1 and the inner if is +1+1 == 3.
+        let grammar = TypeScriptGrammar::new();
+        let src = "function f() {\n  if (a) {\n    if (b) {\n    }\n  }\n}\n";
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&grammar.ts_language()).unwrap();
+        let tree = parser.parse(src, None).unwrap();
+        let calc = ComplexityCalculator::new(&grammar);
+        let end = src.lines().count() as u32;
+        assert_eq!(calc.compute_cognitive_range(tree.root_node(), 1, end, 0), 3);
+    }
+
+    #[test]
+    fn ts_cognitive_every_function_form_equals_bare_declaration() {
+        // Every function form (bare declaration, export-wrapped, const-assigned
+        // arrow, method) must measure the SAME body as nesting level 0, yielding
+        // 3 for `if (a) { if (b) {} }`, never the inflated 5 from routing a
+        // wrapper node through the range fallback.
+        let grammar = TypeScriptGrammar::new();
+        let bare = "function f() {\n  if (a) {\n    if (b) {\n    }\n  }\n}\n";
+        let exported = "export function f() {\n  if (a) {\n    if (b) {\n    }\n  }\n}\n";
+        let arrow = "const f = () => {\n  if (a) {\n    if (b) {\n    }\n  }\n};\n";
+        let method = "class C {\n  m() {\n    if (a) {\n      if (b) {\n      }\n    }\n  }\n}\n";
+        assert_eq!(cognitive_of(&grammar, bare), 3);
+        assert_eq!(cognitive_of(&grammar, exported), 3);
+        assert_eq!(cognitive_of(&grammar, arrow), 3);
+        assert_eq!(cognitive_of(&grammar, method), 3);
+    }
+
+    // --- Finding 2: try does not nest; catch increments and nests --------
+
+    #[test]
+    fn ts_cognitive_try_catch_not_inverted() {
+        let grammar = TypeScriptGrammar::new();
+        // `try {} catch(e) {}`: the try adds nothing, the catch is a single +1.
+        let simple = "function f() {\n  try {\n  } catch (e) {\n  }\n}\n";
+        assert_eq!(cognitive_of(&grammar, simple), 1);
+        // `try {} catch(e){ if(e){} }`: catch +1 (nesting 0) then if +1+1 == 3.
+        // Before the fix `try_statement` nested (so the if was one level too
+        // deep) while `catch_clause` did not, inverting the SonarSource rule.
+        let nested = "function f() {\n  try {\n  } catch (e) {\n    if (e) {\n    }\n  }\n}\n";
+        assert_eq!(cognitive_of(&grammar, nested), 3);
+    }
+
+    // --- Finding 3: ternary both increments and nests --------------------
+
+    #[test]
+    fn ts_cognitive_ternary_nests() {
+        let grammar = TypeScriptGrammar::new();
+        // `a ? (b ? c : d) : e`: outer ternary +1 (nesting 0), inner ternary
+        // +1+1 == 3. Before adding `ternary_expression` to the nesting set the
+        // inner ternary took no penalty and the total was 2.
+        let src = "function f() {\n  return a ? (b ? c : d) : e;\n}\n";
+        assert_eq!(cognitive_of(&grammar, src), 3);
+    }
+
+    // --- Finding 4: else / else-if counted once, no penalty --------------
+
+    #[test]
+    fn ts_cognitive_if_elseif_else_each_plus_one() {
+        let grammar = TypeScriptGrammar::new();
+        // if +1, else-if +1, else +1 == 3. No nesting penalties, and the
+        // `else_clause` wrapping the else-if must not double-count.
+        let src = "function f() {\n  if (a) {\n  } else if (b) {\n  } else {\n  }\n}\n";
+        assert_eq!(cognitive_of(&grammar, src), 3);
+    }
+
+    #[test]
+    fn ts_cognitive_elseif_body_nests_but_elseif_itself_does_not() {
+        let grammar = TypeScriptGrammar::new();
+        // if(a){ if(x){} } else if(b){ if(y){} }:
+        //   outer if 1, inner x (1+1)=2, else-if 1, inner y (1+1)=2 == 6.
+        // The else-if increments +1 with no penalty and does NOT add a nesting
+        // level, so its own body's inner if sits at nesting 1, not 2.
+        let src = "function f() {\n  if (a) {\n    if (x) {\n    }\n  } else if (b) {\n    if (y) {\n    }\n  }\n}\n";
+        assert_eq!(cognitive_of(&grammar, src), 6);
+    }
+
+    // --- Finding 5: logical operator sequences -------------------------
+
+    #[test]
+    fn ts_cognitive_logical_sequences_counted_per_run() {
+        let grammar = TypeScriptGrammar::new();
+        // if + one && run == 2 (before: if + two && nodes == 3).
+        assert_eq!(
+            cognitive_of(&grammar, "function f() {\n  if (a && b && c) {\n  }\n}\n"),
+            2
+        );
+        // if + && run + || run == 3.
+        assert_eq!(
+            cognitive_of(&grammar, "function f() {\n  if (a && b || c) {\n  }\n}\n"),
+            3
+        );
+        // if + || run + && run == 3 (&& binds tighter, forming a separate run).
+        assert_eq!(
+            cognitive_of(
+                &grammar,
+                "function f() {\n  if (a || b || c && d) {\n  }\n}\n"
+            ),
+            3
+        );
+    }
+
+    // --- Finding 6: Python match ----------------------------------------
+
+    #[test]
+    fn python_match_cyclomatic_per_case_cognitive_once() {
+        let grammar = PythonGrammar::new();
+        let src = "def f(x):\n    match x:\n        case 1:\n            return 1\n        case _:\n            return 0\n";
+        // CYCLOMATIC (McCabe): base 1 + one per `case_clause` (2) == 3.
+        assert_eq!(cyclomatic_of(&grammar, src), 3);
+        // COGNITIVE (SonarSource): the `match` structure is charged once == 1.
+        assert_eq!(cognitive_of(&grammar, src), 1);
+    }
+
+    #[test]
+    fn python_if_elif_else_and_try_except_follow_rules() {
+        let grammar = PythonGrammar::new();
+        // if +1, elif +1, else +1 == 3 (elif/else take no nesting penalty).
+        let branches = "def f(x):\n    if x:\n        pass\n    elif x:\n        pass\n    else:\n        pass\n";
+        assert_eq!(cognitive_of(&grammar, branches), 3);
+        // try does not nest; except +1 (nesting 0) then if +1+1 == 3.
+        let trycatch =
+            "def f(x):\n    try:\n        pass\n    except E:\n        if x:\n            pass\n";
+        assert_eq!(cognitive_of(&grammar, trycatch), 3);
+    }
+
+    // --- Canonical SonarSource example: sumOfPrimes == 7 -----------------
+
+    #[test]
+    fn ts_cognitive_sum_of_primes_equals_7() {
+        let grammar = TypeScriptGrammar::new();
+        // From the SonarSource Cognitive Complexity paper (expected 7):
+        //   for (outer)        +1  (nesting 0)
+        //     for (inner)      +2  (nesting 1)
+        //       if             +3  (nesting 2)
+        //         continue OUT +1  (labeled break/continue, no penalty)
+        let src = "function sumOfPrimes(max) {\n\
+            \x20 let total = 0;\n\
+            \x20 OUT: for (let i = 1; i <= max; ++i) {\n\
+            \x20   for (let j = 2; j < i; ++j) {\n\
+            \x20     if (i % j === 0) {\n\
+            \x20       continue OUT;\n\
+            \x20     }\n\
+            \x20   }\n\
+            \x20   total += i;\n\
+            \x20 }\n\
+            \x20 return total;\n\
+            }\n";
+        assert_eq!(cognitive_of(&grammar, src), 7);
+    }
+
+    // --- Generator functions are captured and measured -------------------
+
+    #[test]
+    fn ts_generator_functions_are_measured() {
+        use crate::adapter::queries::extract_functions;
+        let grammar = TypeScriptGrammar::new();
+        // Both a generator declaration and a generator expression must now be
+        // extracted (TS_FUNCTION_QUERY previously captured neither) and measured
+        // at nesting 0: `if (a) { if (b) {} }` == 3.
+        for src in [
+            "function* g() {\n  if (a) {\n    if (b) {\n    }\n  }\n}\n",
+            "const g = function* () {\n  if (a) {\n    if (b) {\n    }\n  }\n};\n",
+        ] {
+            let mut parser = tree_sitter::Parser::new();
+            parser.set_language(&grammar.ts_language()).unwrap();
+            let tree = parser.parse(src, None).unwrap();
+            let funcs =
+                extract_functions(&tree, src, std::path::Path::new("g.ts"), &grammar).unwrap();
+            assert_eq!(funcs.len(), 1, "generator not extracted for: {src}");
+            assert_eq!(cognitive_of(&grammar, src), 3);
+        }
     }
 }

--- a/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/python.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/python.rs
@@ -5,16 +5,19 @@
 //!
 //! ## Complexity Rules (from spec §7.2)
 //!
-//! **Increases CC:**
+//! Adds a decision point:
 //! - if/elif/else branches
 //! - for/while loops
-//! - try/except (each except +1)
+//! - try/except (each except is a decision; the `try` itself is not)
+//! - match/case. Cyclomatic counts each `case`; cognitive (SonarSource) counts
+//!   the `match` structure once.
 //! - list comprehensions with conditions
 //! - assert statements
-//! - logical operators (and, or)
+//! - logical operators (and, or). Cognitive charges one increment per sequence
+//!   of the same operator, not one per operator token.
 //!
-//! **Does NOT increase CC:**
-//! - with statements (context managers)
+//! Does NOT add a decision point:
+//! - with statements (context managers): nesting only, no increment
 //! - finally clause
 //! - raise statements
 
@@ -74,6 +77,8 @@ impl Grammar for PythonGrammar {
     }
 
     fn decision_nodes(&self) -> &'static [&'static str] {
+        // CYCLOMATIC (McCabe): each branch is a decision, so each `case_clause`
+        // of a `match` counts (+1 apiece), like each `elif_clause`.
         &[
             "if_statement",
             "elif_clause",
@@ -81,6 +86,7 @@ impl Grammar for PythonGrammar {
             "for_statement",
             "while_statement",
             "except_clause",
+            "case_clause",        // Each match case is a McCabe branch
             "list_comprehension", // With conditions
             "conditional_expression",
             "boolean_operator", // and, or
@@ -88,12 +94,37 @@ impl Grammar for PythonGrammar {
         ]
     }
 
+    fn cognitive_decision_nodes(&self) -> &'static [&'static str] {
+        // COGNITIVE (SonarSource): a `match` is charged ONCE on
+        // `match_statement` (+1 plus its nesting penalty), not once per case, so
+        // `case_clause` is replaced by `match_statement`. `match_statement` is
+        // also a nesting node, so its cases raise the nesting level.
+        &[
+            "if_statement",
+            "elif_clause",
+            "else_clause",
+            "for_statement",
+            "while_statement",
+            "except_clause",
+            "match_statement", // Charged once (not per case)
+            "list_comprehension",
+            "conditional_expression",
+            "boolean_operator",
+            "assert_statement",
+        ]
+    }
+
     fn nesting_nodes(&self) -> &'static [&'static str] {
+        // SonarSource: `except` (catch) nests but `try` does NOT (finding 2);
+        // `match` nests so its cases sit one level deeper (finding 6);
+        // a ternary (`conditional_expression`) both increments and nests.
         &[
             "if_statement",
             "for_statement",
             "while_statement",
-            "try_statement",
+            "except_clause",
+            "match_statement",
+            "conditional_expression",
             "with_statement",
             "function_definition",
             "class_definition",

--- a/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/typescript.rs
+++ b/standards/v1/APS-V1-0001-code-topology/src/adapter/grammars/typescript.rs
@@ -1,22 +1,25 @@
 //! TypeScript and TSX language grammars for tree-sitter based analysis.
 //!
 //! Both `TypeScriptGrammar` (`.ts`) and `TsxGrammar` (`.tsx`) share identical
-//! queries and complexity rules — TSX is TypeScript plus JSX syntax, and JSX
-//! nodes do not affect cyclomatic complexity.
+//! queries and complexity rules. TSX is TypeScript plus JSX syntax, and JSX
+//! nodes do not affect complexity.
 //!
 //! ## Complexity Rules
 //!
-//! **Increases CC:**
-//! - if/else branches
+//! Structures that add a decision point (both cyclomatic McCabe and cognitive
+//! SonarSource, unless noted):
+//! - if/else-if/else branches
 //! - for/for-in/for-of loops
 //! - while/do-while loops
-//! - switch statements (counted once, per SonarSource, not once per case)
-//! - catch clauses
-//! - ternary expressions
-//! - logical operators (&& and ||)
+//! - switch statements. Cyclomatic counts each `case`; cognitive (SonarSource)
+//!   counts the `switch` structure once.
+//! - catch clauses (cognitive: also a nesting structure; `try` is not)
+//! - ternary expressions (cognitive: also a nesting structure)
+//! - logical operators (&& and ||). Cognitive charges one increment per
+//!   sequence of the same operator, not one per operator token.
 //!
-//! **Does NOT increase CC:**
-//! - optional chaining (`?.`) — idiomatic null-safety, no penalty
+//! Does NOT add a decision point:
+//! - optional chaining (`?.`): idiomatic null-safety, no penalty
 
 use std::path::Path;
 
@@ -200,6 +203,15 @@ const TS_COGNITIVE_DECISION_NODES: &[&str] = &[
     "binary_expression", // && and ||
 ];
 
+// COGNITIVE (SonarSource) nesting structures. A nested structure that also
+// increments (if, ternary, switch, loops, catch) gets the B3 nesting penalty on
+// top of its +1; nested functions/lambdas raise the nesting level without an
+// increment of their own.
+//
+// SonarSource specifics encoded here:
+// - `catch_clause` nests (its body is one level deeper) but `try_statement`
+//   does NOT: a `try` block adds no nesting or increment (finding 2).
+// - `ternary_expression` both increments and nests (finding 3).
 const TS_NESTING_NODES: &[&str] = &[
     "if_statement",
     "for_statement",
@@ -207,16 +219,19 @@ const TS_NESTING_NODES: &[&str] = &[
     "while_statement",
     "do_statement",
     "switch_statement",
-    "try_statement",
+    "catch_clause",
+    "ternary_expression",
     "arrow_function",
     "function",
     "function_declaration",
     "function_expression",
+    "generator_function",
+    "generator_function_declaration",
     "method_definition",
 ];
 
 const TS_IGNORED_NODES: &[&str] = &[
-    "optional_chain", // ?. operator — idiomatic null-safety, no CC penalty
+    "optional_chain", // ?. operator: idiomatic null-safety, no CC penalty
 ];
 
 // ============================================================================
@@ -247,11 +262,20 @@ fn compute_ts_module_path(file_path: &Path, root: &Path) -> String {
 
 /// Tree-sitter query for extracting TypeScript/TSX function definitions.
 ///
-/// Captures named functions, arrow functions, methods, and function expressions.
-/// Note: function expressions use `function_expression`, not `function`.
+/// Captures named functions, arrow functions, methods, function expressions,
+/// and generator functions (both `function* g()` declarations and
+/// `const g = function* ()` expressions). tree-sitter names the generator
+/// forms `generator_function_declaration` and `generator_function`, distinct
+/// from the non-generator `function_declaration`/`function_expression`; each
+/// needs its own pattern here or generators are never measured.
 const TS_FUNCTION_QUERY: &str = r#"
 ; Named function declarations
 (function_declaration
+  name: (identifier) @function.name
+  body: (statement_block) @function.body) @function
+
+; Named generator function declarations: function* g() { ... }
+(generator_function_declaration
   name: (identifier) @function.name
   body: (statement_block) @function.body) @function
 
@@ -270,6 +294,12 @@ const TS_FUNCTION_QUERY: &str = r#"
 (variable_declarator
   name: (identifier) @function.name
   value: (function_expression
+    body: (statement_block) @function.body) @function)
+
+; Generator function expressions: const g = function* () { ... }
+(variable_declarator
+  name: (identifier) @function.name
+  value: (generator_function
     body: (statement_block) @function.body) @function)
 
 ; Exported function declarations


### PR DESCRIPTION
## Context

Follow-up to #90 (merged), which fixed the cognitive-complexity nesting off-by-one and the switch/match per-case over-count. A multi-model review panel (Codex + Gemini + Copilot) run *after* that merge surfaced six further deviations from the [SonarSource Cognitive Complexity spec](https://www.sonarsource.com/docs/CognitiveComplexity.pdf). This PR closes all six, keeping cyclomatic (McCabe) untouched.

## The six fixes (before -> after, each with a reference-value test)

1. **Range-fallback off-by-one + routing.** `compute_cognitive_range` now delegates to `compute_cognitive` on the actual function node (via `find_node_in_range` *or* a new `find_enclosed_function`), so every function form — declaration, `export`-wrapped, `const`-arrow, method, generator — is measured with its own node at nesting 0. `ts_cognitive_range_fallback_not_off_by_one`: **5 -> 3**; all forms now equal the bare declaration (**3**).
2. **try/catch inverted.** `try` no longer nests; `catch` increments *and* nests (TS `catch_clause`, Python `except_clause`). `try{}catch(e){if(e){}}`: **4 -> 3**.
3. **Ternary missing from nesting.** Added `ternary_expression` (TS) / `conditional_expression` (Python). `a ? (b ? c : d) : e`: **2 -> 3**.
4. **else / else-if double-count.** An `if` under an `else_clause` = +1, no nesting penalty; the `else_clause` no longer separately increments; plain `else` = +1. `if(a){}else if(b){}else{}`: **8 -> 3**.
5. **Logical &&/|| chains.** +1 per *run* of the same operator. `a&&b&&c`: **3 -> 2**; `a||b||c&&d`: **4 -> 3**; `a&&b||c` stays **3**.
6. **Python match uncovered.** `case_clause` in cyclomatic; `match_statement` once in cognitive + nesting. 2-case match: cyclomatic **1 -> 3**, cognitive **0 -> 1**.

### Nits also fixed
- Generators (`generator_function_declaration`/`generator_function`) were never captured by `TS_FUNCTION_QUERY` — now measured (`ts_generator_functions_are_measured`).
- Corrected misleading "Increases CC" doc headers to distinguish cyclomatic vs cognitive.
- Implemented labeled `break`/`continue` (B1, +1 no penalty), enabling the canonical SonarSource `sumOfPrimes` integration example to evaluate to **7** as specified.

## Guardrails
- Cyclomatic (McCabe) unchanged: switch/match still count per case/arm (paired divergence tests hold).
- `cargo test --workspace`: 0 failures; `cargo clippy --all-targets -- -D warnings`: clean; `cargo fmt --all --check`: clean.
- No em dashes introduced.

## Deliberate scope call
Recursion-as-B1 (in the spec, but not among the six findings and not test-covered) is left unimplemented to avoid an unrequested behavior change; can follow in a separate PR.

## Deployment
This further lowers emitted cognitive values for real code (breaking-in-practice for consumers pinning baselines). Fold into the same `apss-v1-0001-code-topology` minor bump as the #90 line before consumers re-derive their sensors baseline.

https://claude.ai/code/session_01Dm4SiDBJYWVpJsNmxMt8L1
