### PR TITLE
fix(runbook): correct the ingest snippet and the corpus-migration advice

### DIFF
--- a/docs/runbooks/integrate-session-capture.runbook.md
+++ b/docs/runbooks/integrate-session-capture.runbook.md
@@ -25,7 +25,7 @@ The crate ships *concrete* types and functions:
 | `envelope.validate()` | Structural conformance for an envelope in flight. |
 | `envelope.validate_stored()` | The above, plus requiring `content_hash`. |
 | `envelope.idempotency_key()` | `(session_id, content_hash)`, `None` while in flight. |
-| `content_hash::parse_ijson(text)` | Parse request bytes under I-JSON rules. **Not optional.** See step 3. |
+| `content_hash::parse_ijson(text)` | Parse the request body text (`&str`) under I-JSON rules. **Not optional.** See step 3. |
 | `content_hash_for(&envelope)` | The canonical `content_hash`. |
 | `SESSION_ENVELOPE_SCHEMA` / `session_envelope_schema()` | The embedded JSON Schema. |
 | `reconstitution::Registry` | Per-harness restore knowledge, for resume. |
@@ -84,45 +84,109 @@ graph, and it comes from the crate.
 
 ## 3. Fix the ingest path (this is where conformance is won or lost)
 
-Order matters, and two steps are easy to get wrong.
+The normative order, which the code below follows:
+
+1. Authenticate; the token must be scoped `sessions:write` (5.2).
+2. Decode the body as UTF-8 text.
+3. `parse_ijson` on that text, before anything else parses it.
+4. Require a non-empty `{ "envelopes": [...] }` wrapper (5.1).
+5. Per envelope: schema-validate, deserialize, `validate()`, compute the hash
+   *before* sanitizing, dedup, sanitize, **assign the computed hash**, record the
+   sanitizer version, `validate_stored()`, persist.
+6. Return a per-item `accepted` / `duplicate` / `rejected` outcome, with a reason
+   for each rejection (5.3).
 
 ```rust
-use session_capture::{SessionEnvelope, content_hash_for, content_hash::parse_ijson};
+use session_capture::{
+    SessionEnvelope, content_hash_for, content_hash::parse_ijson, session_envelope_schema,
+};
 
-// 3a. Parse the ORIGINAL request bytes under I-JSON rules.
-//     This cannot be deferred: a normal JSON parser silently keeps the last of a
-//     duplicate member name, so `{"a":1,"a":2}` and `{"a":2}` become
-//     indistinguishable and would receive the same content_hash. By the time you
-//     hold a serde_json::Value the evidence is gone (spec 4.2.3).
-let value = parse_ijson(&request_body)?;      // reject -> 400 / `rejected` per 5.3
+// `parse_ijson` takes &str, so decode first and reject invalid UTF-8 explicitly
+// rather than lossily. `body` here is your framework's byte buffer.
+let text = std::str::from_utf8(&body).map_err(|_| reject("body is not valid UTF-8"))?;
 
-// 3b. Deserialize and validate.
-let envelope: SessionEnvelope = serde_json::from_value(value)?;
-envelope.validate()?;                          // reject -> `rejected` with a reason
+// 3a. I-JSON on the ORIGINAL text. This cannot be deferred: a normal JSON parser
+//     silently keeps the last of a duplicate member name, so `{"a":1,"a":2}` and
+//     `{"a":2}` become indistinguishable and would receive the same
+//     content_hash. Once you hold a serde_json::Value the evidence is gone
+//     (spec 4.2.3).
+let body_value = parse_ijson(text).map_err(|e| reject(&e.to_string()))?;
 
-// 3c. Compute the hash BEFORE sanitizing, over the captured content.
-//     Never honour a producer-supplied value: overwrite it (spec 4.2.3).
-let hash = content_hash_for(&envelope)?;
+// 3b. The batch wrapper. A bare array and an empty array are both invalid (5.1).
+let envelopes = body_value
+    .get("envelopes")
+    .and_then(|v| v.as_array())
+    .filter(|a| !a.is_empty())
+    .ok_or_else(|| reject("body must be a non-empty { \"envelopes\": [...] } (5.1)"))?;
 
-// 3d. Dedup on (session_id, hash). Only now sanitize, then persist.
-//     The pre-sanitization bytes are never written to disk (spec 5.4).
-let stored = sanitize(envelope);               // your redaction + NUL strip
-persist(stored, &hash, sanitizer_version)?;
+let validator = jsonschema::validator_for(&session_envelope_schema())?;
+let mut outcomes = Vec::new();
+
+for value in envelopes {
+    // 3c. Schema validation is a store obligation in its own right (6.3.2).
+    if validator.validate(value).is_err() {
+        outcomes.push(Outcome::rejected("does not satisfy the session-envelope schema"));
+        continue;
+    }
+
+    let envelope: SessionEnvelope = match serde_json::from_value(value.clone()) {
+        Ok(e) => e,
+        Err(e) => {
+            outcomes.push(Outcome::rejected(&e.to_string()));
+            continue;
+        }
+    };
+    if let Err(e) = envelope.validate() {
+        outcomes.push(Outcome::rejected(&e.to_string()));
+        continue;
+    }
+
+    // 3d. Hash BEFORE sanitizing, over the captured content. Any value the
+    //     producer sent is ignored by content_hash_for and overwritten below.
+    let hash = match content_hash_for(&envelope) {
+        Ok(h) => h,
+        Err(e) => {
+            outcomes.push(Outcome::rejected(&e.to_string()));
+            continue;
+        }
+    };
+
+    // 3e. Dedup on the computed hash, never a supplied one (5.3).
+    if store.contains(&envelope.session_id, &hash)? {
+        outcomes.push(Outcome::Duplicate);
+        continue;
+    }
+
+    // 3f. Sanitize, then ASSIGN the computed hash. content_hash_for returns a
+    //     String and does not mutate the envelope, so skipping this assignment
+    //     leaves a producer-supplied hash in the stored row.
+    let mut stored = sanitize(envelope);       // your redaction + NUL strip
+    stored.content_hash = Some(hash);
+    stored.validate_stored()?;                 // a stored envelope must carry it
+    store.persist(&stored, sanitizer_version)?;
+    outcomes.push(Outcome::Accepted);
+}
 ```
 
-The two failure modes worth naming:
+Note that each fallible call returns a *different* error type (`ContentHashError`,
+`serde_json::Error`, `ValidationError`). They all implement `std::error::Error`,
+so `?` works under `anyhow` or `Box<dyn Error>`, but a handler with its own error
+type needs `From` impls. The loop above deliberately matches instead of using `?`,
+because 5.3 requires a per-item outcome rather than failing the whole batch.
 
-- **Hashing after sanitizing.** This makes your sanitizer ruleset part of session
+The failure modes worth naming, because none of them surfaces as an error:
+
+- **Hashing after sanitizing.** Makes your sanitizer ruleset part of session
   identity, so every secret-detection improvement changes the digest of content
-  that never changed, and re-uploads stop deduplicating. Nothing detects it until
-  your corpus is full of duplicates.
+  that never changed and re-uploads stop deduplicating.
+- **Computing the hash but not assigning it.** The stored row keeps whatever the
+  producer sent. Dedup then compares against a value you did not derive.
 - **Trusting a producer's `content_hash`.** You cannot know how it was derived.
-  Recompute and overwrite, always.
 
-**Expected result:** a captured envelope round-trips through ingest and
+**Expected result:** a captured envelope round-trips through ingest, and
 `validate_stored()` passes on what you read back.
 
-## 4. Accept the batch shape the standard defines
+## 4. Reject the shapes the standard forbids
 
 `POST /v1/sessions/batch` takes a wrapper, not a bare array (spec 5.1):
 
@@ -130,12 +194,12 @@ The two failure modes worth naming:
 { "envelopes": [ /* one or more */ ] }
 ```
 
-A bare top-level array MUST be rejected. If your service currently accepts one,
+Step 3b already enforces this. If your service currently accepts a bare array,
 change the route and the exporter in the same change so nothing is left pointing
-at the old shape. An empty `envelopes` array is also invalid.
+at the old shape.
 
-**Expected result:** the wrapper is accepted, a bare array returns an error that
-names section 5.1.
+**Expected result:** the wrapper is accepted; a bare array and an empty
+`envelopes` array both return an error naming section 5.1.
 
 ## 5. Record the sanitizer version
 
@@ -206,8 +270,21 @@ If you already store envelopes under a pre-ratification shape:
    `"scs/1"`, add a tolerant reader and backfill, or the new conformance test
    goes red against your own corpus on day one.
 2. **`content_hash`.** If you previously hashed post-sanitize, or over a
-   different field set, recompute for the whole corpus using `content_hash_for`.
-   Until you do, old and new rows will not deduplicate against each other.
+   different field set, every stored digest is wrong under the ratified
+   definition, and old and new rows will not deduplicate against each other.
+
+   **You cannot repair this by re-hashing what you hold.** A conforming store
+   discarded the pre-sanitization bytes (spec 5.4), so running `content_hash_for`
+   over a stored row yields another *post-sanitization* identity, which is
+   exactly what the standard rejects. It would look like a fix and silently
+   entrench the wrong digest.
+
+   The only correct repair is **re-ingestion from the original transcripts**,
+   running them through the step 3 path so the hash is computed over captured
+   content. Where those originals still exist on disk (`~/.claude/projects`,
+   `~/.codex/sessions`), re-running capture is the migration. Where they do not,
+   those rows cannot be brought into conformance: keep them, mark them as
+   legacy-hash, and accept that they will not deduplicate against re-captures.
 3. **`raw` shape.** If a reader parses a line-delimited transcript into an array
    of objects, it has already forfeited byte-exact resume: re-serializing does
    not reproduce the original bytes. Capture the file's exact bytes as a JSON
@@ -216,24 +293,29 @@ If you already store envelopes under a pre-ratification shape:
 ## Verifying without writing code
 
 The standard ships a CLI for checking envelopes and comparing hash
-implementations:
+implementations. Note that `apss-dev` is the APSS repo's own development binary:
+depending on the crate does not install it. Run these from a checkout of this
+repository, or call the library functions directly from a test in your service.
 
 ```bash
-apss-dev run session-capture validate path/to/envelope-or-batch.json
-apss-dev run session-capture hash path/to/envelope.json
+cargo run -p aps-cli --bin apss-dev -- run session-capture validate path/to/envelope-or-batch.json
+cargo run -p aps-cli --bin apss-dev -- run session-capture hash path/to/envelope.json
 ```
 
-`hash` prints the canonical digest, so you can diff it against what your service
-computes. A mismatch means your store will not deduplicate against any other
-conformant store, which is otherwise a silent failure.
+`hash` prints one tab-separated line per envelope, `session_id<TAB>digest`, so
+compare the second field against what your service computes rather than diffing
+the whole line. A mismatch means your store will not deduplicate against any
+other conformant store, which is otherwise a silent failure.
 
 ## Common mistakes
 
 | Mistake | Consequence |
 |---|---|
 | Implementing "the trait" | There isn't one. You have written a parallel envelope that will drift. |
-| Validating after parsing instead of `parse_ijson` on the raw bytes | Duplicate member names go undetected; two different sessions collide on one hash. |
+| Validating after parsing instead of `parse_ijson` on the original text | Duplicate member names go undetected; two different sessions collide on one hash. |
 | Hashing after sanitizing | Sanitizer updates silently break dedup, unrecoverably. |
+| Computing the hash but never assigning it to the stored envelope | The producer's value survives into storage; dedup compares a digest you did not derive. |
+| Re-hashing already-stored rows to "fix" a legacy corpus | Produces another post-sanitization identity. Looks like a fix, entrenches the wrong digest. Re-ingest instead. |
 | Keeping a local `SessionEnvelope` alongside the crate's | Reintroduces the exact drift the dependency exists to prevent. |
 | Accepting a bare JSON array batch | Non-conformant, and unextendable later without a breaking change. |
 | Joining `metadata.source_path` onto a root by hand | Arbitrary file write from an untrusted envelope. |


### PR DESCRIPTION
A Codex review of #120 found three defects in guidance that would have been
copied verbatim into consumer ingest paths. The runbook is merged but not yet
published, so this lands ahead of the release.

## The one that mattered most

The migration section said a corpus previously hashed post-sanitize could be
repaired by recomputing with `content_hash_for`. **That is wrong and actively
harmful.** A conforming store has discarded the pre-sanitization bytes (spec
5.4), so re-hashing a stored row produces another *post-sanitization* identity,
which is precisely what the standard rejects. It would look like a fix while
entrenching the wrong digest permanently.

Correct repair is re-ingestion from the original transcripts, which for this
corpus still exist on disk. Where they do not, those rows cannot be brought into
conformance and should be marked legacy rather than silently re-hashed. The
runbook now says so.

## The other two

- **The snippet computed the hash and never assigned it.** `content_hash_for`
  returns a `String` and does not mutate the envelope, so a producer-supplied
  `content_hash` could survive into storage, contradicting the overwrite
  requirement the snippet itself described.
- **It deserialized the whole body as one `SessionEnvelope`**, which cannot work
  against the real endpoint, since the body is a `{ "envelopes": [...] }`
  wrapper. It would have failed on the first request. The snippet now walks the
  batch and returns a per-item `accepted`/`duplicate`/`rejected` outcome per
  section 5.3, rather than failing the whole batch on one bad member.

## Smaller corrections

- `parse_ijson` takes `&str`, not bytes. The prose said "bytes" throughout and
  the snippet would not compile against common HTTP body types. It now decodes
  UTF-8 explicitly and rejects invalid input rather than converting lossily.
- Schema validation is a separate store obligation (6.3.2) that `validate()`
  does not cover. The snippet now uses the embedded schema it previously only
  advertised in a table.
- Documented that the fallible calls return different error types, so a bare `?`
  works under `anyhow` but not in a handler with its own error type.
- `apss-dev` is this repo's development binary and is not installed by depending
  on the crate; commands are shown as `cargo run` invocations.
- `hash` prints `session_id<TAB>digest`, so the docs no longer imply the whole
  line can be diffed against a bare digest.

Two new rows in the mistakes table for the failure modes above.

The review also confirmed what was already right: every API identifier resolves
with the correct signature, all relative links work, the "no trait to implement"
framing is accurate, and the 1.4.0 → 1.5.0 workspace bump is correct with nothing
else missing a bump.