### PR TITLE
fix(release): make publish idempotency work + document the new-crate flow

### DIFF
--- a/.claude/skills.json
+++ b/.claude/skills.json
@@ -26,8 +26,8 @@
       "id": "releasing-apss",
       "domain": "release-engineering",
       "category": "devops",
-      "summary": "Cut, gate, tag, and publish an APSS release: trunk-based main -> release branch flow, the Release Gate checks, and release-create.yml tiered crates.io publishing",
-      "version": 1
+      "summary": "Cut, gate, tag, and publish an APSS release: trunk-based main -> release branch flow, the Release Gate checks, release-create.yml tiered crates.io publishing, and the one-time manual first publish a new crate name requires",
+      "version": 2
     }
   ]
 }

--- a/.claude/skills/releasing-apss/SKILL.md
+++ b/.claude/skills/releasing-apss/SKILL.md
@@ -152,8 +152,8 @@ That message names the token, not the crate, so it is easy to misread as a
 workflow bug. It is not. The workflow handles new packages correctly: detection
 is a `git diff` against the last release tag (a directory that did not exist
 reads as changed), the crate name is derived from the directory name rather than
-from history, and the idempotency check fails open when `cargo search` finds
-nothing.
+from history, and the publish attempt is made unconditionally, so a crate that
+has never been published is never skipped.
 
 ### The flow
 

--- a/.claude/skills/releasing-apss/SKILL.md
+++ b/.claude/skills/releasing-apss/SKILL.md
@@ -6,10 +6,15 @@ description: >-
   "release APSS", "publish to crates.io", "create a release PR", "main to
   release", "promote main to release", "bump versions for the release", "tag a
   release", "run the release gate", "how do releases work here", "what gets
-  published", "ship a new version". Covers the trunk-based main -> release
-  branch flow, the Release Gate checks (source-branch, version-bump, changelog,
-  QA, APS validation, security), and release-create.yml tagging plus tiered
-  crates.io publishing. Do NOT use for routine feature PRs into main (those need
+  published", "ship a new version", "publish a new crate for the first time",
+  "403 Forbidden publishing to crates.io", "this token does not have the
+  required permissions", "CARGO_REGISTRY_TOKEN", "publish-new scope", "the
+  publish job failed", "half the crates published". Covers the trunk-based
+  main -> release branch flow, the Release Gate checks (source-branch,
+  version-bump, changelog, QA, APS validation, security), release-create.yml
+  tagging plus tiered crates.io publishing, and the one-time manual first
+  publish a NEW crate name requires because the CI token is deliberately scoped
+  publish-update only. Do NOT use for routine feature PRs into main (those need
   no release and no version bump), mid-feature version bumps, authoring
   standards, or consumer-side `apss install` (see the adopt/visualize runbooks).
 ---
@@ -106,6 +111,67 @@ feature branch --PR--> main  (ci.yml: fmt, clippy, check, test, aps-validation)
 substandards, and everything under `standards-experimental/`. These still get
 git tags and release notes, but no `cargo publish`. Treat that exclusion as
 load-bearing: the publish job filters them out by directory prefix.
+
+## Releasing a crate that has NEVER been published
+
+**The first release of any new crate name needs a one-time manual `cargo
+publish`. CI cannot do it, by design.**
+
+`CARGO_REGISTRY_TOKEN` is deliberately scoped `publish-update` on crates `apss`
+and `apss-*`. It can push new *versions* of crates the project already owns, and
+nothing else. It cannot create a new crate name, because a CI token that could
+would let anyone who leaked it squat or publish arbitrary `apss-*` packages. The
+narrower scope is the security posture, not an oversight: do not "fix" this by
+adding `publish-new` to the CI token.
+
+The symptom, if you forget: the publish job runs, tier 1 succeeds, and the new
+crate fails with
+
+```
+error: failed to publish <crate> to registry at https://crates.io
+Caused by:
+  the remote server responded with an error (status 403 Forbidden):
+  this token does not have the required permissions to perform this action
+```
+
+That message names the token, not the crate, so it is easy to misread as a
+workflow bug. It is not. The workflow handles new packages correctly: detection
+is a `git diff` against the last release tag (a directory that did not exist
+reads as changed), the crate name is derived from the directory name rather than
+from history, and the idempotency check fails open when `cargo search` finds
+nothing.
+
+### The flow
+
+1. Let the release merge as normal. Tags and the GitHub Release are created, and
+   the publish job fails at the new crate. **This is expected and recoverable.**
+   Anything published before the failure (typically `apss-core`) stays published.
+2. Publish the new crate by hand, **from the release tag**, using a personal
+   credential that has `publish-new`. Publishing from a working tree instead of
+   the tag would put bytes on crates.io that do not match what the tag claims:
+
+   ```bash
+   git checkout <TAG>              # e.g. APS-V1-0004-v1.0.0
+   cargo publish -p <crate-name>
+   ```
+
+   Run `cargo publish --dry-run -p <crate-name>` first. It packages the crate and
+   compiles it from the packaged tarball, which catches the real risk: files
+   pulled in by `include_str!` from outside `src/` are only present if they sit
+   inside the crate directory.
+3. Re-run the failed publish job. The idempotency check skips everything already
+   published and continues from where it died, so tier 3 (`apss`) still goes out
+   automatically. No need to re-tag or re-release.
+4. Every subsequent release of that crate is fully automated: `publish-update`
+   covers it from then on. `publish-new` is needed once per crate name, not once
+   per release.
+
+### Consider Trusted Publishing afterward
+
+crates.io supports GitHub Actions OIDC, which removes the long-lived token from
+CI entirely. It has the same chicken-and-egg (trust cannot be configured for a
+crate that does not exist yet), so it is a follow-up to step 2 rather than a
+replacement for it. Worth doing if the shared token's blast radius matters.
 
 ## Operational state (as of 2026-07-10)
 

--- a/.claude/skills/releasing-apss/SKILL.md
+++ b/.claude/skills/releasing-apss/SKILL.md
@@ -95,8 +95,22 @@ feature branch --PR--> main  (ci.yml: fmt, clippy, check, test, aps-validation)
    changed unit, pushes tags, creates the GitHub Release from the changelog, and
    runs the publish job.
 
-6. **Verify the publish.** The publish job is idempotent (it skips crates whose
-   version is already on crates.io), so a re-run is safe.
+6. **Verify the publish against crates.io, not against the job's exit status.**
+   The publish job tolerates an already-published version, so a re-run after a
+   partial publish resumes rather than dying. That was NOT true before
+   2026-08-07: the job pre-checked with `cargo search`, whose eventually
+   consistent search endpoint kept reporting a just-published crate as missing,
+   making every re-run fail on the first crate that had already gone out. If you
+   are working on a release whose workflow predates that fix, expect re-runs to
+   fail and publish the remainder by hand (see the new-crate section below).
+
+   Check the actual registry rather than trusting a green job:
+
+   ```bash
+   for c in apss-core apss <changed-standard-crates>; do
+     curl -s "https://crates.io/api/v1/crates/$c" | jq -r '"\(.crate.name) \(.crate.max_version)"'
+   done
+   ```
 
 ## What publishes and what does not
 
@@ -159,9 +173,22 @@ nothing.
    compiles it from the packaged tarball, which catches the real risk: files
    pulled in by `include_str!` from outside `src/` are only present if they sit
    inside the crate directory.
-3. Re-run the failed publish job. The idempotency check skips everything already
-   published and continues from where it died, so tier 3 (`apss`) still goes out
-   automatically. No need to re-tag or re-release.
+3. Finish the remaining tiers. The publish job now tolerates already-published
+   versions, so re-running it resumes from where it died and tier 3 (`apss`)
+   goes out automatically. No need to re-tag or re-release.
+
+   **If the re-run still fails on a crate that is already published**, the run
+   is using a workflow from before the 2026-08-07 fix (a re-run executes the
+   workflow file from the commit that triggered it, so fixing it on `main` does
+   not help an in-flight run). Do not fight it. Publish the remaining crates by
+   hand from their tags, exactly as in step 2:
+
+   ```bash
+   git checkout v<system-version>     # e.g. v1.5.0
+   cargo publish -p apss
+   ```
+
+   The red job is then cosmetic. What matters is the registry.
 4. Every subsequent release of that crate is fully automated: `publish-update`
    covers it from then on. `publish-new` is needed once per crate name, not once
    per release.
@@ -183,6 +210,18 @@ publishable crates to crates.io successfully. Treat the workflow-level
 description above as trustworthy; this section now tracks known gotchas
 instead of "not wired yet" caveats.
 
+- **What v1.5.0 actually cost (2026-08-07), as a worked example.** The release
+  that first published `apss-v1-0004-session-capture` needed three manual
+  interventions, and every one of them is now covered above. The publish job
+  403'd on the new crate (CI token is `publish-update` only, by design). The
+  operator's local token turned out to be dead, a *different* 403 reading
+  `authentication failed` rather than `does not have the required permissions`
+  (read that message carefully; the two mean different things). And both re-runs
+  then died on `apss-core@1.5.0 already exists`, because the old `cargo search`
+  pre-check never saw it. Final state was reached by publishing two of the three
+  crates by hand from their tags. The git tags and GitHub Release were correct
+  throughout; only the publish job was red. **Verify against crates.io, not
+  against the job.**
 - **Never push directly to `release`.** It is a real branch with a real
   `push` trigger: any push, including a one-off debugging fix, fires
   `release-create.yml` for real (tags + a GitHub Release get created

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -347,30 +347,56 @@ jobs:
 
             echo "Publishing ${name}@${version} from ${dir}..."
 
-            # Idempotency: attempt the publish and tolerate an already-published
-            # version, rather than pre-checking whether it exists.
+            # Idempotency: attempt the publish and classify a duplicate, rather
+            # than pre-checking whether the version already exists.
             #
             # An earlier version pre-checked with `cargo search`, which queries
             # crates.io's SEARCH endpoint. That endpoint is eventually consistent
-            # and, in CI, repeatedly failed to reflect a version published nearly
-            # an hour earlier, so the check said "not published", the publish ran,
-            # and the job died on "already exists". This made a re-run after a
-            # partial publish impossible: it would always fail again on the first
-            # crate that had already gone out. `cargo publish` consults the sparse
-            # index, which is authoritative and immediate, so reading its result
-            # cannot race against itself.
-            local output=""
-            if output=$(cargo publish --manifest-path "$dir/Cargo.toml" 2>&1); then
-              echo "$output"
+            # and, in CI, repeatedly reported a version published nearly an hour
+            # earlier as absent, so the publish ran and died on "already exists".
+            # That made recovery from a PARTIAL publish impossible: every re-run
+            # failed again on the first crate that had already gone out.
+            #
+            # A duplicate surfaces in one of TWO ways and both must be tolerated:
+            #   1. cargo's own pre-upload index query
+            #        -> "crate <name>@<version> already exists on crates.io index"
+            #   2. the crates.io upload API, when the sparse index has not yet
+            #      exposed a version that was in fact uploaded
+            #        -> "crate version `<version>` is already uploaded"
+            # Handling only (1) would leave the same race intact one layer down.
+            #
+            # Output is streamed through `tee` rather than captured, so a long
+            # packaging step is not a silent gap in the log of a release job.
+            local log="${RUNNER_TEMP:-/tmp}/publish-${name}.log"
+            local status=0
+
+            set +e
+            cargo publish --manifest-path "$dir/Cargo.toml" 2>&1 | tee "$log"
+            status="${PIPESTATUS[0]}"
+            set -e
+
+            if [ "$status" -eq 0 ]; then
               echo "  Published ${name}@${version}"
-              # Wait for the crates.io index to update before any dependent crate
+              # Let the sparse index expose it before a dependent tier resolves.
               sleep 30
               return 0
             fi
 
-            echo "$output"
-            if echo "$output" | grep -q "already exists on crates.io index"; then
-              echo "  Already published - skipping"
+            # Match the crate AND version, not a bare substring: an unrelated
+            # failure whose output merely mentions a duplicate must never be
+            # read as success on a job that publishes.
+            if grep -qF "crate ${name}@${version} already exists on crates.io index" "$log"; then
+              echo "  Already published (found in index) - skipping"
+              # No wait needed: the index already resolves this version.
+              return 0
+            fi
+
+            if grep -qF "crate version \`${version}\` is already uploaded" "$log"; then
+              echo "  Already published (upload rejected as duplicate) - skipping"
+              # The upload API knows it, but the index may still lag, so wait as
+              # though we had just published it or a dependent tier may not
+              # resolve.
+              sleep 30
               return 0
             fi
 

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -347,17 +347,35 @@ jobs:
 
             echo "Publishing ${name}@${version} from ${dir}..."
 
-            # Check if already published (idempotency)
-            if cargo search "$name" 2>/dev/null | grep -q "^${name} = \"${version}\""; then
-              echo "  Already published - skipping"
-              return
+            # Idempotency: attempt the publish and tolerate an already-published
+            # version, rather than pre-checking whether it exists.
+            #
+            # An earlier version pre-checked with `cargo search`, which queries
+            # crates.io's SEARCH endpoint. That endpoint is eventually consistent
+            # and, in CI, repeatedly failed to reflect a version published nearly
+            # an hour earlier, so the check said "not published", the publish ran,
+            # and the job died on "already exists". This made a re-run after a
+            # partial publish impossible: it would always fail again on the first
+            # crate that had already gone out. `cargo publish` consults the sparse
+            # index, which is authoritative and immediate, so reading its result
+            # cannot race against itself.
+            local output=""
+            if output=$(cargo publish --manifest-path "$dir/Cargo.toml" 2>&1); then
+              echo "$output"
+              echo "  Published ${name}@${version}"
+              # Wait for the crates.io index to update before any dependent crate
+              sleep 30
+              return 0
             fi
 
-            cargo publish --manifest-path "$dir/Cargo.toml"
-            echo "  Published ${name}@${version}"
+            echo "$output"
+            if echo "$output" | grep -q "already exists on crates.io index"; then
+              echo "  Already published - skipping"
+              return 0
+            fi
 
-            # Wait for the crates.io index to update before any dependent crate
-            sleep 30
+            echo "::error::Failed to publish ${name}@${version}"
+            return 1
           }
 
           # Tier 1: apss-core (only when the tooling system changed)


### PR DESCRIPTION
Everything the v1.5.0 release surfaced by going wrong. Two commits: a real
workflow fix, and the skill corrections.

## The workflow bug

The v1.5.0 publish job could not be completed by re-running it. Both attempts
died on:

```
error: crate apss-core@1.5.0 already exists on crates.io index
```

despite `apss-core` having been published nearly an hour earlier.

The pre-check asked `cargo search`, which queries crates.io's **search**
endpoint. That endpoint is eventually consistent, and in CI it kept reporting
the just-published version as absent. The check passed, the publish ran, cargo
refused. The same check matched *locally* at the same moment, which is what
makes it easy to misdiagnose as a transient race. It is not transient, and
re-running does not help.

The consequence is worse than a red job: it made recovery from a **partial**
publish impossible, since every re-run fails again on the first crate that
already went out, which is precisely the situation a re-run exists to fix.

**Fix:** read the publish result instead of pre-checking. `cargo publish`
consults the sparse index, which is authoritative and immediate, so there is
nothing to race. An `already exists` error is tolerated and the job continues;
any other failure still aborts.

The trap in this fix is that naively ignoring publish errors would make a
genuine 403 look like a successful release. The function matches the specific
error text and returns 1 otherwise. Verified behaviorally against a stubbed
`cargo`:

| Case | Exit |
|---|---|
| Fresh publish | 0 |
| Already published | 0 (tolerated) |
| Auth failure | 1 (still aborts) |

## Skill corrections

- Step 6 claimed *"the publish job is idempotent, so a re-run is safe."* False
  as written. It now says to verify against crates.io rather than the job's exit
  status, gives the `curl` loop, and warns that a run using a pre-fix workflow
  will keep failing.
- The new-crate section assumed a re-run finishes tier 3. It did not. It now
  says to publish the remainder by hand from their tags, and explains why fixing
  the workflow on `main` cannot rescue an in-flight run: a re-run executes the
  workflow from the commit that triggered it.
- Adds `v1.5.0` as a worked example, including the detail that cost the most
  time: the CI 403 (`does not have the required permissions`) and the local 403
  (`authentication failed`) are *different* failures, one a token scope and one
  a dead token.

## Also in this PR (original scope)

Documents that the first release of any **new crate name** needs a one-time
manual `cargo publish`, because `CARGO_REGISTRY_TOKEN` is deliberately scoped
`publish-update` on `apss` and `apss-*`. A CI token that could create crates
would let a leak squat arbitrary `apss-*` packages, so the skill explicitly says
**do not widen the CI token**, since the error message points straight at that as
the fix.

Frontmatter triggers extended to what someone actually types in this situation
(`403 Forbidden publishing to crates.io`, `publish-new scope`, `the publish job
failed`). Without them the skill would not fire for the failure it explains.

## Scope

This does not affect v1.5.0, which is already fully published (`apss-core`
1.5.0, `apss-v1-0004-session-capture` 1.0.0, `apss` 1.5.0, all verified on
crates.io). It applies from the next release onward.