### PR TITLE
chore(meta): bump APS-V1-0000-meta to 1.5.2

### DIFF
--- a/standards/v1/APS-V1-0000-meta/Cargo.toml
+++ b/standards/v1/APS-V1-0000-meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apss-v1-0000-meta"
-version = "1.5.1"
+version = "1.5.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/standards/v1/APS-V1-0000-meta/standard.toml
+++ b/standards/v1/APS-V1-0000-meta/standard.toml
@@ -4,7 +4,7 @@ schema = "aps.standard/v1"
 id = "APS-V1-0000"
 name = "APS Meta-Standard"
 slug = "meta"
-version = "1.5.1"
+version = "1.5.2"
 category = "governance"
 status = "active"
 


### PR DESCRIPTION
## Summary
- Bumps `APS-V1-0000-meta`'s `Cargo.toml`/`standard.toml` version from 1.5.1 -> 1.5.2 (patch).
- `src/lib.rs` changed earlier (clippy::needless_late_init fix riding along in #111) without a version bump, which would fail `version-bump-check` at the release gate per DI01.
- The meta-standard itself is never published to crates.io, this only affects the git tag / gate compliance.

## Test plan
- [x] `cargo check -p apss-v1-0000-meta` passes
- [x] `cargo run -p aps-cli --bin apss-dev -- v1 validate repo` passes (27 packages, 0 errors)