### PR TITLE
chore(release): code-topology 0.3.0 (SonarSource cognitive alignment)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "aps-cli"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "apss-core",
  "apss-distribution",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "apss"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "apss-core",
  "clap",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "apss-core"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "handlebars",
  "semver",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "apss-v1-0001-code-topology"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "apss-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.3.0"
+version = "1.4.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/AgentParadise/agent-paradise-standards-system"

--- a/crates/aps-cli/Cargo.toml
+++ b/crates/aps-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 apss-core.workspace = true
 apss-v1-0000-meta = { version = "1.5.0", path = "../../standards/v1/APS-V1-0000-meta" }
-code-topology = { package = "apss-v1-0001-code-topology", version = "0.2.0", path = "../../standards/v1/APS-V1-0001-code-topology" }
+code-topology = { package = "apss-v1-0001-code-topology", version = "0.3.0", path = "../../standards/v1/APS-V1-0001-code-topology" }
 architecture-fitness = { package = "apss-v1-0002-architecture-fitness", path = "../../standards/v1/APS-V1-0002-architecture-fitness" }
 documentation = { package = "apss-v1-0003-documentation", version = "0.1.0", path = "../../standards/v1/APS-V1-0003-documentation" }
 agent-recipe = { package = "apss-v1-0005-agent-recipe", version = "0.2.0", path = "../../standards-experimental/v1/EXP-V1-0005-agent-recipe" }

--- a/standards/v1/APS-V1-0001-code-topology/Cargo.toml
+++ b/standards/v1/APS-V1-0001-code-topology/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "apss-v1-0001-code-topology"
 
-version = "0.2.5"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/standards/v1/APS-V1-0001-code-topology/standard.toml
+++ b/standards/v1/APS-V1-0001-code-topology/standard.toml
@@ -5,7 +5,7 @@ id = "APS-V1-0001"
 name = "Code Topology and Coupling Analysis"
 slug = "code-topology"
 
-version = "0.2.5"
+version = "0.3.0"
 category = "technical"
 status = "active"
 


### PR DESCRIPTION
Version-bump prep so PR #112's SonarSource cognitive-complexity alignment can be released. Reversible, upstream of the `release` branch: no `main -> release` PR, no `cargo publish`.

## Changelog

### `apss-v1-0001-code-topology` 0.2.5 -> 0.3.0 (BREAKING-IN-PRACTICE)

Cognitive-complexity metric now faithfully follows the SonarSource spec (6 follow-ups to #90, landed in #112):

- Nesting increments; `try`/`catch`; ternary; `else if` chains
- Logical-operator runs (with parenthesis-transparency handling)
- Python `match`, generators, labeled `break`/`continue`
- Cyclomatic (McCabe) values preserved unchanged

Emitted **cognitive values drop for real code**, so consumers pinning architectural-fitness baselines against code-topology output are affected. This is why it takes a `0.x` minor bump (breaking) rather than a patch. Bumped in both `Cargo.toml` and `standard.toml`.

> Note: the interim `0.2.4 -> 0.2.5` came from #110 (agent-queryable sensors CLI), which merged onto `main` after the metric fix; #112's breaking change had not yet been version-bumped. This PR carries the bump to the planned `0.3.0`.

### Dependent crate bumps

- **Workspace version `1.3.0 -> 1.4.0`** — covers `aps-cli`, `apss` (bootstrap), and `apss-core`, which all share `version.workspace`. `aps-cli` is the only in-workspace dependent of the official code-topology crate; its pin moved `version = "0.2.0"` -> `"0.3.0"` (the caret `^0.2.0` excludes `0.3.0`). The CLI's topology output now reflects the new metric, making it a releasable change.

`Cargo.lock` refreshed (`cargo update -p apss-v1-0001-code-topology`). `cargo build --workspace`, `cargo test --workspace` (0 failures), `cargo clippy --all-targets -- -D warnings` (clean), and `cargo fmt --all --check` (clean) all pass.

### Version-magnitude note for reviewers

The workspace bump was taken as **minor** (1.4.0) to match how this repo bumps its binaries for user-visible behavior changes. A **patch** (1.3.1) is defensible since only a dependency pin changed in `aps-cli`; a **major** (2.0.0) is defensible on a strict reading of "breaking-in-practice output." Flagged so a human can decide before the release gate.

https://claude.ai/code/session_01Dm4SiDBJYWVpJsNmxMt8L1