### PR TITLE
chore(release): bump workspace 1.4.0 -> 1.5.0 for APS-V1-0004

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "aps-cli"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "apss-core",
  "apss-distribution",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "apss"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "apss-core",
  "clap",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "apss-core"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "handlebars",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/AgentParadise/agent-paradise-standards-system"


### PR DESCRIPTION
Version bump so the release gate passes. No functional change.

`crates/aps-cli/` changed since the last release (it now depends on
`apss-v1-0004-session-capture` and registers its `validate` and `hash`
commands), and `version-bump-check` requires the shared `[workspace.package]`
version to move whenever a system crate does. Minor rather than patch because
the CLI gained commands.

`APS-V1-0004` itself is deliberately left at 1.0.0: it did not exist at the last
release, and the gate treats a package with no previous version as new rather
than requiring a delta.

Bumps must land on `main` before the `main -> release` PR is opened, since the
gate's source-branch-check requires the release PR's head to be `main`.

Next: the `main -> release` PR carrying this release's changelog.